### PR TITLE
Move terrain_edited signal to Terrain3DStorage.maps_edited

### DIFF
--- a/doc/classes/Terrain3DEditor.xml
+++ b/doc/classes/Terrain3DEditor.xml
@@ -18,11 +18,6 @@
 			<description>
 			</description>
 		</method>
-		<method name="get_singleton" qualifiers="static">
-			<return type="Terrain3DEditor" />
-			<description>
-			</description>
-		</method>
 		<method name="get_terrain">
 			<return type="Terrain3D" />
 			<description>
@@ -76,19 +71,6 @@
 			</description>
 		</method>
 	</methods>
-	<signals>
-		<signal name="terrain_edited">
-			<param index="0" name="edited_area" type="AABB" />
-			<description>
-				This signal is emitted whenever the editor is used to:
-				- add or remove a region,
-				- alter a region map with a brush tool,
-				- undo or redo any of the above operations.
-
-				The parameter contains the axis-aligned bounding box of the area edited.
-			</description>
-		</signal>
-	</signals>
 	<constants>
 		<constant name="ADD" value="0" enum="Operation">
 		</constant>

--- a/doc/classes/Terrain3DStorage.xml
+++ b/doc/classes/Terrain3DStorage.xml
@@ -260,6 +260,17 @@
 			<description>
 			</description>
 		</signal>
+		<signal name="maps_edited">
+			<param index="0" name="edited_area" type="AABB" />
+			<description>
+				This signal is emitted whenever the editor is used to:
+				- add or remove a region,
+				- alter a region map with a brush tool,
+				- undo or redo any of the above operations.
+
+				The parameter contains the axis-aligned bounding box of the area edited.
+			</description>
+		</signal>
 	</signals>
 	<constants>
 		<constant name="TYPE_HEIGHT" value="0" enum="MapType">

--- a/project/addons/terrain_3d/editor/editor.gd
+++ b/project/addons/terrain_3d/editor/editor.gd
@@ -23,7 +23,7 @@ var mouse_global_position: Vector3 = Vector3.ZERO
 
 
 func _enter_tree() -> void:
-	editor = Terrain3DEditor.get_singleton()
+	editor = Terrain3DEditor.new()
 	ui = UI.new()
 	ui.plugin = self
 	add_child(ui)
@@ -44,7 +44,7 @@ func _exit_tree() -> void:
 	remove_control_from_container(texture_dock_container, texture_dock)
 	texture_dock.queue_free()
 	ui.queue_free()
-	editor = null
+	editor.free()
 
 	
 func _handles(p_object: Object) -> bool:

--- a/src/register_types.cpp
+++ b/src/register_types.cpp
@@ -23,16 +23,12 @@ void initialize_terrain_3d(ModuleInitializationLevel p_level) {
 	ClassDB::register_class<Terrain3DTexture>();
 	ClassDB::register_class<Terrain3DTextureList>();
 	ClassDB::register_class<Terrain3DEditor>();
-
-	Terrain3DEditor::create();
 }
 
 void uninitialize_terrain_3d(ModuleInitializationLevel p_level) {
 	if (p_level != MODULE_INITIALIZATION_LEVEL_SCENE) {
 		return;
 	}
-
-	Terrain3DEditor::free();
 }
 
 extern "C" {

--- a/src/terrain_3d_editor.h
+++ b/src/terrain_3d_editor.h
@@ -132,23 +132,9 @@ private:
 	void _store_undo();
 	void _apply_undo(const Array &p_set);
 
-	// Singleton
-	friend void initialize_terrain_3d(ModuleInitializationLevel p_level);
-	friend void uninitialize_terrain_3d(ModuleInitializationLevel p_level);
-
-	static Terrain3DEditor *_singleton;
-
-	static void create() { _singleton = memnew(Terrain3DEditor); }
-	static void free() {
-		memdelete(_singleton);
-		_singleton = nullptr;
-	}
-
+public:
 	Terrain3DEditor();
 	~Terrain3DEditor();
-
-public:
-	static Terrain3DEditor *get_singleton() { return _singleton; }
 
 	void set_terrain(Terrain3D *p_terrain) { _terrain = p_terrain; }
 	Terrain3D *get_terrain() const { return _terrain; }

--- a/src/terrain_3d_storage.cpp
+++ b/src/terrain_3d_storage.cpp
@@ -82,6 +82,20 @@ void Terrain3DStorage::update_height_range() {
 	LOG(INFO, "Updated terrain height range: ", _height_range);
 }
 
+void Terrain3DStorage::clear_edited_area() {
+	_edited_area = AABB();
+}
+
+void Terrain3DStorage::add_edited_area(AABB p_area) {
+	if (_edited_area.has_surface()) {
+		_edited_area = _edited_area.merge(p_area);
+	} else {
+		_edited_area = p_area;
+	}
+	emit_signal("maps_edited", p_area);
+}
+
+
 void Terrain3DStorage::set_region_size(RegionSize p_size) {
 	LOG(INFO, p_size);
 	//ERR_FAIL_COND(p_size < SIZE_64);
@@ -1076,4 +1090,5 @@ void Terrain3DStorage::_bind_methods() {
 	ADD_SIGNAL(MethodInfo("height_maps_changed"));
 	ADD_SIGNAL(MethodInfo("region_size_changed"));
 	ADD_SIGNAL(MethodInfo("regions_changed"));
+	ADD_SIGNAL(MethodInfo("maps_edited", PropertyInfo(Variant::AABB, "edited_area")));
 }

--- a/src/terrain_3d_storage.h
+++ b/src/terrain_3d_storage.h
@@ -76,6 +76,7 @@ private:
 
 	// Stored Data
 	Vector2 _height_range = Vector2(0, 0);
+	AABB _edited_area;
 
 	/**
 	 * These arrays house all of the map data.
@@ -113,6 +114,10 @@ public:
 	void update_heights(real_t p_height);
 	void update_heights(Vector2 p_heights);
 	void update_height_range();
+
+	void clear_edited_area();
+	void add_edited_area(AABB p_area);
+	AABB get_edited_area() const { return _edited_area; }
 
 	// Regions
 	void set_region_size(RegionSize p_size);


### PR DESCRIPTION
As discussed in #270. I've done this so that Terrain3DEditor can be made not a singleton.