### PR TITLE
#233: Replaced PackedByteArray with PackedInt32Array

### DIFF
--- a/src/terrain_3d_material.h
+++ b/src/terrain_3d_material.h
@@ -44,7 +44,7 @@ private:
 	int _texture_count = 0;
 	int _region_size = 1024;
 	Vector2i _region_sizev = Vector2i(_region_size, _region_size);
-	PackedByteArray _region_map;
+	PackedInt32Array _region_map;
 	GeneratedTex _generated_region_blend_map; // 512x512 blurred image of region_map
 
 	// Functions

--- a/src/terrain_3d_storage.h
+++ b/src/terrain_3d_storage.h
@@ -84,7 +84,7 @@ private:
 	 * texture in generated_*_maps.
 	 */
 	bool _region_map_dirty = true;
-	PackedByteArray _region_map; // 16x16 Region grid with index into region_offsets (1 based array)
+	PackedInt32Array _region_map; // 16x16 Region grid with index into region_offsets (1 based array)
 	TypedArray<Vector2i> _region_offsets; // Array of active region coordinates
 	TypedArray<Image> _height_maps;
 	TypedArray<Image> _control_maps;


### PR DESCRIPTION
The #233 was caused by the fact that PackedByteArray was used to store regions' indices.
The code incremented actual index by 1.
Hence the 255th region had index 256 in the _region_map. However 256 overlows 8-bit, hence the bug occured.
I replaced PackedByteArray with PackedInt32Array, which solved the issue.

Fixes #233 