### PR TITLE
Fix saving bug and save only on storage modification

### DIFF
--- a/src/terrain.cpp
+++ b/src/terrain.cpp
@@ -334,6 +334,9 @@ void Terrain3D::_notification(int p_what) {
 		case NOTIFICATION_READY: {
 			LOG(INFO, "NOTIFICATION_READY");
 			set_process(true);
+			if (storage.is_valid()) {
+				storage->clear_modified();
+			}
 			break;
 		}
 
@@ -391,11 +394,19 @@ void Terrain3D::_notification(int p_what) {
 				LOG(DEBUG, "Save requested, but no valid storage. Skipping");
 				return;
 			}
+			if (!storage->is_modified()) {
+				LOG(DEBUG, "Save requested, but not modified. Skipping");
+				return;
+			}
 			String path = storage->get_path();
 			LOG(DEBUG, "Saving the terrain to: " + path);
-			if (path.get_extension() == ".tres" || path.get_extension() == ".res") {
+			if (path.get_extension() == "tres" || path.get_extension() == "res") {
 				Error err = ResourceSaver::get_singleton()->save(storage, path);
 				ERR_FAIL_COND(err);
+				LOG(DEBUG, "ResourceSaver return error (0 is OK): ", err);
+				if (err == OK) {
+					storage->clear_modified();
+				}
 			}
 			LOG(INFO, "Finished saving terrain data");
 			break;

--- a/src/terrain_storage.cpp
+++ b/src/terrain_storage.cpp
@@ -62,8 +62,9 @@ void Terrain3DStorage::print_audit_data() {
 	LOG(INFO, "Dumping storage data");
 
 	LOG(INFO, "_initialized: ", _initialized);
-	LOG(INFO, "region_offsets(", region_offsets.size(), "): ", region_offsets);
-
+	LOG(INFO, "_modified: ", _modified);
+	LOG(INFO, "Region_offsets size: ", region_offsets.size(), " ", region_offsets);
+	LOG(INFO, "Surfaces size: ", surfaces.size(), " ", surfaces);
 	LOG(INFO, "Map type height size: ", height_maps.size(), " ", height_maps);
 	LOG(INFO, "Map type control size: ", control_maps.size(), " ", control_maps);
 	LOG(INFO, "Map type color size: ", color_maps.size(), " ", color_maps);
@@ -1061,6 +1062,7 @@ void Terrain3DStorage::_update_surface_data(bool p_update_textures, bool p_updat
 
 		RenderingServer::get_singleton()->material_set_param(material, "texture_array_albedo", generated_albedo_textures.get_rid());
 		RenderingServer::get_singleton()->material_set_param(material, "texture_array_normal", generated_normal_textures.get_rid());
+		_modified = true;
 	}
 
 	if (p_update_values) {
@@ -1080,6 +1082,7 @@ void Terrain3DStorage::_update_surface_data(bool p_update_textures, bool p_updat
 
 		RenderingServer::get_singleton()->material_set_param(material, "texture_uv_scale_array", uv_scales);
 		RenderingServer::get_singleton()->material_set_param(material, "texture_color_array", colors);
+		_modified = true;
 	}
 }
 
@@ -1088,12 +1091,14 @@ void Terrain3DStorage::_update_regions() {
 		LOG(DEBUG_CONT, "Regenerating height layered texture from ", height_maps.size(), " maps");
 		generated_height_maps.create(height_maps);
 		RenderingServer::get_singleton()->material_set_param(material, "height_maps", generated_height_maps.get_rid());
+		_modified = true;
 	}
 
 	if (generated_control_maps.is_dirty()) {
 		LOG(DEBUG_CONT, "Regenerating control layered texture from ", control_maps.size(), " maps");
 		generated_control_maps.create(control_maps);
 		RenderingServer::get_singleton()->material_set_param(material, "control_maps", generated_control_maps.get_rid());
+		_modified = true;
 	}
 
 	if (generated_color_maps.is_dirty()) {
@@ -1101,6 +1106,7 @@ void Terrain3DStorage::_update_regions() {
 		generated_color_maps.create(color_maps);
 		// Enable when colormaps are in the shader
 		//RenderingServer::get_singleton()->material_set_param(material, "color_maps", generated_color_maps.get_rid());
+		_modified = true;
 	}
 
 	if (generated_region_map.is_dirty()) {
@@ -1117,6 +1123,7 @@ void Terrain3DStorage::_update_regions() {
 		RenderingServer::get_singleton()->material_set_param(material, "region_map", generated_region_map.get_rid());
 		RenderingServer::get_singleton()->material_set_param(material, "region_map_size", REGION_MAP_SIZE);
 		RenderingServer::get_singleton()->material_set_param(material, "region_offsets", region_offsets);
+		_modified = true;
 
 		if (noise_enabled) {
 			LOG(DEBUG_CONT, "Regenerating ", Vector2i(512, 512), " region blend map");
@@ -1157,6 +1164,7 @@ void Terrain3DStorage::_update_material() {
 	RenderingServer::get_singleton()->material_set_param(material, "terrain_height", TERRAIN_MAX_HEIGHT);
 	RenderingServer::get_singleton()->material_set_param(material, "region_size", region_size);
 	RenderingServer::get_singleton()->material_set_param(material, "region_pixel_size", 1.0f / float(region_size));
+	_modified = true;
 }
 
 String Terrain3DStorage::_generate_shader_code() {

--- a/src/terrain_storage.h
+++ b/src/terrain_storage.h
@@ -116,6 +116,7 @@ class Terrain3DStorage : public Resource {
 	Generated generated_normal_textures;
 
 	bool _initialized = false;
+	bool _modified = false;
 
 private:
 	void _update_surfaces();
@@ -133,6 +134,9 @@ protected:
 public:
 	Terrain3DStorage();
 	~Terrain3DStorage();
+
+	bool is_modified() { return _modified; }
+	void clear_modified() { _modified = false; }
 
 	void print_audit_data();
 


### PR DESCRIPTION
Fixes #85, Matching w/ get_extension() should not include periods.

Bug introduced in 
https://github.com/outobugi/GDExtensionTerrain/commit/2ea42d4e155b2f1ddb14ea55df572749c59ccb62

Also, when running a scene, we often get two NOTIFICATION_EDITOR_PRE_SAVE calls. So this PR introduces a modified state for Storage and only saves if modified (any of the _update_* functions regenerate something. )

Tested w/ undo/redo, painting, sculpting.