### PR TITLE
Fix editor cameras

### DIFF
--- a/src/terrain.cpp
+++ b/src/terrain.cpp
@@ -356,7 +356,7 @@ void Terrain3D::get_camera()
     if (Engine::get_singleton()->is_editor_hint()) {
         EditorScript temp_editor_script;
         EditorInterface* editor_interface = temp_editor_script.get_editor_interface();
-        Array& cam_array = Array();
+        Array cam_array = Array();
         find_cameras(editor_interface->get_editor_main_screen()->get_children(), editor_interface->get_edited_scene_root(), cam_array);
         if (!cam_array.is_empty()) {
             camera = Object::cast_to<Camera3D>(cam_array[0]);
@@ -370,7 +370,7 @@ void Terrain3D::get_camera()
 /**
 * Recursive helper function for get_camera(). 
 */
-void Terrain3D::find_cameras(TypedArray<Node>& from_nodes, Node* excluded_node, Array& cam_array)
+void Terrain3D::find_cameras(TypedArray<Node> from_nodes, Node* excluded_node, Array& cam_array)
 {   
     for (int i = 0; i < from_nodes.size(); i++) {
         Node* node = Object::cast_to<Node>(from_nodes[i]);

--- a/src/terrain.h
+++ b/src/terrain.h
@@ -64,7 +64,7 @@ protected:
 
 private:
     void get_camera();
-    void find_cameras(TypedArray<Node>& from_nodes, Node* excluded_node, Array& cam_array);
+    void find_cameras(TypedArray<Node> from_nodes, Node* excluded_node, Array& cam_array);
 
 public:
 


### PR DESCRIPTION
* Fixes a memory leak
* Prevents the terrain system from capturing any cameras inside the user's scene. We only want the editor camera.
* Fixes compiler errors: cannot bind non-const lvalue reference of type 

Eventually we want to support all cameras. See #6.

