### PR TITLE
Add channel packer tool

### DIFF
--- a/project/addons/terrain_3d/editor/components/channel_packer.gd
+++ b/project/addons/terrain_3d/editor/components/channel_packer.gd
@@ -1,0 +1,212 @@
+extends Object
+
+const WINDOW_SCENE: String = "res://addons/terrain_3d/editor/components/channel_packer.tscn"
+const TEMPLATE_PATH: String = "res://addons/terrain_3d/editor/components/channel_packer_import_template.txt"
+
+enum { 
+  IMAGE_ALBEDO,
+  IMAGE_HEIGHT,
+  IMAGE_NORMAL,
+  IMAGE_ROUGHNESS,
+}
+
+var plugin: EditorPlugin
+var editor_interface: EditorInterface
+var dialog: AcceptDialog
+var save_file_dialog: FileDialog
+var open_file_dialog: FileDialog
+var invert_green_checkbox: CheckBox
+var last_opened_directory: String
+var last_saved_directory: String
+var packing_albedo: bool = false
+var queue_pack_normal_roughness: bool = false
+var images: Array[Image] = [null, null, null, null]
+var status_label: Label
+var no_op: Callable = func(): pass
+var last_file_selected_fn: Callable = no_op
+
+
+func pack_textures_popup() -> void:
+	if dialog != null:
+		print("Terrain3DChannelPacker: Cannot open pack tool, dialog already open.")
+		return
+
+	dialog = (load(WINDOW_SCENE) as PackedScene).instantiate()
+	dialog.confirmed.connect(_on_close_requested)
+	dialog.canceled.connect(_on_close_requested)
+	status_label = dialog.find_child("StatusLabel")
+	invert_green_checkbox = dialog.find_child("InvertGreenChannelCheckBox")
+
+	editor_interface = plugin.get_editor_interface()
+	_init_file_dialogs()	
+	editor_interface.popup_dialog_centered(dialog)
+
+	_init_texture_picker(dialog.find_child("AlbedoVBox"), IMAGE_ALBEDO)
+	_init_texture_picker(dialog.find_child("HeightVBox"), IMAGE_HEIGHT)
+	_init_texture_picker(dialog.find_child("NormalVBox"), IMAGE_NORMAL)
+	_init_texture_picker(dialog.find_child("RoughnessVBox"), IMAGE_ROUGHNESS)
+	var pack_button_path: String = "Panel/MarginContainer/VBoxContainer/PackButton" 
+	(dialog.get_node(pack_button_path) as Button).pressed.connect(_on_pack_button_pressed)
+
+
+func _on_close_requested() -> void:
+	last_file_selected_fn = no_op
+	images = [null, null, null, null]
+	dialog.queue_free()
+	dialog = null
+
+
+func _init_file_dialogs() -> void:
+	save_file_dialog = FileDialog.new()
+	save_file_dialog.set_filters(PackedStringArray(["*.png"]))
+	save_file_dialog.set_file_mode(FileDialog.FILE_MODE_SAVE_FILE)
+	save_file_dialog.access = FileDialog.ACCESS_FILESYSTEM
+	save_file_dialog.file_selected.connect(_on_save_file_selected)
+
+	open_file_dialog = FileDialog.new()
+	open_file_dialog.set_filters(PackedStringArray(["*.png", "*.bmp", "*.exr", "*.hdr", "*.jpg", "*.jpeg", "*.tga", "*.svg", "*.webp", ".ktx"]))
+	open_file_dialog.set_file_mode(FileDialog.FILE_MODE_OPEN_FILE)
+	open_file_dialog.access = FileDialog.ACCESS_FILESYSTEM
+
+	dialog.add_child(save_file_dialog)
+	dialog.add_child(open_file_dialog)
+
+
+func _init_texture_picker(p_parent: Node, p_image_index: int) -> void:
+	var line_edit: LineEdit = p_parent.find_child("LineEdit")
+	var file_pick_button: Button = p_parent.find_child("PickButton")
+	var clear_button: Button = p_parent.find_child("ClearButton")
+	var texture_rect: TextureRect = p_parent.find_child("TextureRect")
+	var texture_button: Button = p_parent.find_child("TextureButton")
+
+	var open_fn: Callable = func() -> void:
+		open_file_dialog.current_path = last_opened_directory
+		if last_file_selected_fn != no_op:
+			open_file_dialog.file_selected.disconnect(last_file_selected_fn)
+		last_file_selected_fn = func(path: String) -> void: 
+			line_edit.text = path
+			line_edit.caret_column = path.length()
+			last_opened_directory = path.get_base_dir() + "/"
+			var image: Image = Image.new()
+			var code: int = image.load(path)
+			if code != OK:
+				_show_error("Failed to load texture '" + path + "'")
+				texture_rect.texture = null
+				images[p_image_index] = null
+			else:
+				_show_success("Loaded texture '" + path + "'")
+				texture_rect.texture = ImageTexture.create_from_image(image)
+				images[p_image_index] = image
+		open_file_dialog.file_selected.connect(last_file_selected_fn)
+		open_file_dialog.popup_centered_ratio()
+
+	var clear_fn: Callable = func() -> void:
+		line_edit.text = ""
+		texture_rect.texture = null
+		images[p_image_index] = null
+
+	# allow user to edit textbox and press enter because Godot's file picker doesn't work 100% of the time
+	var line_edit_submit_fn: Callable = func(path: String) -> void: 
+		var image: Image = Image.new()
+		var code: int = image.load(path)
+		if code != OK:
+			_show_error("Failed to load texture '" + path + "'")
+			texture_rect.texture = null
+			images[p_image_index] = null
+		else:
+			texture_rect.texture = ImageTexture.create_from_image(image)
+			images[p_image_index] = image	
+
+	line_edit.text_submitted.connect(line_edit_submit_fn)
+	file_pick_button.pressed.connect(open_fn)
+	texture_button.pressed.connect(open_fn)
+	clear_button.pressed.connect(clear_fn)
+	_set_button_icon(file_pick_button, "Folder")
+	_set_button_icon(clear_button, "Remove")
+
+
+func _set_button_icon(p_button: Button, p_icon_name: String) -> void:
+	var editor_base: Control = editor_interface.get_base_control()
+	var icon: Texture2D = editor_base.get_theme_icon(p_icon_name, "EditorIcons")
+	p_button.icon = icon
+
+
+func _show_error(p_text: String) -> void:
+	push_error("Terrain3DChannelPacker: " + p_text)
+	status_label.text = p_text
+	status_label.add_theme_color_override("font_color", Color(0.9, 0, 0))
+
+
+func _show_success(p_text: String) -> void:
+	print("Terrain3DChannelPacker: " + p_text)
+	status_label.text = p_text
+	status_label.add_theme_color_override("font_color", Color(0, 0.82, 0.14))
+
+
+func _create_import_file(png_path: String) -> void:
+	var dst_import_path: String = png_path + ".import"
+
+	var file: FileAccess = FileAccess.open(TEMPLATE_PATH, FileAccess.READ)
+	var template_content: String = file.get_as_text()
+	file.close()
+
+	var import_content: String = template_content.replace("$SOURCE_FILE", png_path)
+	file = FileAccess.open(dst_import_path, FileAccess.WRITE)
+	file.store_string(import_content)
+	file.close()
+
+
+func _on_pack_button_pressed() -> void:
+	packing_albedo = images[IMAGE_ALBEDO] != null and images[IMAGE_HEIGHT] != null
+	var packing_normal_roughness: bool = images[IMAGE_NORMAL] != null and images[IMAGE_ROUGHNESS] != null
+
+	if not packing_albedo and not packing_normal_roughness:
+		_show_error("Please select an albedo and height texture or a normal and roughness texture.")
+		return
+
+	if packing_albedo:
+		save_file_dialog.current_path = last_saved_directory + "packed_albedo_height"
+		save_file_dialog.title = "Save Packed Albedo/Height Texture"
+		save_file_dialog.popup_centered_ratio()
+		if packing_normal_roughness:
+			queue_pack_normal_roughness = true
+		return
+	if packing_normal_roughness:
+		save_file_dialog.current_path = last_saved_directory + "packed_normal_roughness"
+		save_file_dialog.title = "Save Packed Normal/Roughness Texture"
+		save_file_dialog.popup_centered_ratio()
+
+
+func _on_save_file_selected(p_dst_path) -> void:
+	last_saved_directory = p_dst_path.get_base_dir() + "/"
+	if packing_albedo:
+		_pack_textures(images[IMAGE_ALBEDO], images[IMAGE_HEIGHT], p_dst_path, false)
+	else:
+		_pack_textures(images[IMAGE_NORMAL], images[IMAGE_ROUGHNESS], p_dst_path, invert_green_checkbox.button_pressed)
+	
+	if queue_pack_normal_roughness:
+		queue_pack_normal_roughness = false
+		packing_albedo = false
+		save_file_dialog.current_path = last_saved_directory + "packed_normal_roughness"
+		save_file_dialog.title = "Save Packed Normal/Roughness Texture"
+		save_file_dialog.call_deferred("popup_centered_ratio")
+
+
+func _pack_textures(p_rgb_image: Image, p_a_image: Image, p_dst_path: String, p_invert_green: bool) -> void:
+	if p_rgb_image and p_a_image:
+		if p_rgb_image.get_size() != p_a_image.get_size():
+			_show_error("Textures must be the same size.")
+			return
+
+		var output_image: Image = Terrain3D.pack_image(p_rgb_image, p_a_image, p_invert_green)
+
+		if not output_image:
+			_show_error("Failed to pack textures.")
+			return
+
+		output_image.save_png(p_dst_path)
+		editor_interface.get_resource_filesystem().scan_sources()
+		_create_import_file(p_dst_path)
+		_show_success("Packed to " + p_dst_path + ".")
+	else:
+		_show_error("Failed to load one or more textures.")

--- a/project/addons/terrain_3d/editor/components/channel_packer.tscn
+++ b/project/addons/terrain_3d/editor/components/channel_packer.tscn
@@ -1,0 +1,359 @@
+[gd_scene load_steps=5 format=3 uid="uid://nud6dwjcnj5v"]
+
+[sub_resource type="StyleBoxFlat" id="StyleBoxFlat_ysabf"]
+bg_color = Color(0.211765, 0.239216, 0.290196, 1)
+
+[sub_resource type="StyleBoxFlat" id="StyleBoxFlat_lcvna"]
+bg_color = Color(0.168627, 0.211765, 0.266667, 1)
+border_width_left = 3
+border_width_top = 3
+border_width_right = 3
+border_width_bottom = 3
+border_color = Color(0.270588, 0.435294, 0.580392, 1)
+corner_radius_top_left = 5
+corner_radius_top_right = 5
+corner_radius_bottom_right = 5
+corner_radius_bottom_left = 5
+
+[sub_resource type="StyleBoxFlat" id="StyleBoxFlat_cb0xf"]
+bg_color = Color(0.137255, 0.137255, 0.137255, 1)
+draw_center = false
+border_width_left = 3
+border_width_top = 3
+border_width_right = 3
+border_width_bottom = 3
+border_color = Color(0.784314, 0.784314, 0.784314, 1)
+corner_radius_top_left = 5
+corner_radius_top_right = 5
+corner_radius_bottom_right = 5
+corner_radius_bottom_left = 5
+
+[sub_resource type="StyleBoxEmpty" id="StyleBoxEmpty_7qdas"]
+
+[node name="AcceptDialog" type="AcceptDialog"]
+title = "Terrain3D Channel Packer"
+initial_position = 1
+size = Vector2i(660, 900)
+visible = true
+ok_button_text = "Close"
+
+[node name="Panel" type="Panel" parent="."]
+anchors_preset = 15
+anchor_right = 1.0
+anchor_bottom = 1.0
+offset_left = 8.0
+offset_top = 8.0
+offset_right = -8.0
+offset_bottom = -49.0
+grow_horizontal = 2
+grow_vertical = 2
+theme_override_styles/panel = SubResource("StyleBoxFlat_ysabf")
+
+[node name="MarginContainer" type="MarginContainer" parent="Panel"]
+layout_mode = 1
+anchors_preset = 15
+anchor_right = 1.0
+anchor_bottom = 1.0
+offset_left = 4.0
+offset_top = 4.0
+offset_right = -1.0
+offset_bottom = -53.0
+grow_horizontal = 2
+grow_vertical = 2
+theme_override_constants/margin_left = 5
+theme_override_constants/margin_top = 5
+theme_override_constants/margin_right = 5
+theme_override_constants/margin_bottom = 5
+
+[node name="VBoxContainer" type="VBoxContainer" parent="Panel/MarginContainer"]
+layout_mode = 2
+size_flags_vertical = 0
+theme_override_constants/separation = 10
+
+[node name="AlbedoHeightPanel" type="Panel" parent="Panel/MarginContainer/VBoxContainer"]
+custom_minimum_size = Vector2(0, 250)
+layout_mode = 2
+theme_override_styles/panel = SubResource("StyleBoxFlat_lcvna")
+
+[node name="MarginContainer" type="MarginContainer" parent="Panel/MarginContainer/VBoxContainer/AlbedoHeightPanel"]
+layout_mode = 1
+anchors_preset = 15
+anchor_right = 1.0
+anchor_bottom = 1.0
+grow_horizontal = 2
+grow_vertical = 2
+theme_override_constants/margin_left = 10
+theme_override_constants/margin_top = 10
+theme_override_constants/margin_right = 10
+theme_override_constants/margin_bottom = 10
+
+[node name="HBoxContainer" type="HBoxContainer" parent="Panel/MarginContainer/VBoxContainer/AlbedoHeightPanel/MarginContainer"]
+layout_mode = 2
+
+[node name="AlbedoVBox" type="VBoxContainer" parent="Panel/MarginContainer/VBoxContainer/AlbedoHeightPanel/MarginContainer/HBoxContainer"]
+layout_mode = 2
+size_flags_horizontal = 3
+
+[node name="AlbedoLabel" type="Label" parent="Panel/MarginContainer/VBoxContainer/AlbedoHeightPanel/MarginContainer/HBoxContainer/AlbedoVBox"]
+layout_mode = 2
+text = "Albedo texture"
+
+[node name="AlbedoHBox" type="HBoxContainer" parent="Panel/MarginContainer/VBoxContainer/AlbedoHeightPanel/MarginContainer/HBoxContainer/AlbedoVBox"]
+layout_mode = 2
+
+[node name="LineEdit" type="LineEdit" parent="Panel/MarginContainer/VBoxContainer/AlbedoHeightPanel/MarginContainer/HBoxContainer/AlbedoVBox/AlbedoHBox"]
+layout_mode = 2
+size_flags_horizontal = 3
+
+[node name="PickButton" type="Button" parent="Panel/MarginContainer/VBoxContainer/AlbedoHeightPanel/MarginContainer/HBoxContainer/AlbedoVBox/AlbedoHBox"]
+layout_mode = 2
+
+[node name="ClearButton" type="Button" parent="Panel/MarginContainer/VBoxContainer/AlbedoHeightPanel/MarginContainer/HBoxContainer/AlbedoVBox/AlbedoHBox"]
+layout_mode = 2
+
+[node name="MarginContainer" type="MarginContainer" parent="Panel/MarginContainer/VBoxContainer/AlbedoHeightPanel/MarginContainer/HBoxContainer/AlbedoVBox"]
+layout_mode = 2
+size_flags_vertical = 4
+theme_override_constants/margin_top = 10
+
+[node name="Panel" type="Panel" parent="Panel/MarginContainer/VBoxContainer/AlbedoHeightPanel/MarginContainer/HBoxContainer/AlbedoVBox/MarginContainer"]
+custom_minimum_size = Vector2(110, 110)
+layout_mode = 2
+size_flags_horizontal = 4
+size_flags_vertical = 4
+theme_override_styles/panel = SubResource("StyleBoxFlat_cb0xf")
+
+[node name="TextureRect" type="TextureRect" parent="Panel/MarginContainer/VBoxContainer/AlbedoHeightPanel/MarginContainer/HBoxContainer/AlbedoVBox/MarginContainer/Panel"]
+layout_mode = 1
+anchors_preset = 8
+anchor_left = 0.5
+anchor_top = 0.5
+anchor_right = 0.5
+anchor_bottom = 0.5
+offset_left = -50.0
+offset_top = -50.0
+offset_right = 50.0
+offset_bottom = 50.0
+grow_horizontal = 2
+grow_vertical = 2
+expand_mode = 1
+
+[node name="TextureButton" type="Button" parent="Panel/MarginContainer/VBoxContainer/AlbedoHeightPanel/MarginContainer/HBoxContainer/AlbedoVBox/MarginContainer/Panel"]
+layout_mode = 1
+anchors_preset = 15
+anchor_right = 1.0
+anchor_bottom = 1.0
+grow_horizontal = 2
+grow_vertical = 2
+theme_override_styles/normal = SubResource("StyleBoxEmpty_7qdas")
+
+[node name="HeightVBox" type="VBoxContainer" parent="Panel/MarginContainer/VBoxContainer/AlbedoHeightPanel/MarginContainer/HBoxContainer"]
+layout_mode = 2
+size_flags_horizontal = 3
+
+[node name="HeightLabel" type="Label" parent="Panel/MarginContainer/VBoxContainer/AlbedoHeightPanel/MarginContainer/HBoxContainer/HeightVBox"]
+layout_mode = 2
+text = "Height texture"
+
+[node name="HeightHBox" type="HBoxContainer" parent="Panel/MarginContainer/VBoxContainer/AlbedoHeightPanel/MarginContainer/HBoxContainer/HeightVBox"]
+layout_mode = 2
+
+[node name="LineEdit" type="LineEdit" parent="Panel/MarginContainer/VBoxContainer/AlbedoHeightPanel/MarginContainer/HBoxContainer/HeightVBox/HeightHBox"]
+layout_mode = 2
+size_flags_horizontal = 3
+
+[node name="PickButton" type="Button" parent="Panel/MarginContainer/VBoxContainer/AlbedoHeightPanel/MarginContainer/HBoxContainer/HeightVBox/HeightHBox"]
+layout_mode = 2
+
+[node name="ClearButton" type="Button" parent="Panel/MarginContainer/VBoxContainer/AlbedoHeightPanel/MarginContainer/HBoxContainer/HeightVBox/HeightHBox"]
+layout_mode = 2
+
+[node name="MarginContainer" type="MarginContainer" parent="Panel/MarginContainer/VBoxContainer/AlbedoHeightPanel/MarginContainer/HBoxContainer/HeightVBox"]
+layout_mode = 2
+size_flags_vertical = 4
+theme_override_constants/margin_top = 10
+
+[node name="Panel" type="Panel" parent="Panel/MarginContainer/VBoxContainer/AlbedoHeightPanel/MarginContainer/HBoxContainer/HeightVBox/MarginContainer"]
+custom_minimum_size = Vector2(110, 110)
+layout_mode = 2
+size_flags_horizontal = 4
+size_flags_vertical = 4
+theme_override_styles/panel = SubResource("StyleBoxFlat_cb0xf")
+
+[node name="TextureRect" type="TextureRect" parent="Panel/MarginContainer/VBoxContainer/AlbedoHeightPanel/MarginContainer/HBoxContainer/HeightVBox/MarginContainer/Panel"]
+layout_mode = 1
+anchors_preset = 8
+anchor_left = 0.5
+anchor_top = 0.5
+anchor_right = 0.5
+anchor_bottom = 0.5
+offset_left = -50.0
+offset_top = -50.0
+offset_right = 50.0
+offset_bottom = 50.0
+grow_horizontal = 2
+grow_vertical = 2
+expand_mode = 1
+
+[node name="TextureButton" type="Button" parent="Panel/MarginContainer/VBoxContainer/AlbedoHeightPanel/MarginContainer/HBoxContainer/HeightVBox/MarginContainer/Panel"]
+layout_mode = 1
+anchors_preset = 15
+anchor_right = 1.0
+anchor_bottom = 1.0
+grow_horizontal = 2
+grow_vertical = 2
+theme_override_styles/normal = SubResource("StyleBoxEmpty_7qdas")
+
+[node name="NormalRoughnessPanel" type="Panel" parent="Panel/MarginContainer/VBoxContainer"]
+custom_minimum_size = Vector2(0, 280)
+layout_mode = 2
+theme_override_styles/panel = SubResource("StyleBoxFlat_lcvna")
+
+[node name="MarginContainer" type="MarginContainer" parent="Panel/MarginContainer/VBoxContainer/NormalRoughnessPanel"]
+layout_mode = 1
+anchors_preset = 15
+anchor_right = 1.0
+anchor_bottom = 1.0
+grow_horizontal = 2
+grow_vertical = 2
+theme_override_constants/margin_left = 10
+theme_override_constants/margin_top = 10
+theme_override_constants/margin_right = 10
+theme_override_constants/margin_bottom = 10
+
+[node name="HBoxContainer" type="HBoxContainer" parent="Panel/MarginContainer/VBoxContainer/NormalRoughnessPanel/MarginContainer"]
+layout_mode = 2
+
+[node name="NormalVBox" type="VBoxContainer" parent="Panel/MarginContainer/VBoxContainer/NormalRoughnessPanel/MarginContainer/HBoxContainer"]
+layout_mode = 2
+size_flags_horizontal = 3
+
+[node name="NormalLabel" type="Label" parent="Panel/MarginContainer/VBoxContainer/NormalRoughnessPanel/MarginContainer/HBoxContainer/NormalVBox"]
+layout_mode = 2
+text = "Normal texture"
+
+[node name="NormalHBox" type="HBoxContainer" parent="Panel/MarginContainer/VBoxContainer/NormalRoughnessPanel/MarginContainer/HBoxContainer/NormalVBox"]
+layout_mode = 2
+
+[node name="LineEdit" type="LineEdit" parent="Panel/MarginContainer/VBoxContainer/NormalRoughnessPanel/MarginContainer/HBoxContainer/NormalVBox/NormalHBox"]
+layout_mode = 2
+size_flags_horizontal = 3
+
+[node name="PickButton" type="Button" parent="Panel/MarginContainer/VBoxContainer/NormalRoughnessPanel/MarginContainer/HBoxContainer/NormalVBox/NormalHBox"]
+layout_mode = 2
+
+[node name="ClearButton" type="Button" parent="Panel/MarginContainer/VBoxContainer/NormalRoughnessPanel/MarginContainer/HBoxContainer/NormalVBox/NormalHBox"]
+layout_mode = 2
+
+[node name="MarginContainer" type="MarginContainer" parent="Panel/MarginContainer/VBoxContainer/NormalRoughnessPanel/MarginContainer/HBoxContainer/NormalVBox"]
+layout_mode = 2
+size_flags_vertical = 4
+theme_override_constants/margin_top = 10
+
+[node name="Panel" type="Panel" parent="Panel/MarginContainer/VBoxContainer/NormalRoughnessPanel/MarginContainer/HBoxContainer/NormalVBox/MarginContainer"]
+custom_minimum_size = Vector2(110, 110)
+layout_mode = 2
+size_flags_horizontal = 4
+size_flags_vertical = 4
+theme_override_styles/panel = SubResource("StyleBoxFlat_cb0xf")
+
+[node name="TextureRect" type="TextureRect" parent="Panel/MarginContainer/VBoxContainer/NormalRoughnessPanel/MarginContainer/HBoxContainer/NormalVBox/MarginContainer/Panel"]
+layout_mode = 1
+anchors_preset = 8
+anchor_left = 0.5
+anchor_top = 0.5
+anchor_right = 0.5
+anchor_bottom = 0.5
+offset_left = -50.0
+offset_top = -50.0
+offset_right = 50.0
+offset_bottom = 50.0
+grow_horizontal = 2
+grow_vertical = 2
+expand_mode = 1
+
+[node name="TextureButton" type="Button" parent="Panel/MarginContainer/VBoxContainer/NormalRoughnessPanel/MarginContainer/HBoxContainer/NormalVBox/MarginContainer/Panel"]
+layout_mode = 1
+anchors_preset = 15
+anchor_right = 1.0
+anchor_bottom = 1.0
+grow_horizontal = 2
+grow_vertical = 2
+theme_override_styles/normal = SubResource("StyleBoxEmpty_7qdas")
+
+[node name="InvertGreenChannelCheckBox" type="CheckBox" parent="Panel/MarginContainer/VBoxContainer/NormalRoughnessPanel/MarginContainer/HBoxContainer/NormalVBox"]
+layout_mode = 2
+text = "Convert DirectX to OpenGL"
+
+[node name="RoughnessVBox" type="VBoxContainer" parent="Panel/MarginContainer/VBoxContainer/NormalRoughnessPanel/MarginContainer/HBoxContainer"]
+layout_mode = 2
+size_flags_horizontal = 3
+
+[node name="RoughnessLabel" type="Label" parent="Panel/MarginContainer/VBoxContainer/NormalRoughnessPanel/MarginContainer/HBoxContainer/RoughnessVBox"]
+layout_mode = 2
+text = "Roughness texture"
+
+[node name="RoughnessHBox" type="HBoxContainer" parent="Panel/MarginContainer/VBoxContainer/NormalRoughnessPanel/MarginContainer/HBoxContainer/RoughnessVBox"]
+layout_mode = 2
+
+[node name="LineEdit" type="LineEdit" parent="Panel/MarginContainer/VBoxContainer/NormalRoughnessPanel/MarginContainer/HBoxContainer/RoughnessVBox/RoughnessHBox"]
+layout_mode = 2
+size_flags_horizontal = 3
+
+[node name="PickButton" type="Button" parent="Panel/MarginContainer/VBoxContainer/NormalRoughnessPanel/MarginContainer/HBoxContainer/RoughnessVBox/RoughnessHBox"]
+layout_mode = 2
+
+[node name="ClearButton" type="Button" parent="Panel/MarginContainer/VBoxContainer/NormalRoughnessPanel/MarginContainer/HBoxContainer/RoughnessVBox/RoughnessHBox"]
+layout_mode = 2
+
+[node name="MarginContainer" type="MarginContainer" parent="Panel/MarginContainer/VBoxContainer/NormalRoughnessPanel/MarginContainer/HBoxContainer/RoughnessVBox"]
+layout_mode = 2
+size_flags_vertical = 4
+theme_override_constants/margin_top = 10
+
+[node name="Panel" type="Panel" parent="Panel/MarginContainer/VBoxContainer/NormalRoughnessPanel/MarginContainer/HBoxContainer/RoughnessVBox/MarginContainer"]
+custom_minimum_size = Vector2(110, 110)
+layout_mode = 2
+size_flags_horizontal = 4
+size_flags_vertical = 4
+theme_override_styles/panel = SubResource("StyleBoxFlat_cb0xf")
+
+[node name="TextureRect" type="TextureRect" parent="Panel/MarginContainer/VBoxContainer/NormalRoughnessPanel/MarginContainer/HBoxContainer/RoughnessVBox/MarginContainer/Panel"]
+layout_mode = 1
+anchors_preset = 8
+anchor_left = 0.5
+anchor_top = 0.5
+anchor_right = 0.5
+anchor_bottom = 0.5
+offset_left = -50.0
+offset_top = -50.0
+offset_right = 50.0
+offset_bottom = 50.0
+grow_horizontal = 2
+grow_vertical = 2
+expand_mode = 1
+
+[node name="TextureButton" type="Button" parent="Panel/MarginContainer/VBoxContainer/NormalRoughnessPanel/MarginContainer/HBoxContainer/RoughnessVBox/MarginContainer/Panel"]
+layout_mode = 1
+anchors_preset = 15
+anchor_right = 1.0
+anchor_bottom = 1.0
+grow_horizontal = 2
+grow_vertical = 2
+theme_override_styles/normal = SubResource("StyleBoxEmpty_7qdas")
+
+[node name="NormalRoughnessHBox" type="HBoxContainer" parent="Panel/MarginContainer/VBoxContainer"]
+layout_mode = 2
+
+[node name="PackButton" type="Button" parent="Panel/MarginContainer/VBoxContainer"]
+layout_mode = 2
+text = "Pack textures as..."
+
+[node name="StatusLabel" type="Label" parent="Panel/MarginContainer/VBoxContainer"]
+custom_minimum_size = Vector2(0, 10)
+layout_mode = 2
+theme_override_colors/font_color = Color(1, 1, 1, 1)
+text = "Use this to create a packed Albedo + Height texture and/or a packed Normal + Roughness texture. 
+
+You can then use these textures with Terrain3D."
+autowrap_mode = 2

--- a/project/addons/terrain_3d/editor/components/channel_packer_import_template.txt
+++ b/project/addons/terrain_3d/editor/components/channel_packer_import_template.txt
@@ -1,0 +1,32 @@
+[remap]
+
+importer="texture"
+type="CompressedTexture2D"
+metadata={
+"imported_formats": ["s3tc_bptc"],
+"vram_texture": true
+}
+
+[deps]
+
+source_file="$SOURCE_FILE"
+
+[params]
+
+compress/mode=2
+compress/high_quality=false
+compress/lossy_quality=0.7
+compress/hdr_compression=1
+compress/normal_map=2
+compress/channel_pack=0
+mipmaps/generate=true
+mipmaps/limit=-1
+roughness/mode=0
+roughness/src_normal=""
+process/fix_alpha_border=true
+process/premult_alpha=false
+process/normal_map_invert_y=false
+process/hdr_as_srgb=false
+process/hdr_clamp_exposure=false
+process/size_limit=0
+detect_3d/compress_to=1

--- a/project/addons/terrain_3d/editor/components/terrain_tools.gd
+++ b/project/addons/terrain_3d/editor/components/terrain_tools.gd
@@ -2,10 +2,12 @@ extends HBoxContainer
 
 
 const Baker: Script = preload("res://addons/terrain_3d/editor/components/baker.gd")
+const Packer: Script = preload("res://addons/terrain_3d/editor/components/channel_packer.gd")
 
 var plugin: EditorPlugin
 var menu_button: MenuButton = MenuButton.new()
 var baker: Baker = Baker.new()
+var packer: Packer = Packer.new()
 
 enum {
 	MENU_BAKE_ARRAY_MESH,
@@ -13,11 +15,14 @@ enum {
 	MENU_BAKE_NAV_MESH,
 	MENU_SEPARATOR,
 	MENU_SET_UP_NAVIGATION,
+	MENU_PACK_TEXTURES,
 }
 
 
 func _enter_tree() -> void:
 	baker.plugin = plugin
+	packer.plugin = plugin
+
 	add_child(baker)
 	
 	menu_button.text = "Terrain3D Tools"
@@ -26,6 +31,9 @@ func _enter_tree() -> void:
 	menu_button.get_popup().add_item("Bake NavMesh", MENU_BAKE_NAV_MESH)
 	menu_button.get_popup().add_separator("", MENU_SEPARATOR)
 	menu_button.get_popup().add_item("Set up Navigation", MENU_SET_UP_NAVIGATION)
+	menu_button.get_popup().add_separator("", MENU_SEPARATOR)
+	menu_button.get_popup().add_item("Pack Textures", MENU_PACK_TEXTURES)	
+	
 	menu_button.get_popup().id_pressed.connect(_on_menu_pressed)
 	menu_button.about_to_popup.connect(_on_menu_about_to_popup)
 	add_child(menu_button)
@@ -41,12 +49,15 @@ func _on_menu_pressed(p_id: int) -> void:
 			baker.bake_nav_mesh()
 		MENU_SET_UP_NAVIGATION:
 			baker.set_up_navigation_popup()
+		MENU_PACK_TEXTURES:
+			packer.pack_textures_popup()
 
 
 func _on_menu_about_to_popup() -> void:
 	menu_button.get_popup().set_item_disabled(MENU_BAKE_ARRAY_MESH, not plugin.terrain)
 	menu_button.get_popup().set_item_disabled(MENU_BAKE_OCCLUDER, not plugin.terrain)
-	
+	menu_button.get_popup().set_item_disabled(MENU_PACK_TEXTURES, not plugin.terrain)
+
 	if plugin.terrain:
 		var nav_regions: Array[NavigationRegion3D] = baker.find_terrain_nav_regions(plugin.terrain)
 		menu_button.get_popup().set_item_disabled(MENU_BAKE_NAV_MESH, nav_regions.size() == 0)

--- a/src/terrain_3d.cpp
+++ b/src/terrain_3d.cpp
@@ -1071,6 +1071,7 @@ void Terrain3D::_bind_methods() {
 	ClassDB::bind_static_method("Terrain3D", D_METHOD("get_min_max", "image"), &Util::get_min_max);
 	ClassDB::bind_static_method("Terrain3D", D_METHOD("get_thumbnail", "image", "size"), &Util::get_thumbnail, DEFVAL(Vector2i(256, 256)));
 	ClassDB::bind_static_method("Terrain3D", D_METHOD("get_filled_image", "size", "color", "create_mipmaps", "format"), &Util::get_filled_image);
+	ClassDB::bind_static_method("Terrain3D", D_METHOD("pack_image", "src_rgb", "src_r", "invert_green_channel"), &Util::pack_image, DEFVAL(false));
 
 	// Expose 'update_aabbs' so it can be used in Callable. Not ideal.
 	ClassDB::bind_method(D_METHOD("update_aabbs"), &Terrain3D::update_aabbs);

--- a/src/util.cpp
+++ b/src/util.cpp
@@ -176,3 +176,34 @@ Ref<Image> Util::get_filled_image(Vector2i p_size, Color p_color, bool p_create_
 	}
 	return img;
 }
+
+/* From source RGB and R channels, create a new RGBA image. If p_invert_green_channel is true,
+ * the destination green channel will be 1.0 - input green channel.
+ */
+Ref<Image> Util::pack_image(const Ref<Image> p_src_rgb, const Ref<Image> p_src_r, bool p_invert_green_channel) {
+	if (!p_src_rgb.is_valid() || !p_src_r.is_valid()) {
+		LOG(ERROR, "Provided images are not valid. Cannot pack.");
+		return Ref<Image>();
+	}
+	if (p_src_rgb->get_size() != p_src_r->get_size()) {
+		LOG(ERROR, "Provided images are not the same size. Cannot pack.");
+		return Ref<Image>();
+	}
+	if (p_src_rgb->is_empty() || p_src_r->is_empty()) {
+		LOG(ERROR, "Provided images are empty. Cannot pack.");
+		return Ref<Image>();
+	}
+	Ref<Image> dst = Image::create(p_src_rgb->get_width(), p_src_rgb->get_height(), false, Image::FORMAT_RGBA8);
+	LOG(INFO, "Creating image from source RGB + R images.");
+	for (int y = 0; y < p_src_rgb->get_height(); y++) {
+		for (int x = 0; x < p_src_rgb->get_width(); x++) {
+			Color col = p_src_rgb->get_pixel(x, y);
+			col.a = p_src_r->get_pixel(x, y).r;
+			if (p_invert_green_channel) {
+				col.g = 1.0f - col.g;
+			}
+			dst->set_pixel(x, y, col);
+		}
+	}
+	return dst;
+}

--- a/src/util.h
+++ b/src/util.h
@@ -57,6 +57,7 @@ public:
 			Color p_color = COLOR_BLACK,
 			bool p_create_mipmaps = true,
 			Image::Format p_format = Image::FORMAT_MAX);
+	static Ref<Image> pack_image(const Ref<Image> p_src_rgb, const Ref<Image> p_src_r, bool p_invert_green_channel = false);
 };
 
 #endif // UTIL_CLASS_H


### PR DESCRIPTION
Needs testing.
Closes #125 .

Incorporates the following feedback:

> Cory [Tokisan] — Regarding your channel packing panel, @Lorenz is creating a [tools menu](https://github.com/TokisanGames/Terrain3D/issues/81). Once that's done you can add a menu option that will open up a panel for your channel packer. 
> 
> It should provide filename fields with a directory button that opens up the godot file selector so they can pick their maps, and specify the output file name with little typing. Texture files rarely have the same naming convention. They could have tags like _albedo, _alb, _basecolor, _bc, _diffuse, _diff or hyphens or no tag at all, or have the resolution at the end.
> 
> Other tools will be in Windows. This could open a popup window. If you go with a dock, it will be inconsistent with other tools, but it will mean people can drag and drop files into the file slots. 🤔  I think a popup window is better. We'll likely integrate all tools into a single window in the future, and with the directory buttons they can easily click to their files. 
> 
> Only exporting PNG is fine. 
> 
> You should provide enough fields for all 4 files to be processed into 2 output files at once. But also work if they only fill in one set.

![image](https://github.com/TokisanGames/Terrain3D/assets/7350617/92e6752a-4496-4d83-8096-8489bc644970)
![image](https://github.com/TokisanGames/Terrain3D/assets/7350617/8b4e4e54-86cd-405c-8d56-a3579cdb4129)
