### PR TITLE
Fix the crash on loading multiple terrain scenes

### DIFF
--- a/src/terrain.cpp
+++ b/src/terrain.cpp
@@ -368,6 +368,10 @@ void Terrain3D::_notification(int p_what) {
 		}
 
 		case NOTIFICATION_EDITOR_PRE_SAVE: {
+			if (!storage.is_valid()) {
+				LOG(DEBUG, "Save requested, but no valid storage. Skipping");
+				return;
+			}
 			String path = storage->get_path();
 			LOG(DEBUG, "Saving the terrain to: " + path);
 			if (path.get_extension() == ".tres" || path.get_extension() == ".res") {


### PR DESCRIPTION
Fixes #37 .

The main cause was as follows: when launching the editor with two or more terrain scenes opened, and scene 1 is in the process of generating mesh instances for its terrain, the editor would abruptly switch to scene 2, triggering an exit world notification for scene 1 terrain and causing the get_world_3d() in Terrain3D::build to fail.
 
 
P.S. The crash should be fixed by this PR. However, one remaining issue is that when launching the editor with multiple opened terrain scenes, and the active scene(I mean the first scene you see) has no terrain storage assigned, some artifacts might appear. These artifacts could be resolved by switching scenes and back.