### PR TITLE
Add texture filtering option to terrain material

### DIFF
--- a/src/shaders/main.glsl
+++ b/src/shaders/main.glsl
@@ -29,8 +29,8 @@ uniform vec2 _region_offsets[256];
 uniform sampler2DArray _height_maps : repeat_disable;
 uniform usampler2DArray _control_maps : repeat_disable;
 uniform sampler2DArray _color_maps : source_color, repeat_disable;
-uniform sampler2DArray _texture_array_albedo : source_color, filter_linear_mipmap_anisotropic, repeat_enable;
-uniform sampler2DArray _texture_array_normal : hint_normal, filter_linear_mipmap_anisotropic, repeat_enable;
+//INSERT: TEXTURE_SAMPLERS_NEAREST
+//INSERT: TEXTURE_SAMPLERS_LINEAR
 uniform float _texture_uv_scale_array[32];
 uniform float _texture_uv_rotation_array[32];
 uniform vec4 _texture_color_array[32];

--- a/src/shaders/uniforms.glsl
+++ b/src/shaders/uniforms.glsl
@@ -1,0 +1,13 @@
+// Copyright © 2023 Cory Petkovsek, Roope Palmroos, and Contributors.
+
+R"(
+
+//INSERT: TEXTURE_SAMPLERS_LINEAR
+uniform sampler2DArray _texture_array_albedo : source_color, filter_linear_mipmap_anisotropic, repeat_enable;
+uniform sampler2DArray _texture_array_normal : hint_normal, filter_linear_mipmap_anisotropic, repeat_enable;
+
+//INSERT: TEXTURE_SAMPLERS_NEAREST
+uniform sampler2DArray _texture_array_albedo : source_color, filter_nearest_mipmap_anisotropic, repeat_enable;
+uniform sampler2DArray _texture_array_normal : hint_normal, filter_nearest_mipmap_anisotropic, repeat_enable;
+
+)"

--- a/src/terrain_3d_material.cpp
+++ b/src/terrain_3d_material.cpp
@@ -16,6 +16,11 @@
 
 void Terrain3DMaterial::_preload_shaders() {
 	// Preprocessor loading of external shader inserts
+
+	_parse_shader(
+#include "shaders/uniforms.glsl"
+			, "uniforms");
+
 	_parse_shader(
 #include "shaders/world_noise.glsl"
 			, "world_noise");
@@ -94,6 +99,11 @@ String Terrain3DMaterial::_generate_shader_code() {
 	if (!_world_noise_enabled) {
 		excludes.push_back("WORLD_NOISE1");
 		excludes.push_back("WORLD_NOISE2");
+	}
+	if (_texture_filtering == LINEAR) {
+		excludes.push_back("TEXTURE_SAMPLERS_NEAREST");
+	} else {
+		excludes.push_back("TEXTURE_SAMPLERS_LINEAR");
 	}
 	if (!_debug_view_checkered) {
 		excludes.push_back("DEBUG_CHECKERED");
@@ -428,6 +438,12 @@ void Terrain3DMaterial::set_world_noise_enabled(bool p_enabled) {
 	_update_shader();
 }
 
+void Terrain3DMaterial::set_texture_filtering(TextureFiltering p_filtering) {
+	LOG(INFO, "Setting texture filtering: ", p_filtering);
+	_texture_filtering = p_filtering;
+	_update_shader();
+}
+
 void Terrain3DMaterial::set_show_checkered(bool p_enabled) {
 	LOG(INFO, "Enable set_show_checkered: ", p_enabled);
 	_debug_view_checkered = p_enabled;
@@ -629,6 +645,9 @@ bool Terrain3DMaterial::_get(const StringName &p_name, Variant &r_property) cons
 }
 
 void Terrain3DMaterial::_bind_methods() {
+	BIND_ENUM_CONSTANT(LINEAR);
+	BIND_ENUM_CONSTANT(NEAREST);
+
 	// Private, but Public workaround until callable_mp is implemented
 	// https://github.com/godotengine/godot-cpp/pull/1155
 	ClassDB::bind_method(D_METHOD("_update_regions", "args"), &Terrain3DMaterial::_update_regions);
@@ -657,6 +676,9 @@ void Terrain3DMaterial::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("set_world_noise_enabled", "enabled"), &Terrain3DMaterial::set_world_noise_enabled);
 	ClassDB::bind_method(D_METHOD("get_world_noise_enabled"), &Terrain3DMaterial::get_world_noise_enabled);
 
+	ClassDB::bind_method(D_METHOD("set_texture_filtering", "filtering"), &Terrain3DMaterial::set_texture_filtering);
+	ClassDB::bind_method(D_METHOD("get_texture_filtering"), &Terrain3DMaterial::get_texture_filtering);
+
 	ClassDB::bind_method(D_METHOD("set_show_checkered", "enabled"), &Terrain3DMaterial::set_show_checkered);
 	ClassDB::bind_method(D_METHOD("get_show_checkered"), &Terrain3DMaterial::get_show_checkered);
 	ClassDB::bind_method(D_METHOD("set_show_grey", "enabled"), &Terrain3DMaterial::set_show_grey);
@@ -681,6 +703,7 @@ void Terrain3DMaterial::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("get_show_vertex_grid"), &Terrain3DMaterial::get_show_vertex_grid);
 
 	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "world_noise_enabled", PROPERTY_HINT_NONE), "set_world_noise_enabled", "get_world_noise_enabled");
+	ADD_PROPERTY(PropertyInfo(Variant::INT, "texture_filtering", PROPERTY_HINT_ENUM, "Linear,Nearest"), "set_texture_filtering", "get_texture_filtering");
 	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "shader_override_enabled", PROPERTY_HINT_NONE), "enable_shader_override", "is_shader_override_enabled");
 	ADD_PROPERTY(PropertyInfo(Variant::OBJECT, "shader_override", PROPERTY_HINT_RESOURCE_TYPE, "Shader"), "set_shader_override", "get_shader_override");
 

--- a/src/terrain_3d_material.h
+++ b/src/terrain_3d_material.h
@@ -16,6 +16,11 @@ public:
 	// Constants
 	static inline const char *__class__ = "Terrain3DMaterial";
 
+	enum TextureFiltering {
+		LINEAR,
+		NEAREST,
+	};
+
 private:
 	bool _initialized = false;
 	RID _material;
@@ -25,6 +30,8 @@ private:
 	Dictionary _shader_code;
 	mutable TypedArray<StringName> _active_params;
 	mutable Dictionary _shader_params;
+
+	TextureFiltering _texture_filtering = LINEAR;
 
 	// Built in alternate shaders
 	bool _world_noise_enabled = false;
@@ -82,6 +89,9 @@ public:
 	void set_world_noise_enabled(bool p_enabled);
 	bool get_world_noise_enabled() const { return _world_noise_enabled; }
 
+	void set_texture_filtering(TextureFiltering p_filtering);
+	TextureFiltering get_texture_filtering() const { return _texture_filtering; }
+
 	void set_show_checkered(bool p_enabled);
 	bool get_show_checkered() const { return _debug_view_checkered; }
 	void set_show_grey(bool p_enabled);
@@ -114,5 +124,7 @@ protected:
 
 	static void _bind_methods();
 };
+
+VARIANT_ENUM_CAST(Terrain3DMaterial::TextureFiltering);
 
 #endif // TERRAIN3D_MATERIAL_CLASS_H


### PR DESCRIPTION
![image](https://github.com/TokisanGames/Terrain3D/assets/5546400/c99917e8-f107-411c-bf5b-264cc7f904de)

I added the option to change the texture filtering mode the shader uses from the TerrainMaterial3D. This allows me to have the sharp pixelated look without having to implement my own shader.

Here's what the options look like:

LINEAR - uses linear_mipmap_anisotropic
![image](https://github.com/TokisanGames/Terrain3D/assets/5546400/edb1aaf7-21d4-4496-85ea-cb63b2cb3031)

NEAREST - uses nearest_mipmap_anisotropic
![image](https://github.com/TokisanGames/Terrain3D/assets/5546400/277f2f8a-4b81-4432-bb39-2c9131cda158)
