### PR TITLE
Update main.glsl low LOD vertex normals

### DIFF
--- a/AUTHORS.md
+++ b/AUTHORS.md
@@ -16,3 +16,5 @@ Contributors
 * [@directedchaossoftware](https://github.com/directedchaossoftware)
 * Jacob Coughenour [@jacobcoughenour](https://github.com/jacobcoughenour)
 * [@stakira](https://github.com/stakira) / [@lfxu](https://github.com/lfxu)
+* [@XTarsia](https://github.com/XTarsia)
+* Matt [@FishOfTheNorthStar](https://github.com/FishOfTheNorthStar)

--- a/doc/docs/shader_design.md
+++ b/doc/docs/shader_design.md
@@ -5,14 +5,18 @@ Our shader combines a lot of ideas and code from [cdxntchou's IndexMapTerrain](h
 
 Note that you can find the minimum shader needed to enable the terrain to function in `addons/terrain_3D/extras/minimum.gdshader`.
 
+At its core, the current texture painting and rendering system is a vertex painter, not a pixel painter. We paint codes at each vertex, 1m apart by default, represented as a pixel on the control map. Then the shader uses its many parameters to control how each pixel between the vertices blend together. For an artist, it's not as nice to use as a multi-layer, pixel based painter you might find in photoshop, but the dynamic nature of the system does afford other benefits.
+
+The following describes the various elements of the shader in a linear fashion to help you understand how the various elements are used.
+
 ## Uniforms
 
 [Terrain3DMaterial](../api/class_terrain3dmaterial.rst) exposes uniforms found in the shader, whether we put them there or you do with your own custom shader. Uniforms that begin with `_` are considered private and are not exposed. However you can access them via code. You can create your own private uniforms.
 
-These notable [Terrain3DStorage](](../api/class_terrain3dstorage.rst) variables are passed in as uniforms:
+These notable [Terrain3DStorage](../api/class_terrain3dstorage.rst) variables are passed in as uniforms:
 * `_region_map`, `_region_offsets` define the location and IDs of regions (sculpted areas)
-* `_height_maps`, `_control_maps`, and `_color_maps` texture arrays define the elevation, textures, and colors of the terrain
-* `_texture_array_albedo`, `_normal` are the texture arrays compiling all individual textures
+* `_height_maps`, `_control_maps`, and `_color_maps` texture arrays define the elevation, textures, and colors of the terrain, indexed by region ID
+* `_texture_array_albedo`, `_texture_array_normal` are the texture arrays that combine all of the individual textures, indexed by texture ID
 
 ## Vertex() & Supporting functions
 
@@ -20,11 +24,11 @@ These notable [Terrain3DStorage](](../api/class_terrain3dstorage.rst) variables 
 
 First are `get_region_uv/_uv2()` which take in UV coordinates and return region coordinates, either absolute or normalized. It also returns the region ID, which is used in the map texture arrays above.
 
-Optionally, world noise is inserted here, which generates fractal brownian noise to be used for background hills outside of your regions. It's a visual gimmick only and does not generate collision.
+Optionally, world noise is inserted here, which generates fractal brownian noise to be used for background hills outside of your regions. It's an expensive visual gimmick only and does not generate collision.
 
 `get_height()` returns the value of the heightmap at the given location. If world noise is enabled, it is blended into the height here.
 
-Finally `vertex()` sets the UV and UV2 coordinates, and the height of the mesh vertex. Elsewhere the CPU creates flat mesh components and a mountainous collision mesh. Here is where the flat mesh vertices have their heights set to match the collision mesh with `VERTEX.y = get_height(UV2)`.
+Finally `vertex()` sets the UV and UV2 coordinates, and the height of the mesh vertex. Elsewhere the CPU creates flat mesh components and a collision mesh with heights. Here is where the flat mesh vertices have their heights set to match the collision mesh.
 
 ## Fragment()
 
@@ -32,7 +36,7 @@ Finally `vertex()` sets the UV and UV2 coordinates, and the height of the mesh v
 
 ### Normal calculation
 
-The first step is calculating the terrain normals. This shared between the `vertex()` and `fragment()` functions. Clipmap terrain vertices spread out at lower LODs causing certain things like normals look strange when you look in the distance as the vertices used for calculation suddenly separate at further LODs. So we switch from vertex based to per pixel to calculate normals after a given threshold.
+The first step is calculating the terrain normals. This shared between the `vertex()` and `fragment()` functions. Clipmap terrain vertices spread out at lower LODs causing certain things like normals look strange when you look in the distance as the vertices used for calculation suddenly separate at further LODs. So we switch from normals calculated per vertex to per pixel when the pixel is farther than `vertex_normal_distance`.
 
 The exact distance that the transition from per vertex to per pixel normal calculations occurs can be adjusted from the default of 192m via the `vertex_normals_distance` uniform.
 

--- a/src/shaders/dual_scaling.glsl
+++ b/src/shaders/dual_scaling.glsl
@@ -8,10 +8,6 @@ uniform float dual_scale_reduction : hint_range(0.001,1) = 0.3;
 uniform float tri_scale_reduction : hint_range(0.001,1) = 0.3;
 uniform float dual_scale_far : hint_range(0,1000) = 170.0;
 uniform float dual_scale_near : hint_range(0,1000) = 100.0;
-varying float v_far_factor;
-
-//INSERT: DUAL_SCALING_VERTEX
-		v_far_factor = clamp(smoothstep(dual_scale_near, dual_scale_far, v_vertex_dist), 0.0, 1.0);
 
 //INSERT: DUAL_SCALING_BASE
 	// If dual scaling, apply to base texture
@@ -24,9 +20,11 @@ varying float v_far_factor;
 		albedo_far = texture(_texture_array_albedo, vec3(matUV*dual_scale_reduction, float(dual_scale_texture)));
 		normal_far = texture(_texture_array_normal, vec3(matUV*dual_scale_reduction, float(dual_scale_texture)));
 	}
+
+	float far_factor = clamp(smoothstep(dual_scale_near, dual_scale_far, length(v_vertex - v_camera_pos)), 0.0, 1.0);
 	if(out_mat.base == dual_scale_texture) {
-		albedo_ht = mix(albedo_ht, albedo_far, v_far_factor);
-		normal_rg = mix(normal_rg, normal_far, v_far_factor);
+		albedo_ht = mix(albedo_ht, albedo_far, far_factor);
+		normal_rg = mix(normal_rg, normal_far, far_factor);
 	}
 
 //INSERT: UNI_SCALING_BASE
@@ -36,8 +34,8 @@ varying float v_far_factor;
 //INSERT: DUAL_SCALING_OVERLAY
 		// If dual scaling, apply to overlay texture
 		if(out_mat.over == dual_scale_texture) {
-			albedo_ht2 = mix(albedo_ht2, albedo_far, v_far_factor);
-			normal_rg2 = mix(normal_rg2, normal_far, v_far_factor);
+			albedo_ht2 = mix(albedo_ht2, albedo_far, far_factor);
+			normal_rg2 = mix(normal_rg2, normal_far, far_factor);
 		}
 
 )"

--- a/src/shaders/main.glsl
+++ b/src/shaders/main.glsl
@@ -42,6 +42,7 @@ uniform uint _mouse_layer = 0x80000000u; // Layer 32
 // Public uniforms
 uniform bool height_blending = true;
 uniform float blend_sharpness : hint_range(0, 1) = 0.87;
+uniform float vertex_normals_distance : hint_range(0, 1024) = 192.0;
 //INSERT: AUTO_SHADER_UNIFORMS
 //INSERT: DUAL_SCALING_UNIFORMS
 uniform vec3 macro_variation1 : source_color = vec3(1.);
@@ -65,10 +66,12 @@ struct Material {
 
 varying flat vec3 v_vertex;	// World coordinate vertex location
 varying flat vec3 v_camera_pos;
-varying flat float v_vertex_dist;
+varying float v_vertex_dist;
 varying flat ivec3 v_region;
 varying flat vec2 v_uv_offset;
 varying flat vec2 v_uv2_offset;
+varying vec3 v_normal;
+varying float v_region_border_mask;
 
 ////////////////////////
 // Vertex
@@ -113,33 +116,44 @@ float get_height(vec2 uv) {
 
 void vertex() {
 	// Get camera pos in world vertex coords
-    v_camera_pos = INV_VIEW_MATRIX[3].xyz;
+	v_camera_pos = INV_VIEW_MATRIX[3].xyz;
 
 	// Get vertex of flat plane in world coordinates and set world UV
 	v_vertex = (MODEL_MATRIX * vec4(VERTEX, 1.0)).xyz;
-	
+
 	// UV coordinates in world space. Values are 0 to _region_size within regions
 	UV = round(v_vertex.xz * _mesh_vertex_density);
+
+	// UV coordinates in region space + texel offset. Values are 0 to 1 within regions
+	UV2 = (UV + vec2(0.5)) * _region_texel_size;
+
+	//camera distance to vertex
+	v_vertex_dist = length(v_vertex - v_camera_pos);
 
 	// Discard vertices for Holes. 1 lookup
 	v_region = get_region_uv(UV);
 	uint control = texelFetch(_control_maps, v_region, 0).r;
 	bool hole = bool(control >>2u & 0x1u);
+
 	// Show holes to all cameras except mouse camera (on exactly 1 layer)
 	if ( !(CAMERA_VISIBLE_LAYERS == _mouse_layer) && 
 			(hole || (_background_mode == 0u && v_region.z < 0)) ) {
 		VERTEX.x = 0./0.;
-	} else {
-		// UV coordinates in region space + texel offset. Values are 0 to 1 within regions
-		UV2 = (UV + vec2(0.5)) * _region_texel_size;
-
-		// Get final vertex location and save it
+	} else {		
+		// Set final vertex height & calculate vertex normals. 3 lookups.
 		VERTEX.y = get_height(UV2);
-		v_vertex = (MODEL_MATRIX * vec4(VERTEX, 1.0)).xyz;
-		v_vertex_dist = length(v_vertex - v_camera_pos);
+		v_vertex.y = VERTEX.y;
+		v_normal = vec3(
+			v_vertex.y - get_height(UV2 + vec2(_region_texel_size,0)),
+			_mesh_vertex_spacing,
+			v_vertex.y - get_height(UV2 + vec2(0,_region_texel_size))
+		);
+		// Due to a bug caused by the GPUs linear interpolation across edges of region maps,
+		// mask region edges and use vertex normals only across region boundaries.
+		v_region_border_mask = mod(UV.x+2.5,_region_size) - fract(UV.x) < 5.0 || mod(UV.y+2.5,_region_size) - fract(UV.y) < 5.0 ? 1. : 0.;
+		
 //INSERT: DUAL_SCALING_VERTEX
 	}
-
 	// Transform UVs to local to avoid poor precision during varying interpolation.
 	v_uv_offset = MODEL_MATRIX[3].xz * _mesh_vertex_density;
 	UV -= v_uv_offset;
@@ -151,30 +165,19 @@ void vertex() {
 // Fragment
 ////////////////////////
 
-// 3 lookups
+// 0 - 3 lookups
 vec3 get_normal(vec2 uv, out vec3 tangent, out vec3 binormal) {
-	// Get the height of the current vertex
-	float height = get_height(uv);
-
-	// Get the heights to the right and in front, but because of hardware 
-	// interpolation on the edges of the heightmaps, the values are off
-	// causing the normal map to look weird. So, near the edges of the map
-	// get the heights to the left or behind instead. Hacky solution that 
-	// reduces the artifact, but doesn't fix it entirely. See #185.
-	float u, v;
-	if(mod(uv.y*_region_size, _region_size) > _region_size-2.) {
-		v = get_height(uv + vec2(0, -_region_texel_size)) - height;
+	float u, v, height;
+	vec3 normal;
+	// Use vertex normals within radius of vertex_normals_distance, and along region borders.
+	if (v_region_border_mask > 0.5 || v_vertex_dist < vertex_normals_distance) {
+		normal = normalize(v_normal);
 	} else {
-		v = height - get_height(uv + vec2(0, _region_texel_size));
-	}
-	if(mod(uv.x*_region_size, _region_size) > _region_size-2.) {
-		u = get_height(uv + vec2(-_region_texel_size, 0)) - height;		
-	} else {
+		height = get_height(uv);
 		u = height - get_height(uv + vec2(_region_texel_size, 0));
+		v = height - get_height(uv + vec2(0, _region_texel_size));
+		normal = normalize(vec3(u, _mesh_vertex_spacing, v));
 	}
-
-	vec3 normal = vec3(u, _mesh_vertex_spacing, v);
-	normal = normalize(normal);
 	tangent = cross(normal, vec3(0, 0, 1));
 	binormal = cross(normal, tangent);
 	return normal;

--- a/src/shaders/world_noise.glsl
+++ b/src/shaders/world_noise.glsl
@@ -53,7 +53,7 @@ float world_noise(vec2 p) {
     vec2  d = vec2(0.0);
 
     int octaves = int( clamp(
-	float(world_noise_max_octaves) - floor(v_vertex_dist/(world_noise_lod_distance)),
+	float(world_noise_max_octaves) - floor(v_vertex_xz_dist/(world_noise_lod_distance)),
     float(world_noise_min_octaves), float(world_noise_max_octaves)) );
 	
     for( int i=0; i < octaves; i++ ) {


### PR DESCRIPTION
branching for vertex normals to fix #185 caused performance loss. so make that branch as big as possible without visual loss, whilst also gaining performance!

moved a couple things in the vertex function, and removed redundant matrix multiply.