### PR TITLE
Update build scripts to use upload artifact v4

### DIFF
--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -49,8 +49,19 @@ jobs:
           cp '${{ github.workspace }}/README.md' '${{ github.workspace }}/LICENSE.txt' ${{ github.workspace }}/project/addons/terrain_3d/
 
       - name: Upload Package
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
-          name: ${{ github.event.repository.name }}
+          name: t3d-${{ matrix.platform }}-${{ matrix.arch }}-${{ matrix.target }}
           path: |
             ${{ github.workspace }}/project/
+
+  merge:
+    runs-on: ubuntu-latest
+    needs: build
+    steps:
+      - name: Merge Artifacts
+        uses: actions/upload-artifact/merge@v4
+        with:
+          name: ${{ github.event.repository.name }}
+          pattern: t3d-*
+          delete-merged: true

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -99,12 +99,30 @@ jobs:
         run: |
           cp '${{ github.workspace }}/README.md' '${{ github.workspace }}/LICENSE.txt' ${{ github.workspace }}/project/addons/terrain_3d/
 
+#      - name: Upload Package
+#        uses: Wandalen/wretry.action@master
+#        with:
+#            action: actions/upload-artifact@v3
+#            attempt_limit: 3
+#            attempt_delay: 1000
+#            with: |
+#              name: ${{ github.event.repository.name }}
+#              path: ${{ github.workspace }}/project/
+
       - name: Upload Package
-        uses: Wandalen/wretry.action@master
+        uses: actions/upload-artifact@v4
         with:
-            action: actions/upload-artifact@v3
-            attempt_limit: 3
-            attempt_delay: 1000
-            with: |
-              name: ${{ github.event.repository.name }}
-              path: ${{ github.workspace }}/project/
+          name: t3d-${{ matrix.platform }}-${{ matrix.arch }}-${{ matrix.target }}
+          path: |
+            ${{ github.workspace }}/project/
+
+  merge:
+    runs-on: ubuntu-latest
+    needs: build
+    steps:
+      - name: Merge Artifacts
+        uses: actions/upload-artifact/merge@v4
+        with:
+          name: ${{ github.event.repository.name }}
+          pattern: t3d-*
+          delete-merged: true

--- a/.github/workflows/ios.yml
+++ b/.github/workflows/ios.yml
@@ -2,7 +2,7 @@
 on: [ workflow_call, workflow_dispatch ]
 
 jobs:
-  build-macos:
+  build:
     name: 🍏 iOS ${{ matrix.arch }} ${{ matrix.target }}
     runs-on: macos-latest
     strategy:
@@ -43,8 +43,19 @@ jobs:
           cp '${{ github.workspace }}/README.md' '${{ github.workspace }}/LICENSE.txt' ${{ github.workspace }}/project/addons/terrain_3d/
 
       - name: Upload Package
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
-          name: ${{ github.event.repository.name }}
+          name: t3d-${{ matrix.platform }}-${{ matrix.arch }}-${{ matrix.target }}
           path: |
             ${{ github.workspace }}/project/
+
+  merge:
+    runs-on: ubuntu-latest
+    needs: build
+    steps:
+      - name: Merge Artifacts
+        uses: actions/upload-artifact/merge@v4
+        with:
+          name: ${{ github.event.repository.name }}
+          pattern: t3d-*
+          delete-merged: true

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -2,7 +2,7 @@
 on: [ workflow_call, workflow_dispatch ]
 
 jobs:
-  build-linux:
+  build:
     name: 🐧 Linux ${{ matrix.arch }} ${{ matrix.target }}
     runs-on: ubuntu-20.04
     strategy:
@@ -45,8 +45,19 @@ jobs:
           cp '${{ github.workspace }}/README.md' '${{ github.workspace }}/LICENSE.txt' ${{ github.workspace }}/project/addons/terrain_3d/
 
       - name: Upload Package
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
-          name: ${{ github.event.repository.name }}
+          name: t3d-${{ matrix.platform }}-${{ matrix.arch }}-${{ matrix.target }}
           path: |
             ${{ github.workspace }}/project/
+
+  merge:
+    runs-on: ubuntu-latest
+    needs: build
+    steps:
+      - name: Merge Artifacts
+        uses: actions/upload-artifact/merge@v4
+        with:
+          name: ${{ github.event.repository.name }}
+          pattern: t3d-*
+          delete-merged: true

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -2,7 +2,7 @@
 on: [ workflow_call, workflow_dispatch ]
 
 jobs:
-  build-macos:
+  build:
     name: 🍎 macOS ${{ matrix.arch }} ${{ matrix.target }}
     runs-on: macos-latest
     strategy:
@@ -43,8 +43,19 @@ jobs:
           cp '${{ github.workspace }}/README.md' '${{ github.workspace }}/LICENSE.txt' ${{ github.workspace }}/project/addons/terrain_3d/
 
       - name: Upload Package
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
-          name: ${{ github.event.repository.name }}
+          name: t3d-${{ matrix.platform }}-${{ matrix.arch }}-${{ matrix.target }}
           path: |
             ${{ github.workspace }}/project/
+
+  merge:
+    runs-on: ubuntu-latest
+    needs: build
+    steps:
+      - name: Merge Artifacts
+        uses: actions/upload-artifact/merge@v4
+        with:
+          name: ${{ github.event.repository.name }}
+          pattern: t3d-*
+          delete-merged: true

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -48,8 +48,19 @@ jobs:
           cp '${{ github.workspace }}/README.md' '${{ github.workspace }}/LICENSE.txt' ${{ github.workspace }}/project/addons/terrain_3d/
 
       - name: Upload Package
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
-          name: ${{ github.event.repository.name }}
+          name: t3d-${{ matrix.platform }}-${{ matrix.arch }}-${{ matrix.target }}
           path: |
             ${{ github.workspace }}/project/
+
+  merge:
+    runs-on: ubuntu-latest
+    needs: build
+    steps:
+      - name: Merge Artifacts
+        uses: actions/upload-artifact/merge@v4
+        with:
+          name: ${{ github.event.repository.name }}
+          pattern: t3d-*
+          delete-merged: true


### PR DESCRIPTION
https://github.blog/changelog/2024-04-16-deprecation-notice-v3-of-the-artifact-actions/

Guide here
https://github.com/actions/upload-artifact/blob/main/docs/MIGRATION.md#merging-multiple-artifacts