### PR TITLE
Make sure occlusion meshes contain holes where there are holes in terrain

### DIFF
--- a/src/terrain_3d.cpp
+++ b/src/terrain_3d.cpp
@@ -516,11 +516,11 @@ void Terrain3D::_generate_triangle_pair(PackedVector3Array &p_vertices, PackedVe
 	uint32_t control1 = _storage->get_control(Vector3(x, 0.0, z));
 	uint32_t control2 = _storage->get_control(Vector3(x + step, 0.0, z + step));
 	uint32_t control3 = _storage->get_control(Vector3(x, 0.0, z + step));
-	if (!Util::is_hole(control1) && !Util::is_hole(control2) && !Util::is_hole(control3)) {
-		if (!p_require_nav || (Util::is_nav(control1) && Util::is_nav(control2) && Util::is_nav(control3))) {
-			Vector3 v1 = _storage->get_mesh_vertex(p_lod, p_filter, Vector3(x, 0.0, z));
-			Vector3 v2 = _storage->get_mesh_vertex(p_lod, p_filter, Vector3(x + step, 0.0, z + step));
-			Vector3 v3 = _storage->get_mesh_vertex(p_lod, p_filter, Vector3(x, 0.0, z + step));
+	if (!p_require_nav || (Util::is_nav(control1) && Util::is_nav(control2) && Util::is_nav(control3))) {
+		Vector3 v1 = _storage->get_mesh_vertex(p_lod, p_filter, Vector3(x, 0.0, z));
+		Vector3 v2 = _storage->get_mesh_vertex(p_lod, p_filter, Vector3(x + step, 0.0, z + step));
+		Vector3 v3 = _storage->get_mesh_vertex(p_lod, p_filter, Vector3(x, 0.0, z + step));
+		if (!UtilityFunctions::is_nan(v1.y) && !UtilityFunctions::is_nan(v2.y) && !UtilityFunctions::is_nan(v3.y)) {
 			p_vertices.push_back(v1);
 			p_vertices.push_back(v2);
 			p_vertices.push_back(v3);
@@ -535,11 +535,11 @@ void Terrain3D::_generate_triangle_pair(PackedVector3Array &p_vertices, PackedVe
 	control1 = _storage->get_control(Vector3(x, 0.0, z));
 	control2 = _storage->get_control(Vector3(x + step, 0.0, z));
 	control3 = _storage->get_control(Vector3(x + step, 0.0, z + step));
-	if (!Util::is_hole(control1) && !Util::is_hole(control2) && !Util::is_hole(control3)) {
-		if (!p_require_nav || (Util::is_nav(control1) && Util::is_nav(control2) && Util::is_nav(control3))) {
-			Vector3 v1 = _storage->get_mesh_vertex(p_lod, p_filter, Vector3(x, 0.0, z));
-			Vector3 v2 = _storage->get_mesh_vertex(p_lod, p_filter, Vector3(x + step, 0.0, z));
-			Vector3 v3 = _storage->get_mesh_vertex(p_lod, p_filter, Vector3(x + step, 0.0, z + step));
+	if (!p_require_nav || (Util::is_nav(control1) && Util::is_nav(control2) && Util::is_nav(control3))) {
+		Vector3 v1 = _storage->get_mesh_vertex(p_lod, p_filter, Vector3(x, 0.0, z));
+		Vector3 v2 = _storage->get_mesh_vertex(p_lod, p_filter, Vector3(x + step, 0.0, z));
+		Vector3 v3 = _storage->get_mesh_vertex(p_lod, p_filter, Vector3(x + step, 0.0, z + step));
+		if (!UtilityFunctions::is_nan(v1.y) && !UtilityFunctions::is_nan(v2.y) && !UtilityFunctions::is_nan(v3.y)) {
 			p_vertices.push_back(v1);
 			p_vertices.push_back(v2);
 			p_vertices.push_back(v3);


### PR DESCRIPTION
Fixes #301.

Previously, the occlusion mesh baker would only leave a hole where one or more of the vertices of a triangle was directly over a hole. This meant if there was a hole that fit inside a triangle, or just didn't touch any vertices, the baker would fill the hole. This is possible because occlusion meshes are generally baked at a lower LOD.

With the changes in this PR, the occlusion baker checks every nearby position it samples the heights of for holes, and creates a hole if any of them have holes.

This doesn't change the ArrayMesh baker. The left hole in the example shown in #301 still gets filled by the ArrayMesh baker, but this is (IMO) an acceptable loss of detail that doesn't cause correctness issues.