### PR TITLE
Add terrain occlusion baking to the editor

### DIFF
--- a/project/addons/terrain_3d/editor/components/bake_dialog.gd
+++ b/project/addons/terrain_3d/editor/components/bake_dialog.gd
@@ -1,0 +1,28 @@
+@tool
+extends ConfirmationDialog
+
+var lod: int = 0
+var description: String = ""
+
+
+func _ready() -> void:
+	set_unparent_when_invisible(true)
+	about_to_popup.connect(_on_about_to_popup)
+	visibility_changed.connect(_on_visibility_changed)
+	%LodBox.value_changed.connect(_on_lod_box_value_changed)
+
+
+func _on_about_to_popup() -> void:
+	lod = %LodBox.value
+
+
+func _on_visibility_changed() -> void:
+	# Change text on the autowrap label only when the popup is visible.
+	# Works around Godot issue #47005:
+	# https://github.com/godotengine/godot/issues/47005
+	if visible:
+		%DescriptionLabel.text = description
+
+
+func _on_lod_box_value_changed(value) -> void:
+	lod = %LodBox.value

--- a/project/addons/terrain_3d/editor/components/bake_dialog.tscn
+++ b/project/addons/terrain_3d/editor/components/bake_dialog.tscn
@@ -1,0 +1,41 @@
+[gd_scene load_steps=2 format=3 uid="uid://bhvrrmb8bk1bt"]
+
+[ext_resource type="Script" path="res://addons/terrain_3d/editor/components/bake_dialog.gd" id="1_57670"]
+
+[node name="bake_dialog" type="ConfirmationDialog"]
+title = "Bake Terrain3D Mesh"
+position = Vector2i(0, 36)
+size = Vector2i(400, 115)
+visible = true
+script = ExtResource("1_57670")
+
+[node name="VBoxContainer" type="VBoxContainer" parent="."]
+anchors_preset = 15
+anchor_right = 1.0
+anchor_bottom = 1.0
+offset_left = 8.0
+offset_top = 8.0
+offset_right = -8.0
+offset_bottom = -49.0
+grow_horizontal = 2
+grow_vertical = 2
+
+[node name="HBoxContainer" type="HBoxContainer" parent="VBoxContainer"]
+layout_mode = 2
+theme_override_constants/separation = 20
+
+[node name="Label" type="Label" parent="VBoxContainer/HBoxContainer"]
+layout_mode = 2
+text = "LOD:"
+
+[node name="LodBox" type="SpinBox" parent="VBoxContainer/HBoxContainer"]
+unique_name_in_owner = true
+layout_mode = 2
+size_flags_horizontal = 3
+max_value = 8.0
+value = 4.0
+
+[node name="DescriptionLabel" type="Label" parent="VBoxContainer"]
+unique_name_in_owner = true
+layout_mode = 2
+autowrap_mode = 2

--- a/project/addons/terrain_3d/editor/components/baker.gd
+++ b/project/addons/terrain_3d/editor/components/baker.gd
@@ -1,0 +1,88 @@
+extends HBoxContainer
+
+const BakeDialog: PackedScene = preload("res://addons/terrain_3d/editor/components/bake_dialog.tscn")
+const BAKE_MESH_DESCRIPTION: String = "This will create a child MeshInstance3D. LOD4+ is recommended. LOD0 is slow and dense with vertices every 1 unit. It is not an optimal mesh."
+const BAKE_OCCLUDER_DESCRIPTION: String = "This will create a child OccluderInstance3D. LOD4+ is recommended and will take 5+ seconds per region to generate. LOD0 is unnecessarily dense and slow."
+
+var plugin: EditorPlugin
+var bake_method: Callable
+var bake_dialog: ConfirmationDialog
+var bake_mesh_btn: Button
+var bake_occluder_btn: Button
+
+
+func _enter_tree() -> void:
+	bake_dialog = BakeDialog.instantiate()
+	bake_dialog.hide()
+	bake_dialog.confirmed.connect(func(): bake_method.call())
+
+	bake_mesh_btn = Button.new()
+	bake_mesh_btn.text = "Bake ArrayMesh"
+	bake_mesh_btn.pressed.connect(_on_bake_mesh_btn_pressed)
+	add_child(bake_mesh_btn)
+
+	bake_occluder_btn = Button.new()
+	bake_occluder_btn.text = "Bake Occluder3D"
+	bake_occluder_btn.pressed.connect(_on_bake_occluder_btn_pressed)
+	add_child(bake_occluder_btn)
+
+
+func _on_bake_mesh_btn_pressed() -> void:
+	if plugin.terrain:
+		bake_method = _bake_mesh
+		bake_dialog.description = BAKE_MESH_DESCRIPTION
+		plugin.get_editor_interface().popup_dialog_centered(bake_dialog)
+
+
+func _bake_mesh() -> void:
+	var mesh: Mesh = plugin.terrain.bake_mesh(bake_dialog.lod, Terrain3DStorage.HEIGHT_FILTER_NEAREST)
+	if !mesh:
+		push_error("Failed to bake mesh from Terrain3D")
+		return
+	var undo := plugin.get_undo_redo()
+
+	var mesh_instance := MeshInstance3D.new()
+	mesh_instance.name = &"MeshInstance3D"
+	mesh_instance.mesh = mesh
+	mesh_instance.set_skeleton_path(NodePath())
+
+	undo.create_action("Terrain3D Bake ArrayMesh")
+	undo.add_do_method(plugin.terrain, &"add_child", mesh_instance, true)
+	undo.add_undo_method(plugin.terrain, &"remove_child", mesh_instance)
+	undo.add_do_property(mesh_instance, &"owner", plugin.terrain.owner)
+	undo.add_do_reference(mesh_instance)
+	undo.commit_action()
+
+
+func _on_bake_occluder_btn_pressed() -> void:
+	if plugin.terrain:
+		bake_method = _bake_occluder
+		bake_dialog.description = BAKE_OCCLUDER_DESCRIPTION
+		plugin.get_editor_interface().popup_dialog_centered(bake_dialog)
+
+
+func _bake_occluder() -> void:
+	var mesh: Mesh = plugin.terrain.bake_mesh(bake_dialog.lod, Terrain3DStorage.HEIGHT_FILTER_MINIMUM)
+	if !mesh:
+		push_error("Failed to bake mesh from Terrain3D")
+		return
+	assert(mesh.get_surface_count() == 1)
+
+	var undo := plugin.get_undo_redo()
+
+	var occluder := ArrayOccluder3D.new()
+	var arrays := mesh.surface_get_arrays(0)
+	assert(arrays.size() > Mesh.ARRAY_INDEX)
+	assert(arrays[Mesh.ARRAY_INDEX] != null)
+	occluder.set_arrays(arrays[Mesh.ARRAY_VERTEX], arrays[Mesh.ARRAY_INDEX])
+
+	var occluder_instance := OccluderInstance3D.new()
+	occluder_instance.name = &"OccluderInstance3D"
+	occluder_instance.occluder = occluder
+
+	undo.create_action("Terrain3D Bake Occluder3D")
+	undo.add_do_method(plugin.terrain, &"add_child", occluder_instance, true)
+	undo.add_undo_method(plugin.terrain, &"remove_child", occluder_instance)
+	undo.add_do_property(occluder_instance, &"owner", plugin.terrain.owner)
+	undo.add_do_reference(occluder_instance)
+	undo.commit_action()

--- a/project/addons/terrain_3d/editor/components/ui.gd
+++ b/project/addons/terrain_3d/editor/components/ui.gd
@@ -5,6 +5,7 @@ extends Node
 # Includes
 const Toolbar: Script = preload("res://addons/terrain_3d/editor/components/toolbar.gd")
 const ToolSettings: Script = preload("res://addons/terrain_3d/editor/components/tool_settings.gd")
+const Baker: Script = preload("res://addons/terrain_3d/editor/components/baker.gd")
 const RING1: String = "res://addons/terrain_3d/editor/brushes/ring1.exr"
 const COLOR_RAISE := Color.WHITE
 const COLOR_LOWER := Color.BLACK
@@ -23,6 +24,7 @@ const COLOR_PICK_ROUGH := Color.ROYAL_BLUE
 var plugin: EditorPlugin # Actually Terrain3DEditorPlugin, but Godot still has CRC errors
 var toolbar: Toolbar
 var toolbar_settings: ToolSettings
+var baker: Baker
 var setting_has_changed: bool = false
 var visible: bool = false
 var picking: int = Terrain3DEditor.TOOL_MAX
@@ -43,8 +45,13 @@ func _enter_tree() -> void:
 	toolbar_settings.connect("picking", _on_picking)
 	toolbar_settings.hide()
 
+	baker = Baker.new()
+	baker.plugin = plugin
+	baker.hide()
+
 	plugin.add_control_to_container(EditorPlugin.CONTAINER_SPATIAL_EDITOR_SIDE_LEFT, toolbar)
 	plugin.add_control_to_container(EditorPlugin.CONTAINER_SPATIAL_EDITOR_BOTTOM, toolbar_settings)
+	plugin.add_control_to_container(EditorPlugin.CONTAINER_SPATIAL_EDITOR_MENU, baker)
 
 	decal = Decal.new()
 	add_child(decal)
@@ -61,6 +68,7 @@ func _exit_tree() -> void:
 	plugin.remove_control_from_container(EditorPlugin.CONTAINER_SPATIAL_EDITOR_BOTTOM, toolbar_settings)
 	toolbar.queue_free()
 	toolbar_settings.queue_free()
+	baker.queue_free()
 	decal.queue_free()
 	decal_timer.queue_free()
 
@@ -68,6 +76,7 @@ func _exit_tree() -> void:
 func set_visible(p_visible: bool) -> void:
 	visible = p_visible
 	toolbar.set_visible(p_visible)
+	baker.set_visible(p_visible)
 	
 	if p_visible:
 		p_visible = plugin.editor.get_tool() != Terrain3DEditor.REGION

--- a/project/project.godot
+++ b/project/project.godot
@@ -64,3 +64,7 @@ sprint={
 
 3d_physics/layer_1="Environment"
 3d_physics/layer_2="Player"
+
+[rendering]
+
+occlusion_culling/use_occlusion_culling=true

--- a/src/terrain_3d.h
+++ b/src/terrain_3d.h
@@ -10,6 +10,7 @@
 #include <godot_cpp/classes/camera3d.hpp>
 #include <godot_cpp/classes/editor_plugin.hpp>
 #include <godot_cpp/classes/geometry_instance3d.hpp>
+#include <godot_cpp/classes/mesh.hpp>
 #include <godot_cpp/classes/static_body3d.hpp>
 
 #include "terrain_3d_material.h"
@@ -134,6 +135,9 @@ public:
 	void snap(Vector3 p_cam_pos);
 	void update_aabbs();
 	Vector3 get_intersection(Vector3 p_position, Vector3 p_direction);
+
+	// Baking methods
+	Ref<Mesh> bake_mesh(int p_lod, Terrain3DStorage::HeightFilter p_filter = Terrain3DStorage::HEIGHT_FILTER_NEAREST) const;
 
 protected:
 	void _notification(int p_what);

--- a/src/terrain_3d_storage.h
+++ b/src/terrain_3d_storage.h
@@ -61,6 +61,11 @@ private:
 		//SIZE_2048 = 2048,
 	};
 
+	enum HeightFilter {
+		HEIGHT_FILTER_NEAREST,
+		HEIGHT_FILTER_MINIMUM
+	};
+
 	// Storage Settings & flags
 
 	real_t _version = 0.8; // Set to ensure Godot always saves this
@@ -145,6 +150,8 @@ public:
 	inline Color get_color(Vector3 p_global_position);
 	inline Color get_control(Vector3 p_global_position) { return get_pixel(TYPE_CONTROL, p_global_position); }
 	inline real_t get_roughness(Vector3 p_global_position) { return get_pixel(TYPE_COLOR, p_global_position).a; }
+	Vector3 get_mesh_vertex(int32_t p_lod, HeightFilter p_filter, Vector3 p_global_position);
+
 	TypedArray<Image> sanitize_maps(MapType p_map_type, const TypedArray<Image> &p_maps);
 	void force_update_maps(MapType p_map = TYPE_MAX);
 
@@ -173,5 +180,6 @@ protected:
 
 VARIANT_ENUM_CAST(Terrain3DStorage::MapType);
 VARIANT_ENUM_CAST(Terrain3DStorage::RegionSize);
+VARIANT_ENUM_CAST(Terrain3DStorage::HeightFilter);
 
 #endif // TERRAIN3D_STORAGE_CLASS_H


### PR DESCRIPTION
When a Terrain3D node is selected, this adds a new button to the editor for baking an occlusion mesh for the terrain.
![image](https://github.com/TokisanGames/Terrain3D/assets/165720/d56a82fe-41d4-436b-bfdd-1f99e591c35b)

When clicked, a dialog appears asking for a LOD. This value determines the granularity of the occlusion mesh, and therefore the number of vertices. Baking an occluder at a lower level of detail (higher number) will reduce opportunities for culling, but make occlusion testing quicker (and the mesh will use less memory).

Baking pauses the editor for a few seconds. It has to read every pixel on the height map once to make sure that the generated occluder doesn't extend above / outside the clipmap (at any level of detail).

Here's some draft documentation for the wiki: [occlusion-baking.md](https://github.com/TokisanGames/Terrain3D/files/13253121/occlusion-baking.md)

There's a second button this PR adds ("Bake ArrayMesh") which uses the same LOD dialog. It "comes for free" with occlusion mesh baking since it's generated the same way, but if you prefer I can strip this out of the PR. I've found this function useful for baking low-detail terrain meshes for unreachable distant islands and minimap generation, that are otherwise difficult to do cheaply with the clipmap. The mesh it creates has no material.

Fixes #177 