### PR TITLE
Noise texture sampler filter now matches the albedo and normal filter setting

### DIFF
--- a/src/shaders/main.glsl
+++ b/src/shaders/main.glsl
@@ -43,7 +43,6 @@ uniform float blend_sharpness : hint_range(0, 1) = 0.87;
 //INSERT: AUTO_SHADER_UNIFORMS
 //INSERT: DUAL_SCALING_UNIFORMS
 uniform float noise_scale : hint_range(0, 0.5) = 0.1;
-uniform sampler2D noise_texture : source_color, filter_linear, repeat_enable;
 
 // Varyings & Types
 

--- a/src/shaders/uniforms.glsl
+++ b/src/shaders/uniforms.glsl
@@ -5,9 +5,11 @@ R"(
 //INSERT: TEXTURE_SAMPLERS_LINEAR
 uniform sampler2DArray _texture_array_albedo : source_color, filter_linear_mipmap_anisotropic, repeat_enable;
 uniform sampler2DArray _texture_array_normal : hint_normal, filter_linear_mipmap_anisotropic, repeat_enable;
+uniform sampler2D noise_texture : source_color, filter_linear, repeat_enable;
 
 //INSERT: TEXTURE_SAMPLERS_NEAREST
 uniform sampler2DArray _texture_array_albedo : source_color, filter_nearest_mipmap_anisotropic, repeat_enable;
 uniform sampler2DArray _texture_array_normal : hint_normal, filter_nearest_mipmap_anisotropic, repeat_enable;
+uniform sampler2D noise_texture : source_color, filter_nearest, repeat_enable;
 
 )"


### PR DESCRIPTION
A bit of a follow up to my previous PR: https://github.com/TokisanGames/Terrain3D/pull/265

I made it so the noise texture sampler follows the same texture filtering setting as the albedo and normal.

Here is what it looks like with the Texture Filtering option set to Nearest now
![image](https://github.com/TokisanGames/Terrain3D/assets/5546400/b84d29b5-7bdf-4404-a6d7-aa15db9f8bcf)

I thought about adding a noise texture filtering option to TerrainMaterial3D but I can't think of a use case where someone would want smooth textures and sharp noise or vice versa.