### PR TITLE
Fix mesh vertex spacing

### DIFF
--- a/doc/api/class_terrain3d.rst
+++ b/doc/api/class_terrain3d.rst
@@ -315,6 +315,12 @@ The correlated size of the terrain meshes. Lod0 has ``4*mesh_size + 2`` quads pe
 
 The distance between vertices. Godot units are typically considered to be meters. This scales the terrain on X and Z axes.
 
+This variable changes the global position of landscape features. A mountain peak might be at (512, 512), but with a vertex spacing of 2.0 it is now located at (1024, 1024).
+
+All Terrain3D functions with a global_position expect an absolute global value. If you would normally use :ref:`Terrain3DStorage.import_images<class_Terrain3DStorage_method_import_images>` to import an image in the region at (-1024, -1024), with a mesh_vertex_spacing of 2, you'll need to import that image at (-2048, -2048) to place it in the same region.
+
+To scale heights, export the height map and reimport it with a new height scale.
+
 .. rst-class:: classref-item-separator
 
 ----

--- a/doc/api/class_terrain3dstorage.rst
+++ b/doc/api/class_terrain3dstorage.rst
@@ -417,7 +417,7 @@ And :ref:`get_region_offset<class_Terrain3DStorage_method_get_region_offset>` wh
 - void **set_region_size** **(** :ref:`RegionSize<enum_Terrain3DStorage_RegionSize>` value **)**
 - :ref:`RegionSize<enum_Terrain3DStorage_RegionSize>` **get_region_size** **(** **)**
 
-The size of each region. Limited to 1024 for now.
+The number of vertices in each sculptable region, and the number of pixels for each layer in the TextureArrays that store the height, control, and color maps. Limited to 1024 for now. This does not factor in :ref:`Terrain3D.mesh_vertex_spacing<class_Terrain3D_property_mesh_vertex_spacing>`.
 
 .. rst-class:: classref-item-separator
 
@@ -614,7 +614,7 @@ Returns the location of a terrain vertex at a certain LOD. If there is a hole at
 
 :ref:`Vector3<class_Vector3>` **get_normal** **(** :ref:`Vector3<class_Vector3>` global_position **)**
 
-Returns the terrain normal at the specified location.
+Returns the terrain normal at the specified location. This function uses :ref:`get_height<class_Terrain3DStorage_method_get_height>`, which is not currently accurate between vertices. Therefore, this function may also be inacurate between vertices.
 
 Returns ``Vector3(NAN, NAN, NAN)`` if the requested position is a hole or outside of defined regions.
 
@@ -722,7 +722,7 @@ Imports an Image set (Height, Control, Color) into this resource. It does NOT no
 
 \ ``images`` - MapType.TYPE_MAX sized array of Images for Height, Control, Color. Images can be blank or null.
 
-\ ``global_position`` - X,0,Z location on the region map. Valid range is ~ (+/-8192, +/-8192).
+\ ``global_position`` - X,0,Z location on the region map. Valid range is (+/-8192, +/-8192) \* :ref:`Terrain3D.mesh_vertex_spacing<class_Terrain3D_property_mesh_vertex_spacing>`.
 
 \ ``offset`` - Add this factor to all height values, can be negative.
 

--- a/doc/classes/Terrain3D.xml
+++ b/doc/classes/Terrain3D.xml
@@ -149,6 +149,9 @@
 		</member>
 		<member name="mesh_vertex_spacing" type="float" setter="set_mesh_vertex_spacing" getter="get_mesh_vertex_spacing" default="1.0">
 			The distance between vertices. Godot units are typically considered to be meters. This scales the terrain on X and Z axes.
+			This variable changes the global position of landscape features. A mountain peak might be at (512, 512), but with a vertex spacing of 2.0 it is now located at (1024, 1024).
+			All Terrain3D functions with a global_position expect an absolute global value. If you would normally use [method Terrain3DStorage.import_images] to import an image in the region at (-1024, -1024), with a mesh_vertex_spacing of 2, you'll need to import that image at (-2048, -2048) to place it in the same region.
+			To scale heights, export the height map and reimport it with a new height scale.
 		</member>
 		<member name="render_cast_shadows" type="int" setter="set_cast_shadows" getter="get_cast_shadows" enum="GeometryInstance3D.ShadowCastingSetting" default="1">
 			Tells the renderer how to cast shadows from the terrain onto other objects. This sets [code skip-lint]GeometryInstance3D.ShadowCastingSetting[/code] in the engine.

--- a/doc/classes/Terrain3DStorage.xml
+++ b/doc/classes/Terrain3DStorage.xml
@@ -166,7 +166,7 @@
 			<description>
 				Imports an Image set (Height, Control, Color) into this resource. It does NOT normalize values to 0-1. You must do that using get_min_max() and adjusting scale and offset.
 				[code skip-lint]images[/code] - MapType.TYPE_MAX sized array of Images for Height, Control, Color. Images can be blank or null.
-				[code skip-lint]global_position[/code] - X,0,Z location on the region map. Valid range is ~ (+/-8192, +/-8192).
+				[code skip-lint]global_position[/code] - X,0,Z location on the region map. Valid range is (+/-8192, +/-8192) * [member Terrain3D.mesh_vertex_spacing].
 				[code skip-lint]offset[/code] - Add this factor to all height values, can be negative.
 				[code skip-lint]scale[/code] - Scale all height values by this factor (applied after offset).
 			</description>
@@ -302,7 +302,7 @@
 			And [method get_region_offset] which converts a location in world space to a region space, which is what is stored in this array. Eg. [code skip-lint]get_region_offset(Vector3(1500, 0, 1500))[/code] would return (1, 1).
 		</member>
 		<member name="region_size" type="int" setter="set_region_size" getter="get_region_size" enum="Terrain3DStorage.RegionSize" default="1024">
-			The size of each region. Limited to 1024 for now.
+			The number of vertices in each sculptable region, and the number of pixels for each layer in the TextureArrays that store the height, control, and color maps. Limited to 1024 for now. This does not factor in [member Terrain3D.mesh_vertex_spacing].
 		</member>
 		<member name="save_16_bit" type="bool" setter="set_save_16_bit" getter="get_save_16_bit" default="false">
 			Heightmaps are loaded and edited in 32-bit. This option converts the file to 16-bit upon saving to reduce file size. This process is lossy.

--- a/project/addons/terrain_3d/editor/components/ui.gd
+++ b/project/addons/terrain_3d/editor/components/ui.gd
@@ -229,9 +229,7 @@ func update_decal() -> void:
 		await get_tree().create_timer(.05).timeout 
 		decal.visible = true
 
-	decal.size = Vector3.ONE * brush_data["size"] * plugin.terrain.get_mesh_vertex_spacing()
-	decal.size.y = max(1000, decal.size.y)
-	decal.cull_mask = 1 << plugin.terrain.render_mouse_layer - 1
+	decal.size = Vector3.ONE * brush_data["size"]
 	if brush_data["align_to_view"]:
 		var cam: Camera3D = plugin.terrain.get_camera();
 		if (cam):
@@ -242,7 +240,7 @@ func update_decal() -> void:
 	# Set texture and color
 	if picking != Terrain3DEditor.TOOL_MAX:
 		decal.texture_albedo = picker_texture
-		decal.size = Vector3.ONE*10.
+		decal.size = Vector3.ONE * 10. * plugin.terrain.get_mesh_vertex_spacing()
 		match picking:
 			Terrain3DEditor.HEIGHT:
 				decal.modulate = COLOR_PICK_HEIGHT
@@ -301,7 +299,9 @@ func update_decal() -> void:
 			_:
 				decal.modulate = Color.WHITE
 				decal.modulate.a = max(.3, brush_data["opacity"])
+	decal.size.y = max(1000, decal.size.y)
 	decal.albedo_mix = 1.0
+	decal.cull_mask = 1 << ( plugin.terrain.get_mouse_layer() - 1 )
 	decal_timer.start()
 	
 	for gradient_decal in gradient_decals:
@@ -313,7 +313,7 @@ func update_decal() -> void:
 			if point != Vector3.ZERO:
 				var point_decal: Decal = _get_gradient_decal(index)
 				point_decal.visible = true
-				point_decal.position = point * plugin.terrain.get_mesh_vertex_spacing()
+				point_decal.position = point
 				index += 1
 
 
@@ -325,7 +325,9 @@ func _get_gradient_decal(index: int) -> Decal:
 	gradient_decal = Decal.new()
 	gradient_decal.texture_albedo = picker_texture
 	gradient_decal.modulate = COLOR_SLOPE
-	gradient_decal.size = Vector3(10, 1000, 10)
+	gradient_decal.size = Vector3.ONE * 10. * plugin.terrain.get_mesh_vertex_spacing()
+	gradient_decal.size.y = 1000.
+	gradient_decal.cull_mask = decal.cull_mask
 	add_child(gradient_decal)
 	
 	gradient_decals.push_back(gradient_decal)

--- a/project/addons/terrain_3d/editor/editor.gd
+++ b/project/addons/terrain_3d/editor/editor.gd
@@ -150,12 +150,10 @@ func _forward_3d_gui_input(p_viewport_camera: Camera3D, p_event: InputEvent) -> 
 		else:
 			ui.decal_timer.start()
 
-		## Incorporate vertex spacing into operations
-		mouse_global_position.x /= terrain.get_mesh_vertex_spacing()
-		mouse_global_position.z /= terrain.get_mesh_vertex_spacing()
 		## Update region highlight
 		var region_size = terrain.get_storage().get_region_size()
-		var region_position: Vector2 = (Vector2(mouse_global_position.x, mouse_global_position.z) / region_size).floor()
+		var region_position: Vector2 = ( Vector2(mouse_global_position.x, mouse_global_position.z) \
+			/ (region_size * terrain.get_mesh_vertex_spacing()) ).floor()
 		if current_region_position != region_position:
 			current_region_position = region_position
 			update_region_grid()

--- a/src/terrain_3d_editor.h
+++ b/src/terrain_3d_editor.h
@@ -66,7 +66,7 @@ public:
 	class Brush {
 	private:
 		Ref<Image> _image;
-		Vector2 _img_size;
+		Vector2i _img_size;
 		Ref<ImageTexture> _texture;
 
 		int _size = 0;
@@ -89,7 +89,7 @@ public:
 
 		Ref<ImageTexture> get_texture() const { return _texture; }
 		Ref<Image> get_image() const { return _image; }
-		Vector2 get_image_size() const { return _img_size; }
+		Vector2i get_image_size() const { return _img_size; }
 
 		int get_size() const { return _size; }
 		real_t get_opacity() const { return _opacity; }

--- a/src/terrain_3d_storage.h
+++ b/src/terrain_3d_storage.h
@@ -11,10 +11,14 @@
 #include "terrain_3d_texture_list.h"
 #include "util.h"
 
+class Terrain3D;
+
 using namespace godot;
 
 class Terrain3DStorage : public Resource {
 	GDCLASS(Terrain3DStorage, Resource);
+
+	friend class Terrain3D;
 
 public:
 	// Constants
@@ -73,6 +77,7 @@ private:
 	bool _save_16_bit = false;
 	RegionSize _region_size = SIZE_1024;
 	Vector2i _region_sizev = Vector2i(_region_size, _region_size);
+	real_t _mesh_vertex_spacing = 1.0f; // Set by Terrain3D for get_normal()
 
 	// Stored Data
 	Vector2 _height_range = Vector2(0.f, 0.f);
@@ -117,7 +122,7 @@ public:
 
 	void clear_edited_area();
 	void add_edited_area(AABB p_area);
-	AABB get_edited_area() const { return _edited_area; }
+	AABB get_edited_area() const;
 
 	// Regions
 	void set_region_size(RegionSize p_size);


### PR DESCRIPTION
#296 Mesh scaling did not address Storage or Editor. Only the mouse position was scaled. This means get_height and other storage functions didn't work.

This PR adds on to the work done by @lfxu to ensure the API is global. That is all function calls (eg get_height) operate in absolute global positions. If looking at the height of a mountain peak with `get_height(512, 512)`, then you set vertex spacing to 2.0, you'll need to query that mountain peak with `get_height(1024, 1024)`.

### Working
* Add/remove regions
* Storage.get_height
* Storage.get_normal
* Collision
* Brushing
* Brush decal size
* Picker decals
* Importing - works fine using scaled global positions
* Navigation doesn't generate. With spacing=2, even a very small area produces no nav mesh.
* Baking array mesh and Occlusion culling off
* Slope sculpting, heights are a little off
* Edited AABB - The idea is internally it is in descaled coordinates. What it receives and gives externally are absolute global coordinates.
