### PR TITLE
Baker improvements

### DIFF
--- a/project/addons/terrain_3d/editor/components/baker.gd
+++ b/project/addons/terrain_3d/editor/components/baker.gd
@@ -215,7 +215,7 @@ func _postprocess_nav_mesh_round_vertices(p_nav_mesh: NavigationMesh) -> PackedV
 	
 	var vertices: PackedVector3Array = p_nav_mesh.get_vertices()
 	for i in range(vertices.size()):
-		vertices[i] = (vertices[i] / round_factor).floor() * round_factor
+		vertices[i] = (vertices[i] / round_factor).round() * round_factor
 	return vertices
 
 


### PR DESCRIPTION
A couple of little improvements to nav mesh / occluder / mesh baking:

- Navmesh vertex positions get rounded instead of floored, which keeps it from z-fighting with terrain and looking like it has holes. I've tested this on all the meshes I have on hand and it doesn't reintroduce any of the previous errors.
- Baking occluders and meshes reuses existing nodes, instead of creating new MeshInstance3D/OccluderInstance3D every time.