### PR TITLE
Create Asset Dock

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,3 +35,4 @@ export_presets.cfg
 # Editors
 .vscode/
 .vs/
+project/addons/explore-editor-theme/

--- a/project/addons/terrain_3d/editor/components/asset_dock.tscn
+++ b/project/addons/terrain_3d/editor/components/asset_dock.tscn
@@ -1,0 +1,69 @@
+[gd_scene load_steps=2 format=3 uid="uid://dkb6hii5e48m2"]
+
+[ext_resource type="Script" path="res://addons/terrain_3d/editor/components/asset_dock.gd" id="1_e23pg"]
+
+[node name="Terrain3D" type="PanelContainer"]
+custom_minimum_size = Vector2(256, 136)
+offset_right = 256.0
+offset_bottom = 128.0
+script = ExtResource("1_e23pg")
+
+[node name="VBox" type="VBoxContainer" parent="."]
+layout_mode = 2
+
+[node name="PlacementHBox" type="HBoxContainer" parent="VBox"]
+layout_mode = 2
+
+[node name="Label" type="Label" parent="VBox/PlacementHBox"]
+layout_mode = 2
+text = "Dock Position: "
+
+[node name="Options" type="OptionButton" parent="VBox/PlacementHBox"]
+layout_mode = 2
+size_flags_horizontal = 3
+item_count = 9
+selected = 5
+popup/item_0/text = "Left_UL"
+popup/item_0/id = 0
+popup/item_1/text = "Left_BL"
+popup/item_1/id = 1
+popup/item_2/text = "Left_UR"
+popup/item_2/id = 2
+popup/item_3/text = "Left_BR"
+popup/item_3/id = 3
+popup/item_4/text = "Right_UL"
+popup/item_4/id = 4
+popup/item_5/text = "Right_BL "
+popup/item_5/id = 5
+popup/item_6/text = "Right_UR"
+popup/item_6/id = 6
+popup/item_7/text = "Right_BR"
+popup/item_7/id = 7
+popup/item_8/text = "Bottom"
+popup/item_8/id = 8
+
+[node name="Pinned" type="Button" parent="VBox/PlacementHBox"]
+layout_mode = 2
+tooltip_text = "Keep panel visible even if Terrain3D is not selected. Useful for keeping dock floating."
+toggle_mode = true
+text = "P"
+flat = true
+
+[node name="Label" type="Label" parent="VBox"]
+layout_mode = 2
+theme_override_font_sizes/font_size = 16
+text = "Textures"
+horizontal_alignment = 1
+vertical_alignment = 1
+
+[node name="SizeSlider" type="HSlider" parent="VBox"]
+custom_minimum_size = Vector2(100, 10)
+layout_mode = 2
+min_value = 56.0
+max_value = 256.0
+value = 83.0
+
+[node name="ScrollContainer" type="ScrollContainer" parent="VBox"]
+layout_mode = 2
+size_flags_horizontal = 3
+size_flags_vertical = 3

--- a/project/addons/terrain_3d/editor/components/tool_settings.gd
+++ b/project/addons/terrain_3d/editor/components/tool_settings.gd
@@ -300,7 +300,7 @@ func add_setting(p_type: SettingType, p_name: StringName, p_value: Variant, p_pa
 
 
 func get_setting(p_setting: String) -> Variant:
-	var object: Object = settings[p_setting]
+	var object: Object = settings.get(p_setting)
 	var value: Variant
 	if object is Range:
 		value = object.get_value()
@@ -316,6 +316,8 @@ func get_setting(p_setting: String) -> Variant:
 		value = object.color
 	elif object is PointPicker:
 		value = object.get_points()
+	if value == null:
+		value = 0
 	return value
 
 

--- a/project/addons/terrain_3d/editor/components/toolbar.gd
+++ b/project/addons/terrain_3d/editor/components/toolbar.gd
@@ -59,6 +59,7 @@ func add_tool_button(p_tool: Terrain3DEditor.Tool, p_operation: Terrain3DEditor.
 		p_tip: String, p_icon: Texture2D, p_group: ButtonGroup) -> void:
 		
 	var button: Button = Button.new()
+	button.set_name(p_tip.to_pascal_case())
 	button.set_meta("Tool", p_tool)
 	button.set_meta("Operation", p_operation)
 	button.set_tooltip_text(p_tip)

--- a/project/addons/terrain_3d/editor/components/ui.gd
+++ b/project/addons/terrain_3d/editor/components/ui.gd
@@ -61,6 +61,8 @@ func _enter_tree() -> void:
 	plugin.add_control_to_container(EditorPlugin.CONTAINER_SPATIAL_EDITOR_BOTTOM, toolbar_settings)
 	plugin.add_control_to_container(EditorPlugin.CONTAINER_SPATIAL_EDITOR_MENU, terrain_tools)
 
+	_on_tool_changed(Terrain3DEditor.REGION, Terrain3DEditor.ADD)
+	
 	decal = Decal.new()
 	add_child(decal)
 	decal_timer = Timer.new()
@@ -87,112 +89,114 @@ func _exit_tree() -> void:
 
 func set_visible(p_visible: bool) -> void:
 	visible = p_visible
-	toolbar.set_visible(p_visible and plugin.terrain)
 	terrain_tools.set_visible(p_visible)
-	
-	if p_visible and plugin.terrain:
-		p_visible = plugin.editor.get_tool() != Terrain3DEditor.REGION
-	toolbar_settings.set_visible(p_visible and plugin.terrain)
+	toolbar.set_visible(p_visible)
+	toolbar_settings.set_visible(p_visible)
 	update_decal()
 
 
 func _on_tool_changed(p_tool: Terrain3DEditor.Tool, p_operation: Terrain3DEditor.Operation) -> void:
 	clear_picking()
+
+	# Select which settings to hide. Options in tool_settings.gd:_ready
+	var to_hide: PackedStringArray = []
 	
-	if not visible or not plugin.terrain:
-		return
-
-	if plugin.editor:
-		plugin.editor.set_tool(p_tool)
-		plugin.editor.set_operation(p_operation)
-	
-	if p_tool != Terrain3DEditor.REGION:
-		# Select which settings to hide. Options:
-		# size, opactiy, height, slope, color, roughness, (height|color|roughness) picker
-		var to_hide: PackedStringArray = []
-		
-		if p_tool == Terrain3DEditor.HEIGHT:
-			to_hide.push_back("color")
-			to_hide.push_back("color picker")
-			to_hide.push_back("roughness")
-			to_hide.push_back("roughness picker")
-			to_hide.push_back("slope")
-			to_hide.push_back("enable")
-			if p_operation != Terrain3DEditor.REPLACE:
-				to_hide.push_back("height")
-				to_hide.push_back("height picker")
-			if p_operation != Terrain3DEditor.GRADIENT:
-				to_hide.push_back("gradient_points")
-				to_hide.push_back("drawable")
-
-		elif p_tool == Terrain3DEditor.TEXTURE:
+	if p_tool == Terrain3DEditor.REGION:
+		to_hide.push_back("size")
+		to_hide.push_back("opacity")
+		to_hide.push_back("enable")
+		to_hide.push_back("color")
+		to_hide.push_back("color picker")
+		to_hide.push_back("roughness")
+		to_hide.push_back("roughness picker")
+		to_hide.push_back("height")
+		to_hide.push_back("height picker")
+		to_hide.push_back("slope")
+		to_hide.push_back("gradient_points")
+		to_hide.push_back("drawable")
+				
+	elif p_tool == Terrain3DEditor.HEIGHT:
+		to_hide.push_back("color")
+		to_hide.push_back("color picker")
+		to_hide.push_back("roughness")
+		to_hide.push_back("roughness picker")
+		to_hide.push_back("slope")
+		to_hide.push_back("enable")
+		if p_operation != Terrain3DEditor.REPLACE:
 			to_hide.push_back("height")
 			to_hide.push_back("height picker")
+		if p_operation != Terrain3DEditor.GRADIENT:
 			to_hide.push_back("gradient_points")
 			to_hide.push_back("drawable")
-			to_hide.push_back("color")
-			to_hide.push_back("color picker")
-			to_hide.push_back("roughness")
-			to_hide.push_back("roughness picker")
-			to_hide.push_back("slope")
-			to_hide.push_back("enable")
-			if p_operation == Terrain3DEditor.REPLACE:
-				to_hide.push_back("opacity")
 
-		elif p_tool == Terrain3DEditor.COLOR:
-			to_hide.push_back("height")
-			to_hide.push_back("height picker")
-			to_hide.push_back("gradient_points")
-			to_hide.push_back("drawable")
-			to_hide.push_back("roughness")
-			to_hide.push_back("roughness picker")
-			to_hide.push_back("slope")
-			to_hide.push_back("enable")
-
-		elif p_tool == Terrain3DEditor.ROUGHNESS:
-			to_hide.push_back("height")
-			to_hide.push_back("height picker")
-			to_hide.push_back("gradient_points")
-			to_hide.push_back("drawable")
-			to_hide.push_back("color")
-			to_hide.push_back("color picker")
-			to_hide.push_back("slope")
-			to_hide.push_back("enable")
-	
-		elif p_tool in [ Terrain3DEditor.AUTOSHADER, Terrain3DEditor.HOLES, Terrain3DEditor.NAVIGATION ]:
-			to_hide.push_back("height")
-			to_hide.push_back("height picker")
-			to_hide.push_back("gradient_points")
-			to_hide.push_back("drawable")
-			to_hide.push_back("color")
-			to_hide.push_back("color picker")
-			to_hide.push_back("roughness")
-			to_hide.push_back("roughness picker")
-			to_hide.push_back("slope")
+	elif p_tool == Terrain3DEditor.TEXTURE:
+		to_hide.push_back("height")
+		to_hide.push_back("height picker")
+		to_hide.push_back("gradient_points")
+		to_hide.push_back("drawable")
+		to_hide.push_back("color")
+		to_hide.push_back("color picker")
+		to_hide.push_back("roughness")
+		to_hide.push_back("roughness picker")
+		to_hide.push_back("slope")
+		to_hide.push_back("enable")
+		if p_operation == Terrain3DEditor.REPLACE:
 			to_hide.push_back("opacity")
 
-		toolbar_settings.hide_settings(to_hide)
+	elif p_tool == Terrain3DEditor.COLOR:
+		to_hide.push_back("height")
+		to_hide.push_back("height picker")
+		to_hide.push_back("gradient_points")
+		to_hide.push_back("drawable")
+		to_hide.push_back("roughness")
+		to_hide.push_back("roughness picker")
+		to_hide.push_back("slope")
+		to_hide.push_back("enable")
 
-	toolbar_settings.set_visible(p_tool != Terrain3DEditor.REGION)	
-	
+	elif p_tool == Terrain3DEditor.ROUGHNESS:
+		to_hide.push_back("height")
+		to_hide.push_back("height picker")
+		to_hide.push_back("gradient_points")
+		to_hide.push_back("drawable")
+		to_hide.push_back("color")
+		to_hide.push_back("color picker")
+		to_hide.push_back("slope")
+		to_hide.push_back("enable")
+
+	elif p_tool in [ Terrain3DEditor.AUTOSHADER, Terrain3DEditor.HOLES, Terrain3DEditor.NAVIGATION ]:
+		to_hide.push_back("height")
+		to_hide.push_back("height picker")
+		to_hide.push_back("gradient_points")
+		to_hide.push_back("drawable")
+		to_hide.push_back("color")
+		to_hide.push_back("color picker")
+		to_hide.push_back("roughness")
+		to_hide.push_back("roughness picker")
+		to_hide.push_back("slope")
+		to_hide.push_back("opacity")
+
+	toolbar_settings.hide_settings(to_hide)
+
 	operation_builder = null
 	if p_operation == Terrain3DEditor.GRADIENT:
 		operation_builder = GradientOperationBuilder.new()
 		operation_builder.tool_settings = toolbar_settings
-	
+
+	if plugin.editor:
+		plugin.editor.set_tool(p_tool)
+		plugin.editor.set_operation(p_operation)
+
 	_on_setting_changed()
-	plugin.update_region_grid()
-	
 
 
 func _on_setting_changed() -> void:
-	if not visible or not plugin.terrain:
+	if not plugin.asset_dock:
 		return
 	brush_data = {
 		"size": int(toolbar_settings.get_setting("size")),
 		"opacity": toolbar_settings.get_setting("opacity") / 100.0,
 		"height": toolbar_settings.get_setting("height"),
-		"texture_index": plugin.texture_dock.get_selected_index(),
+		"texture_index": plugin.asset_dock.get_selected_index(),
 		"color": toolbar_settings.get_setting("color"),
 		"roughness": toolbar_settings.get_setting("roughness"),
 		"gradient_points": toolbar_settings.get_setting("gradient_points"),

--- a/project/project.godot
+++ b/project/project.godot
@@ -75,3 +75,8 @@ sprint={
 
 textures/vram_compression/import_etc2_astc=true
 occlusion_culling/use_occlusion_culling=true
+
+[terrain3d]
+
+config/dock_position=5
+config/dock_pinned=false

--- a/src/terrain_3d_editor.cpp
+++ b/src/terrain_3d_editor.cpp
@@ -510,11 +510,17 @@ void Terrain3DEditor::set_brush_data(Dictionary p_data) {
 
 void Terrain3DEditor::set_tool(Tool p_tool) {
 	_tool = p_tool;
-	_terrain->get_material()->set_show_navigation(_tool == NAVIGATION);
+	if (_terrain) {
+		_terrain->get_material()->set_show_navigation(_tool == NAVIGATION);
+	}
 }
 
 // Called on mouse click
 void Terrain3DEditor::start_operation(Vector3 p_global_position) {
+	if (!_terrain) {
+		LOG(ERROR, "_terrain not set");
+		return;
+	}
 	_setup_undo();
 	_pending_undo = true;
 	_modified = false;
@@ -544,6 +550,10 @@ void Terrain3DEditor::operate(Vector3 p_global_position, real_t p_camera_directi
 
 // Called on left mouse button released
 void Terrain3DEditor::stop_operation() {
+	if (!_terrain) {
+		LOG(ERROR, "_terrain not set");
+		return;
+	}
 	if (_pending_undo && _modified) {
 		_store_undo();
 		_pending_undo = false;


### PR DESCRIPTION
Fixes #132 

* Renames Texture dock to Asset dock
* Makes it a real dock that can be moved around or pulled into a separate window
* Converts it to a scene for better editability
* Fixes crashes in Terrain3DEditor
* Toggles between side dock and lower editor
* Hides dock when Terrain3D not selected
* Can pin dock to prevent above when used as a floating dock
* Asset texture scale limits or slider
* Panel retains position when switching scenes w/ two Terrain3Ds. Updates to material list of selected terrain3D.

![image](https://github.com/TokisanGames/Terrain3D/assets/632766/1e904944-1960-4fa4-affd-8d004a8ec32f)
![image](https://github.com/TokisanGames/Terrain3D/assets/632766/d526ae11-9f83-4f10-bdae-9f3718974b24)
![image](https://github.com/TokisanGames/Terrain3D/assets/632766/3e3052ba-7dc3-41d2-9b63-22cc964a7071)
