### PR TITLE
Custom uniforms

### DIFF
--- a/src/constants.h
+++ b/src/constants.h
@@ -16,4 +16,4 @@
 #define COLOR_CHECKED Color(1.f, 1.f, 1.0f, -1.0f)
 #define COLOR_NORMAL Color(0.5f, 0.5f, 1.0f, 1.0f)
 
-#endif CONSTANTS_CLASS_H
+#endif // CONSTANTS_CLASS_H

--- a/src/shaders/debug_views.glsl
+++ b/src/shaders/debug_views.glsl
@@ -73,8 +73,8 @@ R"(
 	float _view_distance = 100.0;	// Visible distance of grid
 	// Draw region grid
 	_region_line = .1*sqrt(_camera_dist);
-	if (mod(_pixel_pos.x + _region_line*.5, region_size) <= _region_line || 
-		mod(_pixel_pos.z + _region_line*.5, region_size) <= _region_line ) {
+	if (mod(_pixel_pos.x + _region_line*.5, _region_size) <= _region_line || 
+		mod(_pixel_pos.z + _region_line*.5, _region_size) <= _region_line ) {
 		ALBEDO = vec3(1.);
 	}
 	if ( _camera_dist < _view_distance ) {

--- a/src/shaders/main.glsl
+++ b/src/shaders/main.glsl
@@ -4,7 +4,7 @@ R"(shader_type spatial;
 render_mode blend_mix,depth_draw_opaque,cull_back,diffuse_burley,specular_schlick_ggx;
 
 uniform float region_size = 1024.0;
-uniform float region_pixel_size = 1.0;
+uniform float region_pixel_size = 0.0009765625; // 1.0 / 1024.0
 uniform int region_map_size = 16;
 
 uniform int region_map[256];

--- a/src/shaders/main.glsl
+++ b/src/shaders/main.glsl
@@ -3,22 +3,20 @@
 R"(shader_type spatial;
 render_mode blend_mix,depth_draw_opaque,cull_back,diffuse_burley,specular_schlick_ggx;
 
-uniform float region_size = 1024.0;
-uniform float region_pixel_size = 0.0009765625; // 1.0 / 1024.0
-uniform int region_map_size = 16;
+uniform float _region_size = 1024.0;
+uniform float _region_pixel_size = 0.0009765625; // 1.0 / 1024.0
+uniform int _region_map_size = 16;
+uniform int _region_map[256];
+uniform vec2 _region_offsets[256];
+uniform sampler2DArray _height_maps : filter_linear_mipmap, repeat_disable;
+uniform sampler2DArray _control_maps : filter_linear_mipmap, repeat_disable;
+uniform sampler2DArray _color_maps : filter_linear_mipmap, repeat_disable;
 
-uniform int region_map[256];
-uniform vec2 region_offsets[256];
-uniform sampler2DArray height_maps : filter_linear_mipmap, repeat_disable;
-uniform sampler2DArray control_maps : filter_linear_mipmap, repeat_disable;
-uniform sampler2DArray color_maps : filter_linear_mipmap, repeat_disable;
-
-uniform sampler2DArray texture_array_albedo : source_color, filter_linear_mipmap_anisotropic, repeat_enable;
-uniform sampler2DArray texture_array_normal : hint_normal, filter_linear_mipmap_anisotropic, repeat_enable;
-uniform float texture_uv_scale_array[32];
-uniform float texture_uv_rotation_array[32];
-uniform vec3 texture_3d_projection_array[32];
-uniform vec4 texture_color_array[32];
+uniform sampler2DArray _texture_array_albedo : source_color, filter_linear_mipmap_anisotropic, repeat_enable;
+uniform sampler2DArray _texture_array_normal : hint_normal, filter_linear_mipmap_anisotropic, repeat_enable;
+uniform float _texture_uv_scale_array[32];
+uniform float _texture_uv_rotation_array[32];
+uniform vec4 _texture_color_array[32];
 
 //INSERT: WORLD_NOISE1
 
@@ -34,26 +32,26 @@ vec4 pack_normal(vec3 n, float a) {
 }
 
 // Takes location in world space coordinates, returns ivec3 with:
-// XY: (0-region_size) coordinates within the region
+// XY: (0-_region_size) coordinates within the region
 // Z: region index used for texturearrays, -1 if not in a region
 ivec3 get_region(vec2 uv) {
-	ivec2 pos = ivec2(floor(uv)) + (region_map_size / 2);
-	int index = region_map[ pos.y*region_map_size + pos.x ] - 1;
-	return ivec3(ivec2((uv - region_offsets[index]) * region_size), index);
+	ivec2 pos = ivec2(floor(uv)) + (_region_map_size / 2);
+	int index = _region_map[ pos.y*_region_map_size + pos.x ] - 1;
+	return ivec3(ivec2((uv - _region_offsets[index]) * _region_size), index);
 }
 
 // vec3 form of get_region. Same return values
 vec3 get_regionf(vec2 uv) {
-	ivec2 pos = ivec2(floor(uv)) + (region_map_size / 2);
-	int index = region_map[ pos.y*region_map_size + pos.x ] - 1;
-	return vec3(uv - region_offsets[index], float(index));
+	ivec2 pos = ivec2(floor(uv)) + (_region_map_size / 2);
+	int index = _region_map[ pos.y*_region_map_size + pos.x ] - 1;
+	return vec3(uv - _region_offsets[index], float(index));
 }
 
 float get_height(vec2 uv) {
 	float height = 0.0;
 	vec3 region = get_regionf(uv);
 	if (region.z >= 0.) {
-		height = texture(height_maps, region).r;
+		height = texture(_height_maps, region).r;
 	}
 //INSERT: WORLD_NOISE2
  	return height;
@@ -85,10 +83,10 @@ vec3 get_normal(vec2 uv, out vec3 tangent, out vec3 binormal) {
 	// Control map is also sampled 4 times, so in theory we could reduce the region samples to 4 from 8,
 	// but control map sampling is slightly different with the mirroring and doesn't work here.
 	// The region map is very, very small, so maybe the performance cost isn't too high
-	float left = get_height(uv + vec2(-region_pixel_size, 0));
-	float right = get_height(uv + vec2(region_pixel_size, 0));
-	float back = get_height(uv + vec2(0, -region_pixel_size));
-	float fore = get_height(uv + vec2(0, region_pixel_size));
+	float left = get_height(uv + vec2(-_region_pixel_size, 0));
+	float right = get_height(uv + vec2(_region_pixel_size, 0));
+	float back = get_height(uv + vec2(0, -_region_pixel_size));
+	float fore = get_height(uv + vec2(0, _region_pixel_size));
 	vec3 horizontal = vec3(2.0, right - left, 0.0);
 	vec3 vertical = vec3(0.0, back - fore, 2.0);
 	vec3 normal = normalize(cross(vertical, horizontal));
@@ -101,24 +99,24 @@ vec3 get_normal(vec2 uv, out vec3 tangent, out vec3 binormal) {
 vec4 get_material(vec2 uv, vec4 index, vec2 uv_center, float weight, inout float total_weight, inout vec4 out_normal) {
 	float material = index.r * 255.0;
 	float r = random(uv_center) * PI;
-	float rand = r * texture_uv_rotation_array[int(material)];
+	float rand = r * _texture_uv_rotation_array[int(material)];
 	vec2 rot = vec2(cos(rand), sin(rand));
-	vec2 matUV = rotate(uv, rot.x, rot.y) * texture_uv_scale_array[int(material)];
+	vec2 matUV = rotate(uv, rot.x, rot.y) * _texture_uv_scale_array[int(material)];
 
-	vec4 albedo = texture(texture_array_albedo, vec3(matUV, material));
-	albedo.rgb *= texture_color_array[int(material)].rgb;
-	vec4 normal = texture(texture_array_normal, vec3(matUV, material));
+	vec4 albedo = texture(_texture_array_albedo, vec3(matUV, material));
+	albedo.rgb *= _texture_color_array[int(material)].rgb;
+	vec4 normal = texture(_texture_array_normal, vec3(matUV, material));
 	vec3 n = unpack_normal(normal);
 	normal.xz = rotate(n.xz, rot.x, -rot.y);
 
 	if (index.b > 0.0) {
 		float materialOverlay = index.g * 255.0;
-		float rand2 = r * texture_uv_rotation_array[int(materialOverlay)];
+		float rand2 = r * _texture_uv_rotation_array[int(materialOverlay)];
 		vec2 rot2 = vec2(cos(rand2), sin(rand2));
-		vec2 matUV2 = rotate(uv, rot2.x, rot2.y) * texture_uv_scale_array[int(materialOverlay)];
-		vec4 albedo2 = texture(texture_array_albedo, vec3(matUV2, materialOverlay));
-		albedo2.rgb *= texture_color_array[int(materialOverlay)].rgb;
-		vec4 normal2 = texture(texture_array_normal, vec3(matUV2, materialOverlay));
+		vec2 matUV2 = rotate(uv, rot2.x, rot2.y) * _texture_uv_scale_array[int(materialOverlay)];
+		vec4 albedo2 = texture(_texture_array_albedo, vec3(matUV2, materialOverlay));
+		albedo2.rgb *= _texture_color_array[int(materialOverlay)].rgb;
+		vec4 normal2 = texture(_texture_array_normal, vec3(matUV2, materialOverlay));
 		n = unpack_normal(normal2);
 		normal2.xz = rotate(n.xz, rot2.x, -rot2.y);
 
@@ -136,7 +134,7 @@ vec4 get_material(vec2 uv, vec4 index, vec2 uv_center, float weight, inout float
 void vertex() {
 	vec3 world_vertex = (MODEL_MATRIX * vec4(VERTEX, 1.0)).xyz;
 	UV = world_vertex.xz * 0.5;	// Without this, individual material UV needs to be very small.
-	UV2 = ((world_vertex.xz + vec2(0.5)) / vec2(region_size));
+	UV2 = ((world_vertex.xz + vec2(0.5)) / vec2(_region_size));
 	VERTEX.y = get_height(UV2);
 	NORMAL = vec3(0, 1, 0);
 }
@@ -152,20 +150,20 @@ void fragment() {
 	// Calculated Weighted Material
 	// source : https://github.com/cdxntchou/IndexMapTerrain
 	// black magic which I don't understand at all. Seems simple but what and why?
-	vec2 pos_texel = UV2 * region_size + 0.5;
+	vec2 pos_texel = UV2 * _region_size + 0.5;
 	vec2 pos_texel00 = floor(pos_texel);
 	vec4 mirror = vec4(fract(pos_texel00 * 0.5) * 2.0, 1.0, 1.0);
 	mirror.zw = vec2(1.0) - mirror.xy;
 
-	ivec3 index00UV = get_region((pos_texel00 + mirror.xy) * region_pixel_size);
-	ivec3 index01UV = get_region((pos_texel00 + mirror.xw) * region_pixel_size);
-	ivec3 index10UV = get_region((pos_texel00 + mirror.zy) * region_pixel_size);
-	ivec3 index11UV = get_region((pos_texel00 + mirror.zw) * region_pixel_size);
+	ivec3 index00UV = get_region((pos_texel00 + mirror.xy) * _region_pixel_size);
+	ivec3 index01UV = get_region((pos_texel00 + mirror.xw) * _region_pixel_size);
+	ivec3 index10UV = get_region((pos_texel00 + mirror.zy) * _region_pixel_size);
+	ivec3 index11UV = get_region((pos_texel00 + mirror.zw) * _region_pixel_size);
 
-	vec4 index00 = texelFetch(control_maps, index00UV, 0);
-	vec4 index01 = texelFetch(control_maps, index01UV, 0);
-	vec4 index10 = texelFetch(control_maps, index10UV, 0);
-	vec4 index11 = texelFetch(control_maps, index11UV, 0);
+	vec4 index00 = texelFetch(_control_maps, index00UV, 0);
+	vec4 index01 = texelFetch(_control_maps, index01UV, 0);
+	vec4 index10 = texelFetch(_control_maps, index10UV, 0);
+	vec4 index11 = texelFetch(_control_maps, index11UV, 0);
 
 	vec2 weights1 = clamp(pos_texel - pos_texel00, 0, 1);
 	weights1 = mix(weights1, vec2(1.0) - weights1, mirror.xy);
@@ -187,7 +185,7 @@ void fragment() {
 	vec3 ruv = get_regionf(UV2);
 	vec4 color_tex = vec4(1., 1., 1., .5);
 	if (ruv.z >= 0.) {
-		color_tex = texture(color_maps, ruv);
+		color_tex = texture(_color_maps, ruv);
 	}
 
 	// Apply PBR

--- a/src/shaders/world_noise.glsl
+++ b/src/shaders/world_noise.glsl
@@ -6,10 +6,10 @@ R"(
 // World Noise
 
 uniform sampler2D _region_blend_map : hint_default_black, filter_linear, repeat_disable;
-uniform float noise_scale = 2.0;
-uniform float noise_height = 300.0;
-uniform float noise_blend_near = 0.5;
-uniform float noise_blend_far = 1.0;
+uniform float noise_scale : hint_range(0, 20, 0.1) = 2.0;
+uniform float noise_height : hint_range(0, 1000, 0.1) = 300.0;
+uniform float noise_blend_near : hint_range(0, .95, 0.01) = 0.5;
+uniform float noise_blend_far : hint_range(.05, 1, 0.01) = 1.0;
 
 float hashv2(vec2 v) {
 	return fract(1e4 * sin(17.0 * v.x + v.y * 0.1) * (0.1 + abs(sin(v.y * 13.0 + v.x))));

--- a/src/shaders/world_noise.glsl
+++ b/src/shaders/world_noise.glsl
@@ -5,7 +5,7 @@ R"(
 //INSERT: WORLD_NOISE1
 // World Noise
 
-uniform sampler2D region_blend_map : hint_default_black, filter_linear, repeat_disable;
+uniform sampler2D _region_blend_map : hint_default_black, filter_linear, repeat_disable;
 uniform float noise_scale = 2.0;
 uniform float noise_height = 300.0;
 uniform float noise_blend_near = 0.5;
@@ -35,8 +35,8 @@ float noise2D(vec2 st) {
 // World Noise end
 //INSERT: WORLD_NOISE2
 	// World Noise
-	float weight = texture(region_blend_map, (uv/float(region_map_size))+0.5).r;
-	float rmap_half_size = float(region_map_size)*.5;
+	float weight = texture(_region_blend_map, (uv/float(_region_map_size))+0.5).r;
+	float rmap_half_size = float(_region_map_size)*.5;
 	if(abs(uv.x) > rmap_half_size+.5 || abs(uv.y) > rmap_half_size+.5) {
 		weight = 0.;
 	} else {

--- a/src/terrain_3d.cpp
+++ b/src/terrain_3d.cpp
@@ -816,15 +816,20 @@ void Terrain3D::_notification(int p_what) {
 
 		case NOTIFICATION_EDITOR_PRE_SAVE: {
 			LOG(INFO, "NOTIFICATION_EDITOR_PRE_SAVE");
-			if (!_texture_list.is_valid()) {
-				LOG(DEBUG, "Save requested, but no valid texture list. Skipping");
-			} else {
-				_texture_list->save();
-			}
 			if (!_storage.is_valid()) {
 				LOG(DEBUG, "Save requested, but no valid storage. Skipping");
 			} else {
 				_storage->save();
+			}
+			if (!_material.is_valid()) {
+				LOG(DEBUG, "Save requested, but no valid material. Skipping");
+			} else {
+				_material->save();
+			}
+			if (!_texture_list.is_valid()) {
+				LOG(DEBUG, "Save requested, but no valid texture list. Skipping");
+			} else {
+				_texture_list->save();
 			}
 			break;
 		}

--- a/src/terrain_3d.cpp
+++ b/src/terrain_3d.cpp
@@ -668,8 +668,10 @@ void Terrain3D::snap(Vector3 p_cam_pos) {
 }
 
 void Terrain3D::update_aabbs() {
-	ERR_FAIL_COND_MSG(_meshes.is_empty(), "Terrain meshes have not been built yet");
-	ERR_FAIL_COND_MSG(!_storage.is_valid(), "Terrain3DStorage is not valid");
+	if (_meshes.is_empty() || _storage.is_null()) {
+		LOG(DEBUG, "Update AABB called before terrain meshes built. Returning.");
+		return;
+	}
 
 	Vector2 height_range = _storage->get_height_range();
 	LOG(DEBUG_CONT, "Updating AABBs. Total height range: ", height_range, ", extra cull margin: ", _cull_margin);

--- a/src/terrain_3d.cpp
+++ b/src/terrain_3d.cpp
@@ -25,7 +25,7 @@
 int Terrain3D::_debug_level{ ERROR };
 
 void Terrain3D::_initialize() {
-	LOG(INFO, "Checking storage, texture list, signal, and terrain initialization");
+	LOG(INFO, "Checking material, storage, texture_list, signal, and mesh initialization");
 
 	// Make blank objects if needed
 	if (_material.is_null()) {
@@ -46,15 +46,15 @@ void Terrain3D::_initialize() {
 
 	// Connect signals
 	if (!_texture_list->is_connected("textures_changed", Callable(_material.ptr(), "_update_texture_arrays"))) {
-		LOG(DEBUG, "Connecting texture_list.textures_changed to _storage._update_texture_arrays()");
+		LOG(DEBUG, "Connecting texture_list.textures_changed to _material->_update_texture_arrays()");
 		_texture_list->connect("textures_changed", Callable(_material.ptr(), "_update_texture_arrays"));
 	}
 	if (!_storage->is_connected("region_size_changed", Callable(_material.ptr(), "set_region_size"))) {
-		LOG(DEBUG, "Connecting region_size_changed signal to set_region_size()");
+		LOG(DEBUG, "Connecting region_size_changed signal to _material->set_region_size()");
 		_storage->connect("region_size_changed", Callable(_material.ptr(), "set_region_size"));
 	}
 	if (!_storage->is_connected("regions_changed", Callable(_material.ptr(), "_update_regions"))) {
-		LOG(DEBUG, "Connecting regions_changed signal to _update_regions()");
+		LOG(DEBUG, "Connecting regions_changed signal to _material->_update_regions()");
 		_storage->connect("regions_changed", Callable(_material.ptr(), "_update_regions"));
 	}
 	if (!_storage->is_connected("height_maps_changed", Callable(this, "update_aabbs"))) {
@@ -64,7 +64,7 @@ void Terrain3D::_initialize() {
 
 	// Initialize the system
 	if (!_initialized && _is_inside_world && is_inside_tree()) {
-		_material->set_region_size(_storage->get_region_size());
+		_material->initialize(_storage->get_region_size());
 		_storage->_update_regions(true); // generate map arrays
 		_texture_list->_update_list(); // generate texture arrays
 		_build(_clipmap_levels, _clipmap_size);

--- a/src/terrain_3d_material.cpp
+++ b/src/terrain_3d_material.cpp
@@ -261,12 +261,15 @@ void Terrain3DMaterial::_update_shader() {
 		RS->material_set_shader(_material, _shader);
 		LOG(DEBUG, "Mat rid: ", _material, ", _shader rid: ", _shader);
 	}
+
 	// Update custom shader params in RenderingServer
-	// Populate _active_params
-	_get_property_list(&(List<PropertyInfo>()));
-	LOG(DEBUG, "_active_params: ", _active_params);
-	LOG(DEBUG, "_shader_params keys: ", _shader_params.keys());
-	LOG(DEBUG, "_shader_params values: ", _shader_params.values());
+	{
+		// Populate _active_params
+		List<PropertyInfo> pi;
+		_get_property_list(&pi);
+		LOG(DEBUG, "_active_params: ", _active_params);
+		Util::print_dict("_shader_params", _shader_params, DEBUG);
+	}
 
 	for (int i = 0; i < _active_params.size(); i++) {
 		StringName param = _active_params[i];

--- a/src/terrain_3d_material.cpp
+++ b/src/terrain_3d_material.cpp
@@ -619,8 +619,7 @@ void Terrain3DMaterial::_bind_methods() {
 	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "shader_override_enabled", PROPERTY_HINT_NONE), "enable_shader_override", "is_shader_override_enabled");
 	ADD_PROPERTY(PropertyInfo(Variant::OBJECT, "shader_override", PROPERTY_HINT_RESOURCE_TYPE, "Shader"), "set_shader_override", "get_shader_override");
 
-	int ro_flags = PROPERTY_USAGE_STORAGE | PROPERTY_USAGE_EDITOR | PROPERTY_USAGE_READ_ONLY;
-	ADD_PROPERTY(PropertyInfo(Variant::DICTIONARY, "param_cache", PROPERTY_HINT_NONE, "", ro_flags), "set_shader_params", "get_shader_params");
+	ADD_PROPERTY(PropertyInfo(Variant::DICTIONARY, "shader_params", PROPERTY_HINT_NONE, "", PROPERTY_USAGE_STORAGE), "set_shader_params", "get_shader_params");
 
 	ADD_GROUP("Debug Views", "show_");
 	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "show_checkered", PROPERTY_HINT_NONE), "set_show_checkered", "get_show_checkered");

--- a/src/terrain_3d_material.cpp
+++ b/src/terrain_3d_material.cpp
@@ -162,9 +162,9 @@ void Terrain3DMaterial::_update_regions(const Array &p_args) {
 	RID height_rid = p_args[0];
 	RID control_rid = p_args[1];
 	RID color_rid = p_args[2];
-	RS->material_set_param(_material, "height_maps", height_rid);
-	RS->material_set_param(_material, "control_maps", control_rid);
-	RS->material_set_param(_material, "color_maps", color_rid);
+	RS->material_set_param(_material, "_height_maps", height_rid);
+	RS->material_set_param(_material, "_control_maps", control_rid);
+	RS->material_set_param(_material, "_color_maps", color_rid);
 	LOG(DEBUG, "Height map RID: ", height_rid);
 	LOG(DEBUG, "Control map RID: ", control_rid);
 	LOG(DEBUG, "Color map RID: ", color_rid);
@@ -174,8 +174,8 @@ void Terrain3DMaterial::_update_regions(const Array &p_args) {
 	if (_region_map.size() != Terrain3DStorage::REGION_MAP_SIZE * Terrain3DStorage::REGION_MAP_SIZE) {
 		LOG(ERROR, "Expected _region_map.size() of ", Terrain3DStorage::REGION_MAP_SIZE * Terrain3DStorage::REGION_MAP_SIZE);
 	}
-	RS->material_set_param(_material, "region_map", _region_map);
-	RS->material_set_param(_material, "region_map_size", Terrain3DStorage::REGION_MAP_SIZE);
+	RS->material_set_param(_material, "_region_map", _region_map);
+	RS->material_set_param(_material, "_region_map_size", Terrain3DStorage::REGION_MAP_SIZE);
 	if (Terrain3D::_debug_level >= DEBUG) {
 		LOG(DEBUG, "Region map");
 		for (int i = 0; i < _region_map.size(); i++) {
@@ -187,7 +187,7 @@ void Terrain3DMaterial::_update_regions(const Array &p_args) {
 
 	TypedArray<Vector2i> region_offsets = p_args[4];
 	LOG(DEBUG, "Region_offsets size: ", region_offsets.size(), " ", region_offsets);
-	RS->material_set_param(_material, "region_offsets", region_offsets);
+	RS->material_set_param(_material, "_region_offsets", region_offsets);
 
 	if (_noise_enabled) {
 		_generate_region_blend_map();
@@ -211,17 +211,17 @@ void Terrain3DMaterial::_update_texture_arrays(const Array &p_args) {
 	_texture_count = p_args[0];
 	RID albedo_array = p_args[1];
 	RID normal_array = p_args[2];
-	RS->material_set_param(_material, "texture_array_albedo", albedo_array);
-	RS->material_set_param(_material, "texture_array_normal", normal_array);
+	RS->material_set_param(_material, "_texture_array_albedo", albedo_array);
+	RS->material_set_param(_material, "_texture_array_normal", normal_array);
 
 	if (p_args.size() == 6) {
 		PackedFloat32Array uv_scales = p_args[3];
 		PackedFloat32Array uv_rotations = p_args[4];
 		PackedColorArray colors = p_args[5];
 		_texture_count = uv_scales.size();
-		RS->material_set_param(_material, "texture_uv_rotation_array", uv_scales);
-		RS->material_set_param(_material, "texture_uv_scale_array", uv_rotations);
-		RS->material_set_param(_material, "texture_color_array", colors);
+		RS->material_set_param(_material, "_texture_uv_rotation_array", uv_scales);
+		RS->material_set_param(_material, "_texture_uv_scale_array", uv_rotations);
+		RS->material_set_param(_material, "_texture_color_array", colors);
 	}
 
 	// Enable checkered view if texture_count is 0, disable if not
@@ -293,8 +293,8 @@ void Terrain3DMaterial::set_region_size(int p_size) {
 	LOG(INFO, "Setting region size in material: ", p_size);
 	_region_size = CLAMP(p_size, 64, 4096);
 	_region_sizev = Vector2i(_region_size, _region_size);
-	RS->material_set_param(_material, "region_size", float(_region_size));
-	RS->material_set_param(_material, "region_pixel_size", 1.0f / float(_region_size));
+	RS->material_set_param(_material, "_region_size", float(_region_size));
+	RS->material_set_param(_material, "_region_pixel_size", 1.0f / float(_region_size));
 }
 
 void Terrain3DMaterial::set_show_checkered(bool p_enabled) {

--- a/src/terrain_3d_material.cpp
+++ b/src/terrain_3d_material.cpp
@@ -2,6 +2,7 @@
 
 #include <godot_cpp/classes/image_texture.hpp>
 #include <godot_cpp/classes/rendering_server.hpp>
+#include <godot_cpp/classes/resource_saver.hpp>
 
 #include "logger.h"
 #include "terrain_3d_material.h"
@@ -309,6 +310,18 @@ Terrain3DMaterial::~Terrain3DMaterial() {
 		RS->free_rid(_material);
 		RS->free_rid(_shader);
 		_generated_region_blend_map.clear();
+	}
+}
+
+void Terrain3DMaterial::save() {
+	String path = get_path();
+	if (path.get_extension() == "tres" || path.get_extension() == "res") {
+		LOG(DEBUG, "Attempting to save material to external file: " + path);
+		Error err;
+		err = ResourceSaver::get_singleton()->save(this, path);
+		ERR_FAIL_COND(err);
+		LOG(DEBUG, "ResourceSaver return error (0 is OK): ", err);
+		LOG(INFO, "Finished saving material");
 	}
 }
 

--- a/src/terrain_3d_material.h
+++ b/src/terrain_3d_material.h
@@ -34,11 +34,7 @@ private:
 	bool _debug_view_tex_rough = false;
 	bool _debug_view_vertex_grid = false;
 
-	bool _noise_enabled = false;
-	float _noise_scale = 2.0;
-	float _noise_height = 300.0;
-	float _noise_blend_near = 0.5;
-	float _noise_blend_far = 1.0;
+	bool _world_noise_enabled = false;
 
 	// Cached data from Storage
 	int _region_size = 1024;
@@ -92,16 +88,8 @@ public:
 	void set_show_vertex_grid(bool p_enabled);
 	bool get_show_vertex_grid() const { return _debug_view_vertex_grid; }
 
-	void set_noise_enabled(bool p_enabled);
-	bool get_noise_enabled() const { return _noise_enabled; }
-	void set_noise_scale(float p_scale);
-	float get_noise_scale() const { return _noise_scale; };
-	void set_noise_height(float p_height);
-	float get_noise_height() const { return _noise_height; };
-	void set_noise_blend_near(float p_near);
-	float get_noise_blend_near() const { return _noise_blend_near; };
-	void set_noise_blend_far(float p_far);
-	float get_noise_blend_far() const { return _noise_blend_far; };
+	void set_world_noise_enabled(bool p_enabled);
+	bool get_world_noise_enabled() const { return _world_noise_enabled; }
 
 protected:
 	void _get_property_list(List<PropertyInfo> *p_list) const;

--- a/src/terrain_3d_material.h
+++ b/src/terrain_3d_material.h
@@ -19,8 +19,9 @@ private:
 	bool _shader_override_enabled = false;
 	Ref<Shader> _shader_override;
 	Dictionary _shader_code;
-	int _texture_count = 0;
+	mutable TypedArray<StringName> _shader_param_list;
 
+	int _texture_count = 0;
 	bool _debug_view_checkered = false;
 	bool _debug_view_grey = false;
 	bool _debug_view_heightmap = false;
@@ -102,6 +103,12 @@ public:
 	float get_noise_blend_far() const { return _noise_blend_far; };
 
 protected:
+	void _get_property_list(List<PropertyInfo> *p_list) const;
+	bool _property_can_revert(const StringName &p_name) const;
+	bool _property_get_revert(const StringName &p_name, Variant &r_property) const;
+	bool _set(const StringName &p_name, const Variant &p_property);
+	bool _get(const StringName &p_name, Variant &r_property) const;
+
 	static void _bind_methods();
 };
 

--- a/src/terrain_3d_material.h
+++ b/src/terrain_3d_material.h
@@ -14,15 +14,17 @@ private:
 	GDCLASS(Terrain3DMaterial, Resource);
 	static inline const char *__class__ = "Terrain3DMaterial";
 
+	bool _initialized = false;
 	RID _material;
 	RID _shader;
 	bool _shader_override_enabled = false;
 	Ref<Shader> _shader_override;
 	Dictionary _shader_code;
-	mutable TypedArray<StringName> _shader_param_list;
-	mutable Dictionary _param_cache;
+	mutable TypedArray<StringName> _active_params;
+	mutable Dictionary _shader_params;
 
-	int _texture_count = 0;
+	// Built in alternate shaders
+	bool _world_noise_enabled = false;
 	bool _debug_view_checkered = false;
 	bool _debug_view_grey = false;
 	bool _debug_view_heightmap = false;
@@ -34,14 +36,14 @@ private:
 	bool _debug_view_tex_rough = false;
 	bool _debug_view_vertex_grid = false;
 
-	bool _world_noise_enabled = false;
-
 	// Cached data from Storage
+	int _texture_count = 0;
 	int _region_size = 1024;
 	Vector2i _region_sizev = Vector2i(_region_size, _region_size);
 	PackedByteArray _region_map;
 	GeneratedTex _generated_region_blend_map; // 512x512 blurred image of region_map
 
+	// Functions
 	void _preload_shaders();
 	String _parse_shader(String p_shader, String p_name = String(), Array p_excludes = Array());
 	String _generate_shader_code();
@@ -51,7 +53,8 @@ private:
 	void _update_shader();
 
 public:
-	Terrain3DMaterial();
+	Terrain3DMaterial(){};
+	void initialize(int p_region_size);
 	~Terrain3DMaterial();
 
 	RID get_material_rid() const { return _material; }
@@ -62,8 +65,8 @@ public:
 	void set_shader_override(const Ref<Shader> &p_shader);
 	Ref<Shader> get_shader_override() const { return _shader_override; }
 
-	void set_param_cache(const Dictionary &p_dict);
-	Dictionary get_param_cache() const { return _param_cache; }
+	void set_shader_params(const Dictionary &p_dict);
+	Dictionary get_shader_params() const { return _shader_params; }
 
 	void set_region_size(int p_size);
 	int get_region_size() const { return _region_size; }

--- a/src/terrain_3d_material.h
+++ b/src/terrain_3d_material.h
@@ -20,7 +20,7 @@ private:
 	Ref<Shader> _shader_override;
 	Dictionary _shader_code;
 	mutable TypedArray<StringName> _shader_param_list;
-	Dictionary _param_cache;
+	mutable Dictionary _param_cache;
 
 	int _texture_count = 0;
 	bool _debug_view_checkered = false;

--- a/src/terrain_3d_material.h
+++ b/src/terrain_3d_material.h
@@ -20,6 +20,7 @@ private:
 	Ref<Shader> _shader_override;
 	Dictionary _shader_code;
 	mutable TypedArray<StringName> _shader_param_list;
+	Dictionary _param_cache;
 
 	int _texture_count = 0;
 	bool _debug_view_checkered = false;

--- a/src/terrain_3d_material.h
+++ b/src/terrain_3d_material.h
@@ -60,6 +60,8 @@ public:
 	RID get_material_rid() const { return _material; }
 	RID get_shader_rid() const { return _shader; }
 
+	void save();
+
 	void enable_shader_override(bool p_enabled);
 	bool is_shader_override_enabled() const { return _shader_override_enabled; }
 	void set_shader_override(const Ref<Shader> &p_shader);

--- a/src/terrain_3d_material.h
+++ b/src/terrain_3d_material.h
@@ -62,10 +62,15 @@ public:
 	void set_shader_override(const Ref<Shader> &p_shader);
 	Ref<Shader> get_shader_override() const { return _shader_override; }
 
+	void set_param_cache(const Dictionary &p_dict);
+	Dictionary get_param_cache() const { return _param_cache; }
+
 	void set_region_size(int p_size);
 	int get_region_size() const { return _region_size; }
-
 	RID get_region_blend_map() { return _generated_region_blend_map.get_rid(); }
+
+	void set_world_noise_enabled(bool p_enabled);
+	bool get_world_noise_enabled() const { return _world_noise_enabled; }
 
 	void set_show_checkered(bool p_enabled);
 	bool get_show_checkered() const { return _debug_view_checkered; }
@@ -87,9 +92,6 @@ public:
 	bool get_show_texture_rough() const { return _debug_view_tex_rough; }
 	void set_show_vertex_grid(bool p_enabled);
 	bool get_show_vertex_grid() const { return _debug_view_vertex_grid; }
-
-	void set_world_noise_enabled(bool p_enabled);
-	bool get_world_noise_enabled() const { return _world_noise_enabled; }
 
 protected:
 	void _get_property_list(List<PropertyInfo> *p_list) const;

--- a/src/terrain_3d_storage.cpp
+++ b/src/terrain_3d_storage.cpp
@@ -503,8 +503,9 @@ void Terrain3DStorage::save() {
 		return;
 	}
 	String path = get_path();
-	LOG(DEBUG, "Attempting to save terrain data to: " + path);
+	// Initiate save to external file. The scene will save itself.
 	if (path.get_extension() == "tres" || path.get_extension() == "res") {
+		LOG(DEBUG, "Attempting to save terrain data to external file: " + path);
 		LOG(DEBUG, "Saving storage version: ", vformat("%.2f", CURRENT_VERSION));
 		set_version(CURRENT_VERSION);
 		Error err;
@@ -531,6 +532,8 @@ void Terrain3DStorage::save() {
 			_modified = false;
 		}
 		LOG(INFO, "Finished saving terrain data");
+	} else {
+		LOG(WARN, "Storage resource is saving in the scene file. Save it as an external binary .res file");
 	}
 }
 

--- a/src/terrain_3d_texture_list.cpp
+++ b/src/terrain_3d_texture_list.cpp
@@ -288,8 +288,8 @@ void Terrain3DTextureList::set_textures(const TypedArray<Terrain3DTexture> &p_te
 
 void Terrain3DTextureList::save() {
 	String path = get_path();
-	LOG(DEBUG, "Attempting to save texture list to: " + path);
 	if (path.get_extension() == "tres" || path.get_extension() == "res") {
+		LOG(DEBUG, "Attempting to save texture list to external file: " + path);
 		Error err;
 		err = ResourceSaver::get_singleton()->save(this, path);
 		ERR_FAIL_COND(err);

--- a/src/util.cpp
+++ b/src/util.cpp
@@ -7,6 +7,13 @@
 // Public Functions
 ///////////////////////////
 
+void Util::print_dict(const Dictionary &p_dict, int level) {
+	Array keys = p_dict.keys();
+	for (int i = 0; i < keys.size(); i++) {
+		LOG(level, "Key: ", keys[i], ", Value: ", p_dict[keys[i]]);
+	}
+}
+
 void Util::dump_gen(GeneratedTex p_gen, String p_name) {
 	LOG(DEBUG, "Generated ", p_name, " RID: ", p_gen.get_rid(), ", dirty: ", p_gen.is_dirty(), ", image: ", p_gen.get_image());
 }

--- a/src/util.cpp
+++ b/src/util.cpp
@@ -7,7 +7,8 @@
 // Public Functions
 ///////////////////////////
 
-void Util::print_dict(const Dictionary &p_dict, int level) {
+void Util::print_dict(String p_name, const Dictionary &p_dict, int level) {
+	LOG(level, "Printing Dictionary: ", p_name);
 	Array keys = p_dict.keys();
 	for (int i = 0; i < keys.size(); i++) {
 		LOG(level, "Key: ", keys[i], ", Value: ", p_dict[keys[i]]);

--- a/src/util.h
+++ b/src/util.h
@@ -14,8 +14,9 @@ class Util {
 	static inline const char *__class__ = "Terrain3DUtil";
 
 public:
+	static void print_dict(const Dictionary &p_dict, int p_level = 1); // Defaults to INFO
 	static void dump_gen(GeneratedTex p_gen, String name = "");
-	static void dump_maps(const TypedArray<Image> p_maps, String name = "");
+	static void dump_maps(const TypedArray<Image> p_maps, String p_name = "");
 	static Vector2 get_min_max(const Ref<Image> p_image);
 	static Ref<Image> get_thumbnail(const Ref<Image> p_image, Vector2i p_size = Vector2i(256, 256));
 	static Ref<Image> get_filled_image(Vector2i p_size,

--- a/src/util.h
+++ b/src/util.h
@@ -14,7 +14,7 @@ class Util {
 	static inline const char *__class__ = "Terrain3DUtil";
 
 public:
-	static void print_dict(const Dictionary &p_dict, int p_level = 1); // Defaults to INFO
+	static void print_dict(String name, const Dictionary &p_dict, int p_level = 1); // Defaults to INFO
 	static void dump_gen(GeneratedTex p_gen, String name = "");
 	static void dump_maps(const TypedArray<Image> p_maps, String p_name = "");
 	static Vector2 get_min_max(const Ref<Image> p_image);


### PR DESCRIPTION
* Custom uniforms in shaders are now detected and displayed in the Terrain3DMaterial inspector. Uniforms that begin with _ are considered private and not displayed.
* All of the hard coded functions for worldnoise parameters are removed and instead the above pulls out the public world noise settings from the shader. It displays them whether they are part of a custom shader or the built in one.
* Uniforms work as the native data types (int, float, vec*, mat*, etc) and texture objects. I tested ImageTexture (dds), CompressedTexture (png), and NoiseTexture
* Shader includes work

Fixes #86