### PR TITLE
Adds brush as a decal to the cursor

### DIFF
--- a/project/addons/terrain/editor/components/tool_settings.gd
+++ b/project/addons/terrain/editor/components/tool_settings.gd
@@ -54,6 +54,7 @@ func _ready() -> void:
 	advanced_list = create_submenu(list, "Advanced", Layout.VERTICAL)
 	add_setting(SettingType.CHECKBOX, "automatic_regions", true, advanced_list)
 	add_setting(SettingType.CHECKBOX, "align_with_view", true, advanced_list)
+	add_setting(SettingType.CHECKBOX, "show_cursor_while_painting", true, advanced_list)
 	advanced_list.add_child(HSeparator.new(), true)
 	add_setting(SettingType.SLIDER, "gamma", 1.0, advanced_list, "γ", 0.1, 2.0, 0.01)
 	add_setting(SettingType.SLIDER, "jitter", 50, advanced_list, "%", 0, 100)
@@ -115,6 +116,7 @@ func add_brushes(parent: Control) -> void:
 				var btn: Button = Button.new()
 				btn.set_custom_minimum_size(Vector2.ONE * 100)
 				btn.set_button_icon(tex)
+				btn.set_meta("image", img)
 				btn.set_expand_icon(true)
 				btn.set_material(_get_brush_preview_material())
 				btn.set_toggle_mode(true)
@@ -267,11 +269,13 @@ func get_setting(p_setting: String) -> Variant:
 	elif object is DoubleSlider:
 		value = [object.get_min_value(), object.get_max_value()]
 	elif object is ButtonGroup:
-		value = object.get_pressed_button().get_button_icon().get_image()
+		var img: Image = object.get_pressed_button().get_meta("image")
+		var tex: Texture2D = object.get_pressed_button().get_button_icon()
+		value = [ img, tex ]
 	elif object is CheckBox:
 		value = object.is_pressed()
 	elif object is ColorPickerButton:
-		value = object.color
+		value = object.color.srgb_to_linear()
 		
 	return value
 

--- a/project/addons/terrain/editor/components/ui.gd
+++ b/project/addons/terrain/editor/components/ui.gd
@@ -5,6 +5,19 @@ class_name Terrain3DUI
 # Includes
 const Toolbar: Script = preload("res://addons/terrain/editor/components/toolbar.gd")
 const ToolSettings: Script = preload("res://addons/terrain/editor/components/tool_settings.gd")
+const RING1: String = "res://addons/terrain/editor/brushes/ring1.exr"
+const COLOR_RAISE := Color.WHITE
+const COLOR_LOWER := Color.BLACK
+const COLOR_SMOOTH := Color(0.5, 0, .1)
+const COLOR_GROW := Color.PERU
+const COLOR_FLATTEN := Color(0., 0.32, .4)
+const COLOR_PAINT := Color.FOREST_GREEN
+const COLOR_SPRAY := Color.SEA_GREEN
+const COLOR_ROUGHNESS := Color.ROYAL_BLUE
+const COLOR_PICK_COLOR := Color.WHITE
+const COLOR_PICK_HEIGHT := Color.DARK_RED
+const COLOR_PICK_ROUGH := Color.ROYAL_BLUE
+
 
 var plugin: Terrain3DEditorPlugin
 var toolbar: Toolbar
@@ -13,6 +26,9 @@ var setting_has_changed: bool = false
 var visible: bool = false
 var picking: int = Terrain3DEditor.TOOL_MAX
 var picking_callback: Callable
+var decal: Decal
+var brush_data: Dictionary
+@onready var picker_texture: ImageTexture =  ImageTexture.create_from_image(Image.load_from_file(RING1))
 
 
 func _enter_tree() -> void:
@@ -28,12 +44,16 @@ func _enter_tree() -> void:
 	plugin.add_control_to_container(EditorPlugin.CONTAINER_SPATIAL_EDITOR_SIDE_LEFT, toolbar)
 	plugin.add_control_to_bottom(toolbar_settings)
 
+	decal = Decal.new()
+	add_child(decal)
+	
 
 func _exit_tree() -> void:
 	plugin.remove_control_from_container(EditorPlugin.CONTAINER_SPATIAL_EDITOR_SIDE_LEFT, toolbar)
 	toolbar_settings.get_parent().remove_child(toolbar_settings)
 	toolbar.queue_free()
 	toolbar_settings.queue_free()
+	decal.queue_free()
 
 	
 func set_visible(p_visible: bool) -> void:
@@ -43,6 +63,7 @@ func set_visible(p_visible: bool) -> void:
 	if p_visible:
 		p_visible = plugin.editor.get_tool() != Terrain3DEditor.REGION
 	toolbar_settings.set_visible(p_visible)
+	update_decal()
 
 
 func _on_tool_changed(p_tool: Terrain3DEditor.Tool, p_operation: Terrain3DEditor.Operation) -> void:
@@ -52,7 +73,6 @@ func _on_tool_changed(p_tool: Terrain3DEditor.Tool, p_operation: Terrain3DEditor
 	if plugin.editor:
 		plugin.editor.set_tool(p_tool)
 		plugin.editor.set_operation(p_operation)
-		print_debug("Setting tool: %s, operation: %s" % [ p_tool, p_operation ])
 	
 	if p_tool != Terrain3DEditor.REGION:
 		# Select which settings to hide. Options:
@@ -100,7 +120,7 @@ func _on_tool_changed(p_tool: Terrain3DEditor.Tool, p_operation: Terrain3DEditor
 func _on_setting_changed() -> void:
 	if not visible:
 		return
-	var brush_data: Dictionary = {
+	brush_data = {
 		"size": int(toolbar_settings.get_setting("size")),
 		"opacity": toolbar_settings.get_setting("opacity") / 100.0,
 		"color": toolbar_settings.get_setting("color"),
@@ -108,14 +128,90 @@ func _on_setting_changed() -> void:
 		"gamma": toolbar_settings.get_setting("gamma"),
 		"height": toolbar_settings.get_setting("height"),
 		"jitter": toolbar_settings.get_setting("jitter"),
-		"image": toolbar_settings.get_setting("brush"),
 		"automatic_regions": toolbar_settings.get_setting("automatic_regions"),
 		"align_with_view": toolbar_settings.get_setting("align_with_view"),
+		"show_cursor_while_painting": toolbar_settings.get_setting("show_cursor_while_painting"),
 		"index": plugin.surface_list.get_selected_index(),
 	}
+	var brush_imgs: Array = toolbar_settings.get_setting("brush")
+	brush_data["image"] = brush_imgs[0]
+	brush_data["texture"] = brush_imgs[1]
+	update_decal()
 	plugin.editor.set_brush_data(brush_data)
+
+
+func update_decal() -> void:
+	var mouse_buttons: int = Input.get_mouse_button_mask()
+	if not visible or \
+			brush_data.is_empty() or \
+			mouse_buttons & MOUSE_BUTTON_RIGHT or \
+			(mouse_buttons & MOUSE_BUTTON_LEFT and not brush_data["show_cursor_while_painting"]) or \
+			plugin.editor.get_tool() == Terrain3DEditor.REGION:
+		decal.visible = false
+		return
+	else:
+		# Wait for cursor to recenter after right-click before revealing
+		# See https://github.com/godotengine/godot/issues/70098
+		await get_tree().create_timer(.05).timeout 
+		decal.visible = true
+
+	decal.size = Vector3.ONE * brush_data["size"]
+	if brush_data["align_with_view"]:
+		decal.rotation.y = plugin.terrain.get_camera().rotation.y
+	else:
+		decal.rotation.y = 0
+
+	# Set texture and color
+	if picking != Terrain3DEditor.TOOL_MAX:
+		decal.texture_albedo = picker_texture
+		decal.size = Vector3.ONE*10.
+		match picking:
+			Terrain3DEditor.HEIGHT:
+				decal.modulate = COLOR_PICK_HEIGHT
+			Terrain3DEditor.COLOR:
+				decal.modulate = COLOR_PICK_COLOR
+			Terrain3DEditor.ROUGHNESS:
+				decal.modulate = COLOR_PICK_ROUGH
+	else:
+		decal.texture_albedo = brush_data["texture"]		
+		match plugin.editor.get_tool():
+			Terrain3DEditor.HEIGHT:
+				match plugin.editor.get_operation():
+					Terrain3DEditor.ADD:
+						decal.modulate = COLOR_RAISE
+					Terrain3DEditor.SUBTRACT:
+						decal.modulate = COLOR_LOWER
+					Terrain3DEditor.MULTIPLY:
+						decal.modulate = COLOR_GROW
+					Terrain3DEditor.REPLACE:
+						decal.modulate = COLOR_FLATTEN
+					Terrain3DEditor.AVERAGE:
+						decal.modulate = COLOR_SMOOTH
+					_:
+						decal.modulate = Color.WHITE
+			Terrain3DEditor.TEXTURE:
+				match plugin.editor.get_operation():
+					Terrain3DEditor.ADD:
+						decal.modulate = COLOR_SPRAY
+					Terrain3DEditor.REPLACE:
+						decal.modulate = COLOR_PAINT
+					_:
+						decal.modulate = Color.WHITE
+			Terrain3DEditor.COLOR:
+				decal.modulate = brush_data["color"]
+			Terrain3DEditor.ROUGHNESS:
+				decal.modulate = COLOR_ROUGHNESS
+			_:
+				decal.modulate = Color.WHITE
+
+	decal.modulate.a = max(.3, brush_data["opacity"])
+
+
+func set_decal_rotation(rot: float) -> void:
+	decal.rotation.y = rot
 
 
 func _on_picking(type: int, callback: Callable) -> void:
 	picking = type
 	picking_callback = callback
+	update_decal()

--- a/src/terrain.h
+++ b/src/terrain.h
@@ -71,12 +71,15 @@ protected:
 	void _update_world(RID p_space, RID p_scenario);
 
 private:
-	void get_camera();
-	void find_cameras(TypedArray<Node> from_nodes, Node *excluded_node, TypedArray<Camera3D> &cam_array);
+	void _grab_camera();
+	void _find_cameras(TypedArray<Node> from_nodes, Node *excluded_node, TypedArray<Camera3D> &cam_array);
 
 public:
+	void set_camera(Camera3D *p_plugin);
+	Camera3D *get_camera() const { return camera; }
+
 	void set_plugin(EditorPlugin *p_plugin);
-	EditorPlugin *get_plugin() const;
+	EditorPlugin *get_plugin() const { return plugin; }
 
 	void set_debug_level(int p_level);
 	int get_debug_level() const { return debug_level; }

--- a/src/terrain_editor.cpp
+++ b/src/terrain_editor.cpp
@@ -19,6 +19,7 @@ void Terrain3DEditor::Brush::set_data(Dictionary p_data) {
 	roughness = p_data["roughness"];
 	gamma = p_data["gamma"];
 	jitter = p_data["jitter"];
+	texture = p_data["texture"];
 	image = p_data["image"];
 	if (image.is_valid()) {
 		img_size = Vector2(image->get_size());
@@ -110,12 +111,14 @@ void Terrain3DEditor::_operate_map(Vector3 p_global_position, float p_camera_dir
 	Color color = brush.get_color();
 	float roughness = brush.get_roughness();
 	float gamma = brush.get_gamma();
+
 	float randf = UtilityFunctions::randf();
 	float rot = randf * Math_PI * brush.get_jitter();
-
 	if (brush.is_aligned_to_view()) {
 		rot += p_camera_direction;
 	}
+	Object::cast_to<Node>(terrain->plugin->get("ui"))->call("set_decal_rotation", rot);
+
 	for (int x = 0; x < brush_size; x++) {
 		for (int y = 0; y < brush_size; y++) {
 			Vector2i brush_offset = Vector2i(x, y) - (Vector2i(brush_size, brush_size) / 2);

--- a/src/terrain_editor.h
+++ b/src/terrain_editor.h
@@ -7,6 +7,7 @@
 #endif
 
 #include <godot_cpp/classes/image.hpp>
+#include <godot_cpp/classes/image_texture.hpp>
 #include <godot_cpp/classes/object.hpp>
 #include <godot_cpp/classes/time.hpp>
 #include <godot_cpp/core/math.hpp>
@@ -57,6 +58,7 @@ public:
 
 	struct Brush {
 	private:
+		Ref<ImageTexture> texture;
 		Ref<Image> image;
 		Vector2 img_size;
 		int size = 0;
@@ -71,6 +73,7 @@ public:
 		bool auto_regions = false;
 
 	public:
+		Ref<ImageTexture> get_texture() const { return texture; }
 		Ref<Image> get_image() const { return image; }
 		Vector2 get_image_size() const { return img_size; }
 		void set_data(Dictionary p_data);

--- a/src/terrain_storage.cpp
+++ b/src/terrain_storage.cpp
@@ -1356,10 +1356,6 @@ String Terrain3DStorage::_generate_shader_code() {
 		code += "	total_weight += weight;\n";
 		code += "	return albedo * weight;\n";
 		code += "}\n\n";
-
-		code += "vec4 to_linear(vec4 col) {\n";
-		code += "	return vec4(pow(col.rgb, vec3(2.2)), col.a);\n";
-		code += "}\n\n";
 	}
 
 	// Vertex Shader
@@ -1432,7 +1428,7 @@ String Terrain3DStorage::_generate_shader_code() {
 		code += "	color *= total_weight;\n\n";
 
 		code += "	// Look up colormap\n";
-		code += "	vec4 color_tex = to_linear(texture(color_maps, get_regionf(UV2)));\n\n";
+		code += "	vec4 color_tex = texture(color_maps, get_regionf(UV2));\n\n";
 
 		code += "	ALBEDO = color * color_tex.rgb;\n";
 		code += "	ROUGHNESS = clamp(fma(color_tex.a-0.5, 2.0, in_normal.a), 0., 1.);\n";


### PR DESCRIPTION
* Adds the current brush as a decal to the cursor.
* It is scaled and aligned with how the brush will affect the terrain. 
* If jitter is high, the brush will spin like a drill bit as it paints the ground. 
* Advanced option to hide brush decal while painting (see drill bit)
* Decal opacity matches brush opacity down to a minimum of 33%. 
* Different modes have different colors. e.g. Sculpt raise is white, lower is black, flatten is dark cyan, roughness is light cyan, texturing is green, and the colormap is whatever color you have selected.
* Pickers use a smaller circle brush (ring1)

![image](https://github.com/outobugi/GDExtensionTerrain/assets/632766/12f09ae3-9c24-4a66-b3de-2c17a6c16f51)


Fixes #62 
Only one commit 03fd1bb26ecaaf01e43a8f18ddb282cede92cde3
Based off of #91 , merge that first