### PR TITLE
Improve mouse cursor location

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -86,13 +86,43 @@ Other formatting:
 
 ## Documentation
 
-### User Manual
-The usage documentation lives in [doc/docs](https://github.com/TokisanGames/Terrain3D/tree/main/doc/docs) and is written in Markdown. Images are stored in images and videos are stored [_static/video](https://github.com/TokisanGames/Terrain3D/tree/main/doc/_static/video). 
+All PRs that include new methods and features or changed functionality should include documentation updates. This could be in the form of a tutorial page for the user manual, or API changes to the XML Class Reference.
 
-Man pages need to also be included in doc/index.rst. Readthedocs should then be able to find everything and build it upon a commit.
+### User Manual
+
+Tutorials and usage documentation lives in [doc/docs](https://github.com/TokisanGames/Terrain3D/tree/main/doc/docs) and is written in Markdown (*.md). Images are stored in `images` and videos are stored [_static/video](https://github.com/TokisanGames/Terrain3D/tree/main/doc/_static/video). 
+
+Pages also need to be included in the table of contents `doc/index.rst`. Readthedocs will then be able to find everything it needs to build the html documentation upon a commit.
 
 ### Class Reference
-Godot's doc-tool is used to extract or update the class reference in [XML files](https://github.com/TokisanGames/Terrain3D/tree/main/doc/classes). These files are edited for class documentation. Then `build_docs.sh` can be used to generate the API rst files and the html files.
+
+The class reference documentation that contributors edit is stored in [XML files](https://github.com/TokisanGames/Terrain3D/tree/main/doc/classes). These files are used as the source for generated documentation.
 
 Edit the class reference according to the [Godot class reference primer](https://docs.godotengine.org/en/stable/contributing/documentation/class_reference_primer.html#doc-class-reference-primer).
+
+Godot's doc-tool is used to extract or update the class structure from the compiled addon. See below for instructions.
+
+### Using the Documentation Tools
+
+This step isn't required for contributors. You may ask for help generating the XML class structure so you can edit it, or generating the resulting RST files. 
+
+#### To setup your system
+
+1. Use a bash shell available in linux, [gitforwindows](https://gitforwindows.org), or [Microsoft's WSL](https://learn.microsoft.com/en-us/windows/wsl/install).
+2. Install the following modules using python's pip: `pip install docutils myst-parser sphinx sphinx-rtd-theme sphinx-rtd-dark-mode`.
+3. Edit `doc/build_docs.sh` and adjust the paths to your Godot executable and `make_rst.py`, found in the Godot repository.
+
+#### To edit the documentation
+
+1. Build Terrain3D with your updated code.
+2. Within the `doc` folder, run `./build_docs.sh`. The following will occur:
+  - The Godot executable dumps the XML structure for all classes, including those of installed addons.
+  - Any existing XML files (eg Terrain3D*) will be updated with the new structure, leaving prior written documentation.
+  - Sphinx RST files are generated from the XML files.
+  - All non-Terrain3D XML files are removed.
+  - A local html copy of the docs are generated from the Markdown and RST files, and a browser is open to view them.
+3. Fill in the XML files with documentation of the new generated structure and make any other changes to the Markdown files.
+4. Run the script again to update the RST files. This isn't necessary for Markdown updates, except to view the changes locally.
+5. Push your updates to the Markdown, XML, and RST files to the repository. Due to the nature of generation scripts, carefully review the changes so you only push those you intend.
+6. Readthedocs will detect commits to the main tree and will build the online html docs from the Markdown and RST files.
 

--- a/SConstruct
+++ b/SConstruct
@@ -49,4 +49,21 @@ else:
         source=sources,
     )
 
+## Option to use C++20 for this extension by replacing CXXFLAGS
+#if env.get("is_msvc", False):
+#    env.Replace(CXXFLAGS=["/std:c++20"])
+#else:
+#    env.Replace(CXXFLAGS=["-std=c++20"])
+
+## Reenable CXXFLAGS removed by the above from godot-cpp/tools/godotcpp.py
+# Disable exception handling. Godot doesn't use exceptions anywhere, and this
+# saves around 20% of binary size and very significant build time.
+#if env["disable_exceptions"]:
+#    if env.get("is_msvc", False):
+#        env.Append(CPPDEFINES=[("_HAS_EXCEPTIONS", 0)])
+#    else:
+#        env.Append(CXXFLAGS=["-fno-exceptions"])
+#elif env.get("is_msvc", False):
+#    env.Append(CXXFLAGS=["/EHsc"])
+
 Default(library)

--- a/Terrain3D.vcxproj
+++ b/Terrain3D.vcxproj
@@ -178,6 +178,7 @@
     <None Include="AUTHORS.md" />
     <None Include="CONTRIBUTING.md" />
     <None Include="doc\conf.py" />
+    <None Include="doc\docs\double_precision.md" />
     <None Include="doc\docs\mobile_web.md" />
     <None Include="doc\docs\nightly_builds.md" />
     <None Include="doc\docs\press.md" />

--- a/Terrain3D.vcxproj
+++ b/Terrain3D.vcxproj
@@ -217,6 +217,7 @@
     <Text Include="doc\_static\theme_overrides.css" />
     <Text Include="LICENSE.txt" />
     <Text Include="doc\docs\navigation.md" />
+    <Text Include="src\shaders\gpu_depth.glsl" />
   </ItemGroup>
   <ItemGroup>
     <Xml Include="doc\classes\Terrain3D.xml" />

--- a/Terrain3D.vcxproj.filters
+++ b/Terrain3D.vcxproj.filters
@@ -181,6 +181,9 @@
     <None Include="doc\docs\nightly_builds.md">
       <Filter>2. Docs</Filter>
     </None>
+    <None Include="doc\docs\double_precision.md">
+      <Filter>2. Docs</Filter>
+    </None>
   </ItemGroup>
   <ItemGroup>
     <Text Include=".readthedocs.yaml">

--- a/Terrain3D.vcxproj.filters
+++ b/Terrain3D.vcxproj.filters
@@ -246,6 +246,9 @@
     <Text Include="doc\docs\tutorial_videos.md">
       <Filter>2. Docs</Filter>
     </Text>
+    <Text Include="src\shaders\gpu_depth.glsl">
+      <Filter>3. Shaders</Filter>
+    </Text>
   </ItemGroup>
   <ItemGroup>
     <Xml Include="doc\classes\Terrain3D.xml">

--- a/doc/api/class_terrain3dstorage.rst
+++ b/doc/api/class_terrain3dstorage.rst
@@ -462,7 +462,17 @@ Method Descriptions
 
 godot.Error **add_region** **(** :ref:`Vector3<class_Vector3>` global_position, :ref:`Image[]<class_Image>` images=[], :ref:`bool<class_bool>` update=true **)**
 
-Adds a region for sculpting and painting. This allocates new :ref:`region_size<class_Terrain3DStorage_property_region_size>` sized textures in memory and on disk to store sculpting and texture painting data.
+Adds a region for sculpting and painting. This allocates new set of :ref:`region_size<class_Terrain3DStorage_property_region_size>` sized image maps in memory and on disk to store sculpting and texture painting data.
+
+If the region already exists and image maps are included, the current maps will be overwritten. This means that if some maps are null, existing maps will be removed.
+
+Parameters:
+
+-	p_global_position - the world location to place the region, which gets rounded down to the nearest region_size multiple. That means adding a region at (1500, 0, 1500) is the same as adding it at (1024, 0, 1024) when region_size is 1024.
+
+-	p_images - Optional array of { Height, Control, Color } with region_sized images. See :ref:`MapType<enum_Terrain3DStorage_MapType>`.
+
+-	p_update - rebuild the maps if true. Set to false if bulk adding many regions, then true on the last one or use :ref:`force_update_maps<class_Terrain3DStorage_method_force_update_maps>`.
 
 .. rst-class:: classref-item-separator
 

--- a/doc/api/class_terrain3dtexture.rst
+++ b/doc/api/class_terrain3dtexture.rst
@@ -201,7 +201,7 @@ The user settable ID of the texture, between 0 and 31. You can change this to re
 - void **set_uv_rotation** **(** :ref:`float<class_float>` value **)**
 - :ref:`float<class_float>` **get_uv_rotation** **(** **)**
 
-The shader rotates UV lookups in a detiling pattern based on this value. However, it does not work well and is not recommended at this time.
+The shader rotates UV lookups in a detiling pattern based on this value.
 
 .. rst-class:: classref-item-separator
 

--- a/doc/classes/Terrain3D.xml
+++ b/doc/classes/Terrain3D.xml
@@ -4,7 +4,7 @@
 	</brief_description>
 	<description>
 		Terrain3D is a high performance, editable terrain system for Godot 4. It provides a clipmap based terrain that supports up to 16k terrains with multiple LODs, 32 textures, and editor tools for importing or creating terrains.
-    This class handles mesh and collision generation, and management of the whole system. See [url=../docs/system_architecture.html]System Architecture[/url] for design details.
+		This class handles mesh and collision generation, and management of the whole system. See [url=../docs/system_architecture.html]System Architecture[/url] for design details.
 	</description>
 	<tutorials>
 	</tutorials>
@@ -43,7 +43,7 @@
 			<param index="3" name="format" type="int" enum="Image.Format" />
 			<description>
 				A utility function that returns an Image filled with a specified color and format.
-				        If [code]color.a &lt; 0[/code], its filled with a checkered pattern multiplied by [code]color.rgb[/code].
+				If [code]color.a &lt; 0[/code], its filled with a checkered pattern multiplied by [code]color.rgb[/code].
 				The behavior changes if a compressed format is requested:
 				- If the editor is running and the format is DXT1, DXT5, or BPTC_RGBA, it returns a filled image in the requested color and format.
 				- All other compressed formats return a blank image in that format.
@@ -52,10 +52,17 @@
 		</method>
 		<method name="get_intersection">
 			<return type="Vector3" />
-			<param index="0" name="position" type="Vector3" />
+			<param index="0" name="src_pos" type="Vector3" />
 			<param index="1" name="direction" type="Vector3" />
 			<description>
-				Returns the terrain intersection point that a given camera position and direction is looking at. Currently this works out to a maximum of about 3000 units. It returns [code]&gt;3.4e38[/code] (max float value) if there is no hit.
+				Casts a ray from [code]src_pos[/code] pointing towards [code]direction[/code], attempting to intersect the terrain.
+				Possible return values:
+				- If the terrain is hit, the intersection point is returned.
+				- If there is no intersection, eg. the ray points towards the sky, it returns the maximum double float value [code]Vector3(3.402823466e+38F,...)[/code]. You can check this case with this code: [code]if point.z &gt; 3.4e38:[/code]
+				- On error, it returns [code]Vector3(NAN, NAN, NAN)[/code] and prints a message to the console.
+				This ray cast does not use physics, so enabling collision is unnecessary. It places a camera at the specified point and "looks" at the terrain. It then uses the renderer's depth texture to determine how far away the intersection point is.
+				This function is used by the editor plugin to place the mouse cursor. It can also be used by 3rd party plugins, and even during gameplay, such as a space ship firing lasers at the terrain and causing an explosion at the hit point.
+				It does require the use of an editor render layer (21-32) that should be dedicated while using this function. See [member render_mouse_layer].
 			</description>
 		</method>
 		<method name="get_min_max" qualifiers="static">
@@ -149,8 +156,14 @@
 		<member name="render_cull_margin" type="float" setter="set_cull_margin" getter="get_cull_margin" default="0.0">
 			This margin is added to the terrain bounding box (AABB). The terrain already sets its AABB, so this setting only needs to be used if the shader has expanded the terrain beyond the AABB and the terrain meshes are being culled, as might happen from using [member Terrain3DMaterial.world_background] with NOISE and a large height value. This sets [code]GeometryInstance3D.extra_cull_margin[/code] in the engine.
 		</member>
-		<member name="render_layers" type="int" setter="set_render_layers" getter="get_render_layers" default="1">
-			The render layers the terrain is drawn on. This sets [code]VisualInstance3D.layers[/code] in the engine.
+		<member name="render_layers" type="int" setter="set_render_layers" getter="get_render_layers" default="2147483649">
+			The render layers the terrain is drawn on. This sets [code]VisualInstance3D.layers[/code] in the engine. The defaults is layer 1 and 32 (for the mouse cursor). When you set this, make sure the layer for [member render_mouse_layer] is included, or set that variable again after this so that the mouse cursor works.
+		</member>
+		<member name="render_mouse_layer" type="int" setter="set_mouse_layer" getter="get_mouse_layer" default="32">
+			Godot supports 32 render layers. For most objects, only layers 1-20 are available for selection in the inspector. 21-32 are settable via code, and are considered reserved for editor plugins.
+			This variable sets the editor render layer (21-32) to be used by [code]get_intersection[/code], which the mouse cursor uses.
+			You may place other objects on this layer, however [code]get_intersection[/code] will report intersections with them. So either dedicate this layer to Terrain3D, or if you must use all 32 layers, dedicate this one during editing or when using [code]get_intersection[/code], and then you can use it during game play.
+			See [method get_intersection].
 		</member>
 		<member name="storage" type="Terrain3DStorage" setter="set_storage" getter="get_storage">
 			The object that houses all Terrain3D region, height, control, and color maps. Make sure to save this as an external [code].res[/code] binary file.

--- a/doc/classes/Terrain3DStorage.xml
+++ b/doc/classes/Terrain3DStorage.xml
@@ -14,7 +14,12 @@
 			<param index="1" name="images" type="Image[]" default="[]" />
 			<param index="2" name="update" type="bool" default="true" />
 			<description>
-				Adds a region for sculpting and painting. This allocates new [member region_size] sized textures in memory and on disk to store sculpting and texture painting data.
+				Adds a region for sculpting and painting. This allocates new set of [member region_size] sized image maps in memory and on disk to store sculpting and texture painting data.
+				If the region already exists and image maps are included, the current maps will be overwritten. This means that if some maps are null, existing maps will be removed.
+				Parameters:
+				-	p_global_position - the world location to place the region, which gets rounded down to the nearest region_size multiple. That means adding a region at (1500, 0, 1500) is the same as adding it at (1024, 0, 1024) when region_size is 1024.
+				-	p_images - Optional array of { Height, Control, Color } with region_sized images. See [enum MapType].
+				-	p_update - rebuild the maps if true. Set to false if bulk adding many regions, then true on the last one or use [method force_update_maps].
 			</description>
 		</method>
 		<method name="export_image">

--- a/doc/classes/Terrain3DTexture.xml
+++ b/doc/classes/Terrain3DTexture.xml
@@ -32,7 +32,7 @@
 			The user settable ID of the texture, between 0 and 31. You can change this to reorder textures in the list, however it won't change the ID painted on the terrain.
 		</member>
 		<member name="uv_rotation" type="float" setter="set_uv_rotation" getter="get_uv_rotation" default="0.0">
-			The shader rotates UV lookups in a detiling pattern based on this value. However, it does not work well and is not recommended at this time.
+			The shader rotates UV lookups in a detiling pattern based on this value.
 		</member>
 		<member name="uv_scale" type="float" setter="set_uv_scale" getter="get_uv_scale" default="0.1">
 			The scale of the textures.

--- a/doc/docs/building_from_source.md
+++ b/doc/docs/building_from_source.md
@@ -140,12 +140,15 @@ scons: done building targets.
 
 ## 6. Set up the extension in Godot
 
-* Close Godot. (Not required the first time, but necessary when updating the files on subsequent builds.)
-* Copy `project/addons/terrain_3d` to your own project folder as `/addons/terrain_3d`. 
-* Upon opening or switching back to Godot, it should prompt to restart. Do so.
-* To finalize resource importing and clear out error messages, it's best to reload the project a second time. 
-* Create or open a 3D scene and add a new Terrain3D node.
-* Select Terrain3D in the scene tree. In the inspector, click the down arrow to the right of the storage resource and save it as a binary .res file. This is optional, but highly recommended. Otherwise it will save terrain data as text in the current scene file. The other resources can be left as is or saved as text .tres. These external files can be shared with other scenes.
+1. Build Terrain3D, then ensure binary libraries exist in `project/addons/terrain_3d/bin`.
+2. Close Godot. (Not required the first time, but necessary when updating the files on subsequent builds.)
+3. Copy `project/addons/terrain_3d` to your own project folder as `/addons/terrain_3d`. 
+4. Run Godot, using the console executable so you can see error messages. Restart when it prompts.
+5. In `Project Settings / Plugins`, ensure that Terrain3D is enabled.
+6. Select `Project / Reload Current Project` to restart once more.
+7. Create or open a 3D scene and add a new Terrain3D node.
+8. Select Terrain3D in the Scene panel. In the Inspector, click the down arrow to the right of the `storage` resource and save it as a binary `.res` file. The other resources can be left as is or saved as text `.tres`. These external files can be shared with other scenes.
+9. Learn how to properly [set up your textures](texture_prep.md), or skip to [importing data](import_export.md).
 
 ## Other Build Options
 
@@ -180,6 +183,12 @@ This plugin supports Windows, Linux and macOS. We've received successful reports
 
 scons platform=linux
 ```
+
+### Using C++20
+The C++ standard used in Godot and Godot-cpp is C++17. However you may use C++20 for building GDExtensions if desired.
+
+The [SConstruct](https://github.com/TokisanGames/Terrain3D/blob/main/SConstruct) file has some commented code at the bottom that will replace update the standard.
+
 
 ### See all options
 ```

--- a/doc/docs/double_precision.md
+++ b/doc/docs/double_precision.md
@@ -1,0 +1,37 @@
+Double Precision
+=================
+
+Building Terrain3D with double precision (aka 64-bit) floats is possible, but there are some caveats.
+
+When the player and camera move 10s-100s of thousands, or millions of units away from the origin using a single precision float engine, things start to break down. Movements, positions, and rendering starts to become jittery or corrupted as the gradation between values gets larger and larger.
+
+Building with double precision floats allows the step between values to remains very small even at large numbers.
+
+For a more detailed explanation, see [Large World Coordinates](https://docs.godotengine.org/en/stable/tutorials/physics/large_world_coordinates.html) in the Godot documentation.
+
+
+## Caveats
+
+* This feature is experimental and has had only one user give a positive report so far.
+* There are many caveats listed in the link above. You should read them all before beginning this process.
+* You must build Godot and Terrain3D from source.
+* Terrain3D currently only supports a maximum world of 16k by 16k, or (+/-8192, +/-8192). You can have Terrain3D located around the origin, then have your own meshes or a shader generated terrain outside of that world. See [Support more region sizes #70](https://github.com/TokisanGames/Terrain3D/issues/77) for supporting worlds up to 90k per side and more.
+* Shaders do not support double precision. Clayjohn wrote an article demonstrating how to [Emulate Double Precision](https://godotengine.org/article/emulating-double-precision-gpu-render-large-worlds/) in shaders. He wrote that the camera and model transform matrices needed to be emulated to support double precision. This is now done automatically in the engine when building it with double precision. There may be other cases where shaders will need this emulation.
+
+
+## Setup
+
+One user reported success using Godot 4.2.1 and Terrain3D 0.9.1.
+
+To get Terrain3D and Godot working with double precision floats, you must:
+
+1. [Build Godot from source](https://docs.godotengine.org/en/latest/contributing/development/compiling/index.html) with `scons precision=double` along with your other parameters like target, platform, etc.
+2. [Generate custom godot-cpp bindings](https://docs.godotengine.org/en/latest/tutorials/scripting/gdextension/gdextension_cpp_example.html#building-the-c-bindings) using this new executable. This will generate a JSON file you will use in the next step.
+3. [Build Terrain3D from source](building_from_source.md) (which includes godot-cpp) using `scons precision=double custom_api_file=YOUR_CUSTOM_JSON_FILE`
+
+After that, you can run the double version of Godot with the double version of Terrain3D.
+
+
+## Further Reading
+
+See [Support Doubles #30](https://github.com/TokisanGames/Terrain3D/issues/30) for our Issue that documents implementing support for doubles in Terrain3D.

--- a/doc/docs/installation.md
+++ b/doc/docs/installation.md
@@ -19,11 +19,11 @@ If it isn't working for you, watch the [tutorial videos](tutorial_videos.md) and
 1. Download the [latest release](https://github.com/TokisanGames/Terrain3D/releases) and extract the files, or [build the plugin from source](building_from_source.md).
 2. Copy `addons/terrain_3d` to your project folder as `addons/terrain_3d`.
 3. Run Godot, using the console executable so you can see error messages. Restart when it prompts.
-6. In `Project Settings / Plugins`, ensure that Terrain3D is enabled.
-7. Select `Project / Reload Current Project` to restart once more.
-8. Create or open a 3D scene and add a new Terrain3D node.
-9. Select Terrain3D in the Scene panel. In the Inspector, click the down arrow to the right of the `storage` resource and save it as a binary `.res` file. The other resources can be left as is or saved as text `.tres`. These external files can be shared with other scenes.
-10. Click Next to learn how to properly [set up your textures](texture_prep.md), or skip to [import data](import_export.md).
+4. In `Project Settings / Plugins`, ensure that Terrain3D is enabled.
+5. Select `Project / Reload Current Project` to restart once more.
+6. Create or open a 3D scene and add a new Terrain3D node.
+7. Select Terrain3D in the Scene panel. In the Inspector, click the down arrow to the right of the `storage` resource and save it as a binary `.res` file. The other resources can be left as is or saved as text `.tres`. These external files can be shared with other scenes.
+8. Click Next to learn how to properly [set up your textures](texture_prep.md), or skip to [import data](import_export.md).
 
 If it isn't working for you, watch the [tutorial videos](tutorial_videos.md) and read [Troubleshooting](troubleshooting.md) and [Getting Help](getting_help.md).
 

--- a/doc/docs/project_status.md
+++ b/doc/docs/project_status.md
@@ -13,12 +13,12 @@ See the [Roadmap](https://github.com/users/TokisanGames/projects/3/views/1) for 
 | **Editing** |
 | Sculpting Operations | Raise, Lower, Flatten, Expand (Multiply away from 0), Reduce (Divide towards 0), Slope and Smooth. It can be improved over time.
 | Painting Operations | Texture, Color, Wetness (roughness) with Height blending.
-| GPU Sculpting| [Pending](https://github.com/TokisanGames/Terrain3D/issues/174). Currently painting occurs on the CPU in C++. It's reasonably fast, but we limit the brush size to 200 as larger lags too much.
+| GPU Sculpting| [Pending](https://github.com/TokisanGames/Terrain3D/issues/174). Currently painting occurs on the CPU in C++. It's reasonably fast, but we have a soft limit of 200 on the brush size, as larger sizes lag.
 | Advanced texturing| [Pending](https://github.com/TokisanGames/Terrain3D/discussions/64) and [this](https://github.com/TokisanGames/Terrain3D/discussions/4). eg. Paintable uv scale / slope / rotation, 2-layer texture blending, 3D projection. We intend to implement all of these and adopt techniques provided by The Witcher 3 team. (See [System Architecture](system_architecture.md))
 | **Environment** |
-| Foliage | [Pending](https://github.com/TokisanGames/Terrain3D/issues/43). Non-collision based, paintable meshes (rocks, grass) will likely be added as a particle shader. Alternatives are [Scatter](https://github.com/HungryProton/scatter) once he has his particle shader working, your own particle shader, [Simple Grass Painter](https://godotengine.org/asset-library/asset/1623) (add as a child and enable debug collision) or [MultiMeshInstance3D](https://docs.godotengine.org/en/stable/tutorials/3d/using_multi_mesh_instance.html)
+| Foliage | [Pending](https://github.com/TokisanGames/Terrain3D/issues/43). Non-collision based, paintable meshes (rocks, grass) will likely be added as a particle shader. Alternatives are using [MultiMeshInstance3D](https://docs.godotengine.org/en/stable/tutorials/3d/using_multi_mesh_instance.html), or see 3rd party tools below.
 | Object placement | [Out of scope](https://github.com/TokisanGames/Terrain3D/issues/47). See 3rd party tools below.
-| Holes | Supported in 0.9. See [#60](https://github.com/TokisanGames/Terrain3D/issues/60#issuecomment-1817623935)
+| Holes | Supported since 0.9. See [#60](https://github.com/TokisanGames/Terrain3D/issues/60#issuecomment-1817623935)
 | Water | Use [WaterWays](https://github.com/Arnklit/Waterways) for rivers, or [Realistic Water Shader](https://github.com/godot-extended-libraries/godot-realistic-water/) or [Infinite Ocean](https://stayathomedev.com/tutorials/making-an-infinite-ocean-in-godot-4/) for lakes or oceans.
 | Destructibility | Real-time modification is technically possible by fetching the height and control maps and directly modifying them. That's how the editor works. But most gamedevs who want destructible terrains are better served by [Zylann's Voxel Tools](https://github.com/Zylann/godot_voxel).
 | Non-destructive layers | Used for things like river beds, roads or paths that follow a curve and tweak the terrain. It's [possible](https://github.com/TokisanGames/Terrain3D/issues/129), but low priority.
@@ -29,12 +29,13 @@ See the [Roadmap](https://github.com/users/TokisanGames/projects/3/views/1) for 
 | **Data** |
 | Large terrains | 8k^2 works, maybe a little more, though [collision will take up ~3GB RAM](https://github.com/TokisanGames/Terrain3D/issues/161). 16k x 8k up to 16k^2 works in memory, but cannot be saved due to an [engine bug](https://github.com/TokisanGames/Terrain3D/issues/159).
 | Importing / Exporting | Works. See [Importing data](import_export.md)
-| Double precision floats | [Needs testing](https://github.com/TokisanGames/Terrain3D/issues/30)
+| Double precision floats | [Supported](double_precision.md).
 | **Rendering** |
 | Frustum Culling | The terrain is made up of several meshes, so half can be culled if the camera is near the ground.
 | Occlusion Culling | [Supported](occlusion_culling.md).
 | SDFGI | Works fine.
 | Lightmap baking | Not possible. There is no static mesh, nor UV2 channel to bake lightmaps on to.
 | **3rd Party Tools** |
-| [Scatter](https://github.com/HungryProton/scatter) | For placing objects algorithmically, with or without collision. We provide [a script](https://github.com/TokisanGames/Terrain3D/blob/main/project/addons/terrain_3d/extras/project_on_terrain3d.gd) that allows Scatter to detect our terrain. 
+| [Scatter](https://github.com/HungryProton/scatter) | For placing objects algorithmically, with or without collision. We provide [a script](https://github.com/TokisanGames/Terrain3D/blob/main/project/addons/terrain_3d/extras/project_on_terrain3d.gd) that allows Scatter to detect our terrain. Or you can enable debug collision and use the default `Project on Colliders`.
 | [AssetPlacer](https://cookiebadger.itch.io/assetplacer) | A level design tool for placing assets manually. Works on Terrain3D with `debug_show_collision` turned on. Native support is pending.
+| [Simple Grass Painter](https://godotengine.org/asset-library/asset/1623) | A foliage painter. Add as a child and enable `debug_show_collision`.

--- a/doc/index.rst
+++ b/doc/index.rst
@@ -99,6 +99,7 @@ Geometry clipmap mesh code created by `Mike J. Savage <https://mikejsavage.co.uk
    :maxdepth: 1
    :caption: Advanced Usage
 
+   docs/double_precision
    docs/integrating
    docs/mobile_web
    docs/navigation

--- a/project/addons/terrain_3d/editor/components/ui.gd
+++ b/project/addons/terrain_3d/editor/components/ui.gd
@@ -65,8 +65,8 @@ func _enter_tree() -> void:
 	add_child(decal)
 	decal_timer = Timer.new()
 	decal_timer.wait_time = .5
+	decal_timer.one_shot = true
 	decal_timer.timeout.connect(Callable(func(node):
-		decal_timer.stop()
 		if node:
 			get_tree().create_tween().tween_property(node, "albedo_mix", 0.0, 0.15)).bind(decal))
 	add_child(decal_timer)
@@ -230,6 +230,8 @@ func update_decal() -> void:
 		decal.visible = true
 
 	decal.size = Vector3.ONE * brush_data["size"] * plugin.terrain.get_mesh_vertex_spacing()
+	decal.size.y = max(1000, decal.size.y)
+	decal.cull_mask = 1 << plugin.terrain.render_mouse_layer - 1
 	if brush_data["align_to_view"]:
 		var cam: Camera3D = plugin.terrain.get_camera();
 		if (cam):

--- a/project/addons/terrain_3d/editor/editor.gd
+++ b/project/addons/terrain_3d/editor/editor.gd
@@ -118,7 +118,7 @@ func _forward_3d_gui_input(p_viewport_camera: Camera3D, p_event: InputEvent) -> 
 
 		## Get mouse location on terrain
 		var mouse_pos: Vector2 = p_event.position
-		var camera_pos: Vector3 = p_viewport_camera.global_position
+		var camera_pos: Vector3 = p_viewport_camera.project_ray_origin(mouse_pos)
 		var camera_dir: Vector3 = p_viewport_camera.project_ray_normal(mouse_pos)
 		
 		# If mouse intersected terrain within 3000 units (3.4e38 is Double max val)

--- a/project/demo/Demo.tscn
+++ b/project/demo/Demo.tscn
@@ -32,6 +32,7 @@ noise = SubResource("FastNoiseLite_d8lcj")
 
 [sub_resource type="Terrain3DMaterial" id="Terrain3DMaterial_jrc01"]
 _shader_parameters = {
+"_mouse_layer": 2147483648,
 "auto_base_texture": 0,
 "auto_height_reduction": 0.1,
 "auto_overlay_texture": 1,

--- a/src/shaders/gpu_depth.glsl
+++ b/src/shaders/gpu_depth.glsl
@@ -1,0 +1,34 @@
+// Copyright © 2023 Cory Petkovsek, Roope Palmroos, and Contributors.
+
+// This shader reads the screen and returns absolute depth encoded in Albedo.rg
+// It is not used as an INSERT
+
+R"(
+shader_type spatial;
+render_mode unshaded;
+
+uniform sampler2D depth_texture : source_color, hint_depth_texture, filter_nearest, repeat_disable;
+
+uniform float camera_far = 100000.0;
+
+// Mobile renderer HDR mode has limit of 1 or 2. Pack full range depth to RG
+// https://gamedev.stackexchange.com/questions/201151/24bit-float-to-rgb
+vec3 encode_rg(float value) {
+    vec2 kEncodeMul = vec2(1.0, 255.0);
+    float kEncodeBit = 1.0 / 255.0;
+    vec2 color = kEncodeMul * value / camera_far;
+    color = fract(color);
+    color.x -= color.y * kEncodeBit;
+	return vec3(color, 0.);
+}
+	
+void fragment() {
+	float depth = textureLod(depth_texture, SCREEN_UV, 0.).x;
+	vec3 ndc = vec3(SCREEN_UV * 2.0 - 1.0, depth);
+	vec4 view = INV_PROJECTION_MATRIX * vec4(ndc, 1.0);
+	view.xyz /= view.w;
+	float depth_linear = -view.z;
+	ALBEDO = encode_rg(depth_linear); // Encoded value for Mobile
+}
+
+)"

--- a/src/shaders/world_noise.glsl
+++ b/src/shaders/world_noise.glsl
@@ -70,7 +70,7 @@ float world_noise(vec2 p) {
 
 //INSERT: WORLD_NOISE2
 	// World Noise
-   	if(_background_mode == 2) {
+   	if(_background_mode == 2u) {
 	    float weight = texture(_region_blend_map, (uv/float(_region_map_size))+0.5).r;
 	    float rmap_half_size = float(_region_map_size)*.5;
 	    if(abs(uv.x) > rmap_half_size+.5 || abs(uv.y) > rmap_half_size+.5) {

--- a/src/terrain_3d.h
+++ b/src/terrain_3d.h
@@ -11,7 +11,9 @@
 #include <godot_cpp/classes/editor_plugin.hpp>
 #include <godot_cpp/classes/geometry_instance3d.hpp>
 #include <godot_cpp/classes/mesh.hpp>
+#include <godot_cpp/classes/mesh_instance3d.hpp>
 #include <godot_cpp/classes/static_body3d.hpp>
+#include <godot_cpp/classes/sub_viewport.hpp>
 
 #include "terrain_3d_material.h"
 #include "terrain_3d_storage.h"
@@ -59,9 +61,15 @@ private:
 	} _data;
 
 	// Renderer settings
-	uint32_t _render_layers = 1;
+	uint32_t _render_layers = 1 | (1 << 31); // Bit 1 and 32 for the cursor
 	GeometryInstance3D::ShadowCastingSetting _shadow_casting = GeometryInstance3D::SHADOW_CASTING_SETTING_ON;
 	real_t _cull_margin = 0.0;
+
+	// Mouse cursor
+	SubViewport *_mouse_vp = nullptr;
+	Camera3D *_mouse_cam = nullptr;
+	MeshInstance3D *_mouse_quad = nullptr;
+	uint32_t _mouse_layer = 32;
 
 	// Physics body and settings
 	RID _static_body;
@@ -76,6 +84,8 @@ private:
 	void __ready();
 	void __process(double delta);
 
+	void _setup_mouse_picking();
+	void _destroy_mouse_picking();
 	void _grab_camera();
 	void _find_cameras(TypedArray<Node> from_nodes, Node *excluded_node, TypedArray<Camera3D> &cam_array);
 
@@ -124,6 +134,8 @@ public:
 	// Renderer settings
 	void set_render_layers(uint32_t p_layers);
 	uint32_t get_render_layers() const { return _render_layers; };
+	void set_mouse_layer(uint32_t p_layer);
+	uint32_t get_mouse_layer() const { return _mouse_layer; };
 	void set_cast_shadows(GeometryInstance3D::ShadowCastingSetting p_shadow_casting);
 	GeometryInstance3D::ShadowCastingSetting get_cast_shadows() const { return _shadow_casting; };
 	void set_cull_margin(real_t p_margin);
@@ -144,7 +156,7 @@ public:
 	// Terrain methods
 	void snap(Vector3 p_cam_pos);
 	void update_aabbs();
-	Vector3 get_intersection(Vector3 p_position, Vector3 p_direction);
+	Vector3 get_intersection(Vector3 p_src_pos, Vector3 p_direction);
 
 	// Baking methods
 	Ref<Mesh> bake_mesh(int p_lod, Terrain3DStorage::HeightFilter p_filter = Terrain3DStorage::HEIGHT_FILTER_NEAREST) const;

--- a/src/terrain_3d_material.cpp
+++ b/src/terrain_3d_material.cpp
@@ -238,16 +238,18 @@ void Terrain3DMaterial::_update_shader() {
 	// Fetch saved shader parameters, converting textures to RIDs
 	for (int i = 0; i < _active_params.size(); i++) {
 		StringName param = _active_params[i];
-		Variant value = _shader_params[param];
-		if (value.get_type() == Variant::OBJECT) {
-			Ref<Texture> tex = value;
-			if (tex.is_valid()) {
-				RS->material_set_param(_material, param, tex->get_rid());
+		if (!param.begins_with("_")) {
+			Variant value = _shader_params[param];
+			if (value.get_type() == Variant::OBJECT) {
+				Ref<Texture> tex = value;
+				if (tex.is_valid()) {
+					RS->material_set_param(_material, param, tex->get_rid());
+				} else {
+					RS->material_set_param(_material, param, Variant());
+				}
 			} else {
-				RS->material_set_param(_material, param, Variant());
+				RS->material_set_param(_material, param, value);
 			}
-		} else {
-			RS->material_set_param(_material, param, value);
 		}
 	}
 
@@ -674,9 +676,6 @@ void Terrain3DMaterial::_get_property_list(List<PropertyInfo> *p_list) const {
 			pi.usage = PROPERTY_USAGE_EDITOR;
 			p_list->push_back(pi);
 
-			// Populate list of public parameters for current shader
-			_active_params.push_back(name);
-
 			// Store this param in a dictionary that is saved in the resource file
 			// Initially set with default value
 			// Also acts as a cache for _get
@@ -686,6 +685,9 @@ void Terrain3DMaterial::_get_property_list(List<PropertyInfo> *p_list) const {
 				_property_get_revert(name, _shader_params[name]);
 			}
 		}
+
+		// Populate list of public and private parameters for current shader
+		_active_params.push_back(name);
 	}
 	return;
 }

--- a/src/terrain_3d_material.h
+++ b/src/terrain_3d_material.h
@@ -35,8 +35,8 @@ private:
 	Ref<Shader> _shader_override;
 	Ref<Shader> _shader_tmp;
 	Dictionary _shader_code;
-	mutable TypedArray<StringName> _active_params;
-	mutable Dictionary _shader_params;
+	mutable TypedArray<StringName> _active_params; // All shader params in the current shader
+	mutable Dictionary _shader_params; // Public shader params saved to disk
 
 	// Material Features
 	WorldBackground _world_background = FLAT;

--- a/src/util.h
+++ b/src/util.h
@@ -60,4 +60,12 @@ public:
 	static Ref<Image> pack_image(const Ref<Image> p_src_rgb, const Ref<Image> p_src_r, bool p_invert_green_channel = false);
 };
 
+template <typename TType>
+_FORCE_INLINE_ void memdelete_safely(TType *&p_ptr) {
+	if (p_ptr != nullptr) {
+		memdelete(p_ptr);
+		p_ptr = nullptr;
+	}
+}
+
 #endif // UTIL_CLASS_H


### PR DESCRIPTION
Fixes #121
Fixes #311 
Fixes #225 
Fixes #6 

**Features**
* Uses the GPU to detect the location of the mouse on the terrain. Like the previous method, it works without collision. Unlike the previous method, it is instant and has virtually no distance limit (camera far clip hard coded at 100k).
* Works with both the Forward+ and Mobile renderers.
* Provides a render_mouse_layer option to specify the render layer used so get_intersection does not pick up non-terrain objects.
* Ignores holes, so drawing on the opposite side of the terrain is no longer an issue.
* Adds support for Orthogonal cameras
* Adds support for Half resolution viewports
* Adds support for all editor cameras and 4-way terrain editing
* Improvements to decals
* material.get/set_shader_params now provides access to private shader variables.
* Improved usage with vertex_spacing
* Tons of documentation updates

