### PR TITLE
Make Terrain3D instance accessible to major classes

### DIFF
--- a/src/constants.h
+++ b/src/constants.h
@@ -5,9 +5,7 @@
 
 using namespace godot;
 
-//////////////////////////////////////
-// Macro Constants & Syntactic Sugar
-//////////////////////////////////////
+// Constants
 
 #define RS RenderingServer::get_singleton()
 
@@ -19,9 +17,13 @@ using namespace godot;
 #define COLOR_NORMAL Color(0.5f, 0.5f, 1.0f, 1.0f)
 #define COLOR_CONTROL Color(as_float(enc_auto(true)), 0.f, 0.f, 1.0f)
 
+// For consistency between msvc, gcc, clang
+
 #ifndef __FLT_MAX__
 #define __FLT_MAX__ FLT_MAX
 #endif
+
+// Double precision builds
 
 #ifdef REAL_T_IS_DOUBLE
 typedef PackedFloat64Array PackedRealArray;
@@ -29,9 +31,42 @@ typedef PackedFloat64Array PackedRealArray;
 typedef PackedFloat32Array PackedRealArray;
 #endif
 
+// Set class name for logger.h
+
 #define CLASS_NAME() const String __class__ = get_class_static() + \
 		String("#") + String::num_uint64(get_instance_id()).right(4);
 
 #define CLASS_NAME_STATIC(p_name) static inline const char *__class__ = p_name;
+
+// Validation macros
+
+#define NOP // a return value for void, to avoid warnings
+
+#define IS_INIT(ret)           \
+	if (_terrain == nullptr) { \
+		return ret;            \
+	}
+
+#define IS_INIT_MESG(mesg, ret) \
+	if (_terrain == nullptr) {  \
+		LOG(ERROR, mesg);       \
+		return ret;             \
+	}
+
+#define IS_INIT_COND(cond, ret)        \
+	if (_terrain == nullptr || cond) { \
+		return ret;                    \
+	}
+
+#define IS_STORAGE_INIT(ret)                                        \
+	if (_terrain == nullptr || _terrain->get_storage().is_null()) { \
+		return ret;                                                 \
+	}
+
+#define IS_STORAGE_INIT_MESG(mesg, ret)                             \
+	if (_terrain == nullptr || _terrain->get_storage().is_null()) { \
+		LOG(ERROR, mesg);                                           \
+		return ret;                                                 \
+	}
 
 #endif // CONSTANTS_CLASS_H

--- a/src/terrain_3d.cpp
+++ b/src/terrain_3d.cpp
@@ -51,9 +51,9 @@ void Terrain3D::_initialize() {
 		LOG(DEBUG, "Connecting texture_list.textures_changed to _material->_update_texture_arrays()");
 		_texture_list->connect("textures_changed", callable_mp(_material.ptr(), &Terrain3DMaterial::_update_texture_arrays));
 	}
-	if (!_storage->is_connected("region_size_changed", callable_mp(_material.ptr(), &Terrain3DMaterial::_set_region_size))) {
-		LOG(DEBUG, "Connecting region_size_changed signal to _material->_set_region_size()");
-		_storage->connect("region_size_changed", callable_mp(_material.ptr(), &Terrain3DMaterial::_set_region_size));
+	if (!_storage->is_connected("region_size_changed", callable_mp(_material.ptr(), &Terrain3DMaterial::_update_regions))) {
+		LOG(DEBUG, "Connecting region_size_changed signal to _material->_update_regions()");
+		_storage->connect("region_size_changed", callable_mp(_material.ptr(), &Terrain3DMaterial::_update_regions));
 	}
 	if (!_storage->is_connected("regions_changed", callable_mp(_material.ptr(), &Terrain3DMaterial::_update_regions))) {
 		LOG(DEBUG, "Connecting regions_changed signal to _material->_update_regions()");
@@ -66,9 +66,9 @@ void Terrain3D::_initialize() {
 
 	// Initialize the system
 	if (!_initialized && _is_inside_world && is_inside_tree()) {
-		_material->initialize(_storage->get_region_size());
-		_material->set_mesh_vertex_spacing(_mesh_vertex_spacing);
-		_storage->update_regions(true); // generate map arrays
+		_storage->initialize(this);
+		_material->initialize(this);
+		_material->_update_regions();
 		_texture_list->update_list(); // generate texture arrays
 		_setup_mouse_picking();
 		_build(_mesh_lods, _mesh_size);
@@ -656,9 +656,6 @@ void Terrain3D::set_mesh_vertex_spacing(real_t p_spacing) {
 	if (_mesh_vertex_spacing != p_spacing) {
 		LOG(INFO, "Setting mesh vertex spacing: ", p_spacing);
 		_mesh_vertex_spacing = p_spacing;
-		if (_storage != nullptr) {
-			_storage->_mesh_vertex_spacing = p_spacing;
-		}
 		_clear();
 		_initialize();
 	}

--- a/src/terrain_3d_editor.cpp
+++ b/src/terrain_3d_editor.cpp
@@ -508,12 +508,6 @@ void Terrain3DEditor::_apply_undo(const Array &p_set) {
 // Public Functions
 ///////////////////////////
 
-Terrain3DEditor::Terrain3DEditor() {
-}
-
-Terrain3DEditor::~Terrain3DEditor() {
-}
-
 void Terrain3DEditor::set_brush_data(Dictionary p_data) {
 	if (p_data.is_empty()) {
 		return;
@@ -530,10 +524,7 @@ void Terrain3DEditor::set_tool(Tool p_tool) {
 
 // Called on mouse click
 void Terrain3DEditor::start_operation(Vector3 p_global_position) {
-	if (!_terrain) {
-		LOG(ERROR, "_terrain not set");
-		return;
-	}
+	IS_STORAGE_INIT_MESG("Terrain isn't initialized", NOP);
 	_setup_undo();
 	_pending_undo = true;
 	_modified = false;
@@ -547,10 +538,10 @@ void Terrain3DEditor::start_operation(Vector3 p_global_position) {
 
 // Called on mouse movement with left mouse button down
 void Terrain3DEditor::operate(Vector3 p_global_position, real_t p_camera_direction) {
+	IS_STORAGE_INIT_MESG("Terrain isn't initialized", NOP);
 	if (!_pending_undo) {
 		return;
 	}
-
 	_operation_movement = p_global_position - _operation_position;
 	_operation_position = p_global_position;
 
@@ -563,10 +554,7 @@ void Terrain3DEditor::operate(Vector3 p_global_position, real_t p_camera_directi
 
 // Called on left mouse button released
 void Terrain3DEditor::stop_operation() {
-	if (!_terrain) {
-		LOG(ERROR, "_terrain not set");
-		return;
-	}
+	IS_STORAGE_INIT_MESG("Terrain isn't initialized", NOP);
 	if (_pending_undo && _modified) {
 		_store_undo();
 		_pending_undo = false;

--- a/src/terrain_3d_editor.h
+++ b/src/terrain_3d_editor.h
@@ -106,7 +106,6 @@ public: // Constants
 	};
 
 private:
-	// Object references
 	Terrain3D *_terrain = nullptr;
 
 	// Painter settings & variables
@@ -132,8 +131,8 @@ private:
 	void _apply_undo(const Array &p_set);
 
 public:
-	Terrain3DEditor();
-	~Terrain3DEditor();
+	Terrain3DEditor() {}
+	~Terrain3DEditor() {}
 
 	void set_terrain(Terrain3D *p_terrain) { _terrain = p_terrain; }
 	Terrain3D *get_terrain() const { return _terrain; }

--- a/src/terrain_3d_material.h
+++ b/src/terrain_3d_material.h
@@ -31,7 +31,8 @@ public: // Constants
 	};
 
 private:
-	bool _initialized = false;
+	Terrain3D *_terrain = nullptr;
+
 	RID _material;
 	RID _shader;
 	bool _shader_override_enabled = false;
@@ -40,6 +41,7 @@ private:
 	Dictionary _shader_code;
 	mutable TypedArray<StringName> _active_params; // All shader params in the current shader
 	mutable Dictionary _shader_params; // Public shader params saved to disk
+	GeneratedTexture _generated_region_blend_map; // 512x512 blurred image of region_map
 
 	// Material Features
 	WorldBackground _world_background = FLAT;
@@ -63,13 +65,6 @@ private:
 	bool _debug_view_tex_rough = false;
 	bool _debug_view_vertex_grid = false;
 
-	// Cached data from Storage
-	int _region_size = 1024;
-	real_t _mesh_vertex_spacing = 1.0f;
-	Vector2i _region_sizev = Vector2i(_region_size, _region_size);
-	PackedInt32Array _region_map;
-	GeneratedTexture _generated_region_blend_map; // 512x512 blurred image of region_map
-
 	// Functions
 	void _preload_shaders();
 	void _parse_shader(String p_shader, String p_name);
@@ -77,16 +72,15 @@ private:
 	String _generate_shader_code();
 	String _inject_editor_code(String p_shader);
 	void _update_shader();
-	void _update_regions(const Array &p_args);
+	void _update_regions();
 	void _generate_region_blend_map();
-	void _update_texture_arrays(const Ref<Terrain3DTextureList> p_texture_list);
-	void _set_region_size(int p_size);
+	void _update_texture_arrays();
 	void _set_shader_parameters(const Dictionary &p_dict);
 	Dictionary _get_shader_parameters() const { return _shader_params; }
 
 public:
 	Terrain3DMaterial(){};
-	void initialize(int p_region_size);
+	void initialize(Terrain3D *p_terrain);
 	~Terrain3DMaterial();
 
 	RID get_material_rid() const { return _material; }
@@ -110,8 +104,6 @@ public:
 
 	void set_shader_param(const StringName &p_name, const Variant &p_value);
 	Variant get_shader_param(const StringName &p_name) const;
-
-	void set_mesh_vertex_spacing(real_t p_spacing);
 
 	// Editor functions / Debug views
 	void set_show_checkered(bool p_enabled);

--- a/src/terrain_3d_storage.cpp
+++ b/src/terrain_3d_storage.cpp
@@ -26,8 +26,16 @@ void Terrain3DStorage::_clear() {
 // Public Functions
 ///////////////////////////
 
-Terrain3DStorage::Terrain3DStorage() {
+void Terrain3DStorage::initialize(Terrain3D *p_terrain) {
+	if (p_terrain != nullptr) {
+		_terrain = p_terrain;
+	} else {
+		LOG(ERROR, "Initialization failed, p_terrain is null");
+		return;
+	}
+	LOG(INFO, "Initializing storage");
 	_region_map.resize(REGION_MAP_SIZE * REGION_MAP_SIZE);
+	update_regions(true); // generate map arrays
 }
 
 Terrain3DStorage::~Terrain3DStorage() {
@@ -115,7 +123,8 @@ void Terrain3DStorage::set_region_offsets(const TypedArray<Vector2i> &p_offsets)
 
 /** Returns a region offset given a location */
 Vector2i Terrain3DStorage::get_region_offset(Vector3 p_global_position) {
-	Vector3 descaled_position = p_global_position / _mesh_vertex_spacing;
+	IS_INIT_MESG("Storage not initialized", Vector2i());
+	Vector3 descaled_position = p_global_position / _terrain->get_mesh_vertex_spacing();
 	return Vector2i((Vector2(descaled_position.x, descaled_position.z) / real_t(_region_size)).floor());
 }
 
@@ -138,6 +147,7 @@ int Terrain3DStorage::get_region_index(Vector3 p_global_position) {
  *	p_update - rebuild the maps if true. Set to false if bulk adding many regions.
  */
 Error Terrain3DStorage::add_region(Vector3 p_global_position, const TypedArray<Image> &p_images, bool p_update) {
+	IS_INIT_MESG("Storage not initialized", FAILED);
 	Vector2i uv_offset = get_region_offset(p_global_position);
 	LOG(INFO, "Adding region at ", p_global_position, ", uv_offset ", uv_offset,
 			", array size: ", p_images.size(),
@@ -148,7 +158,7 @@ Error Terrain3DStorage::add_region(Vector3 p_global_position, const TypedArray<I
 		uint64_t time = Time::get_singleton()->get_ticks_msec();
 		if (time - _last_region_bounds_error > 1000) {
 			_last_region_bounds_error = time;
-			LOG(ERROR, "Specified position outside of maximum region map size: +/-", real_t((REGION_MAP_SIZE / 2) * _region_size) * _mesh_vertex_spacing);
+			LOG(ERROR, "Specified position outside of maximum region map size: +/-", real_t((REGION_MAP_SIZE / 2) * _region_size) * _terrain->get_mesh_vertex_spacing());
 		}
 		return FAILED;
 	}
@@ -280,13 +290,7 @@ void Terrain3DStorage::update_regions(bool force_emit) {
 
 	// Emit if requested or changes were made
 	if (force_emit) {
-		Array region_signal_args;
-		region_signal_args.push_back(_generated_height_maps.get_rid());
-		region_signal_args.push_back(_generated_control_maps.get_rid());
-		region_signal_args.push_back(_generated_color_maps.get_rid());
-		region_signal_args.push_back(_region_map);
-		region_signal_args.push_back(_region_offsets);
-		emit_signal("regions_changed", region_signal_args);
+		emit_signal("regions_changed");
 	}
 }
 
@@ -410,6 +414,7 @@ TypedArray<Image> Terrain3DStorage::get_maps_copy(MapType p_map_type) const {
 }
 
 void Terrain3DStorage::set_pixel(MapType p_map_type, Vector3 p_global_position, Color p_pixel) {
+	IS_INIT_MESG("Storage not initialized", NOP);
 	if (p_map_type < 0 || p_map_type >= TYPE_MAX) {
 		LOG(ERROR, "Specified map type out of range");
 		return;
@@ -419,7 +424,7 @@ void Terrain3DStorage::set_pixel(MapType p_map_type, Vector3 p_global_position, 
 		return;
 	}
 	Vector2i global_offset = Vector2i(get_region_offsets()[region]) * _region_size;
-	Vector3 descaled_position = p_global_position / _mesh_vertex_spacing;
+	Vector3 descaled_position = p_global_position / _terrain->get_mesh_vertex_spacing();
 	Vector2i img_pos = Vector2i(
 			Vector2(descaled_position.x - global_offset.x,
 					descaled_position.z - global_offset.y)
@@ -429,6 +434,7 @@ void Terrain3DStorage::set_pixel(MapType p_map_type, Vector3 p_global_position, 
 }
 
 Color Terrain3DStorage::get_pixel(MapType p_map_type, Vector3 p_global_position) {
+	IS_INIT_MESG("Storage not initialized", COLOR_NAN);
 	if (p_map_type < 0 || p_map_type >= TYPE_MAX) {
 		LOG(ERROR, "Specified map type out of range");
 		return COLOR_NAN;
@@ -438,7 +444,7 @@ Color Terrain3DStorage::get_pixel(MapType p_map_type, Vector3 p_global_position)
 		return COLOR_NAN;
 	}
 	Vector2i global_offset = Vector2i(get_region_offsets()[region]) * _region_size;
-	Vector3 descaled_position = p_global_position / _mesh_vertex_spacing;
+	Vector3 descaled_position = p_global_position / _terrain->get_mesh_vertex_spacing();
 	Vector2i img_pos = Vector2i(
 			Vector2(descaled_position.x - global_offset.x,
 					descaled_position.z - global_offset.y)
@@ -449,11 +455,12 @@ Color Terrain3DStorage::get_pixel(MapType p_map_type, Vector3 p_global_position)
 }
 
 real_t Terrain3DStorage::get_height(Vector3 p_global_position) {
+	IS_INIT_MESG("Storage not initialized", NAN);
 	if (is_hole(get_control(p_global_position))) {
 		return NAN;
 	}
 	Vector3 &pos = p_global_position;
-	real_t &step = _mesh_vertex_spacing;
+	real_t step = _terrain->get_mesh_vertex_spacing();
 	pos.y = 0.f;
 	// Round to nearest vertex
 	Vector3 pos_round = Vector3(
@@ -638,6 +645,7 @@ void Terrain3DStorage::save() {
  *	p_scale - Scale all height values by this factor (applied after offset)
  */
 void Terrain3DStorage::import_images(const TypedArray<Image> &p_images, Vector3 p_global_position, real_t p_offset, real_t p_scale) {
+	IS_INIT_MESG("Storage not initialized", NOP);
 	if (p_images.size() != TYPE_MAX) {
 		LOG(ERROR, "p_images.size() is ", p_images.size(), ". It should be ", TYPE_MAX, " even if some Images are blank or null");
 		return;
@@ -664,16 +672,17 @@ void Terrain3DStorage::import_images(const TypedArray<Image> &p_images, Vector3 
 		return;
 	}
 
-	Vector3 descaled_position = p_global_position / _mesh_vertex_spacing;
+	real_t vertex_spacing = _terrain->get_mesh_vertex_spacing();
+	Vector3 descaled_position = p_global_position / vertex_spacing;
 	int max_dimension = _region_size * REGION_MAP_SIZE / 2;
 	if ((abs(descaled_position.x) > max_dimension) || (abs(descaled_position.z) > max_dimension)) {
-		LOG(ERROR, "Specify a position within +/-", Vector3(max_dimension, 0.f, max_dimension) * _mesh_vertex_spacing);
+		LOG(ERROR, "Specify a position within +/-", Vector3(max_dimension, 0.f, max_dimension) * vertex_spacing);
 		return;
 	}
 	if ((descaled_position.x + img_size.x > max_dimension) ||
 			(descaled_position.z + img_size.y > max_dimension)) {
 		LOG(ERROR, img_size, " image will not fit at ", p_global_position,
-				". Try ", -(img_size * _mesh_vertex_spacing) / 2.f, " to center");
+				". Try ", -(img_size * vertex_spacing) / 2.f, " to center");
 		return;
 	}
 
@@ -740,7 +749,7 @@ void Terrain3DStorage::import_images(const TypedArray<Image> &p_images, Vector3 
 			}
 			// Add the heightmap slice and only regenerate on the last one
 			Vector3 position = Vector3(descaled_position.x + start_coords.x, 0.f, descaled_position.z + start_coords.y);
-			add_region(position * _mesh_vertex_spacing, images, (x == slices_width - 1 && y == slices_height - 1));
+			add_region(position * vertex_spacing, images, (x == slices_width - 1 && y == slices_height - 1));
 		}
 	} // for y < slices_height, x < slices_width
 }
@@ -888,6 +897,7 @@ Ref<Image> Terrain3DStorage::layered_to_image(MapType p_map_type) {
  * p_global_position: X and Z coordinates of the vertex. Heights will be sampled around these coordinates.
  */
 Vector3 Terrain3DStorage::get_mesh_vertex(int32_t p_lod, HeightFilter p_filter, Vector3 p_global_position) {
+	IS_INIT_MESG("Storage not initialized", Vector3());
 	LOG(INFO, "Calculating vertex location");
 	int32_t step = 1 << CLAMP(p_lod, 0, 8);
 	real_t height = 0.0f;
@@ -904,7 +914,7 @@ Vector3 Terrain3DStorage::get_mesh_vertex(int32_t p_lod, HeightFilter p_filter, 
 			height = get_height(p_global_position);
 			for (int32_t dx = -step / 2; dx < step / 2; dx += 1) {
 				for (int32_t dz = -step / 2; dz < step / 2; dz += 1) {
-					Vector3 position = p_global_position + Vector3(dx, 0.f, dz) * _mesh_vertex_spacing;
+					Vector3 position = p_global_position + Vector3(dx, 0.f, dz) * _terrain->get_mesh_vertex_spacing();
 					if (is_hole(get_control(position))) {
 						height = NAN;
 						break;
@@ -921,14 +931,16 @@ Vector3 Terrain3DStorage::get_mesh_vertex(int32_t p_lod, HeightFilter p_filter, 
 }
 
 Vector3 Terrain3DStorage::get_normal(Vector3 p_global_position) {
+	IS_INIT_MESG("Storage not initialized", Vector3());
 	int region = get_region_index(p_global_position);
 	if (region < 0 || region >= _region_offsets.size() || is_hole(get_control(p_global_position))) {
 		return Vector3(NAN, NAN, NAN);
 	}
+	real_t vertex_spacing = _terrain->get_mesh_vertex_spacing();
 	real_t height = get_height(p_global_position);
-	real_t u = height - get_height(p_global_position + Vector3(_mesh_vertex_spacing, 0.0f, 0.0f));
-	real_t v = height - get_height(p_global_position + Vector3(0.f, 0.f, _mesh_vertex_spacing));
-	Vector3 normal = Vector3(u, _mesh_vertex_spacing, v);
+	real_t u = height - get_height(p_global_position + Vector3(vertex_spacing, 0.0f, 0.0f));
+	real_t v = height - get_height(p_global_position + Vector3(0.f, 0.f, vertex_spacing));
+	Vector3 normal = Vector3(u, vertex_spacing, v);
 	normal.normalize();
 	return normal;
 }

--- a/src/terrain_3d_storage.h
+++ b/src/terrain_3d_storage.h
@@ -19,8 +19,6 @@ class Terrain3DStorage : public Resource {
 	GDCLASS(Terrain3DStorage, Resource);
 	CLASS_NAME();
 
-	friend class Terrain3D;
-
 public: // Constants
 	static inline const real_t CURRENT_VERSION = 0.842f;
 	static inline const int REGION_MAP_SIZE = 16;
@@ -69,13 +67,14 @@ public: // Constants
 	};
 
 private:
+	Terrain3D *_terrain = nullptr;
+
 	// Storage Settings & flags
 	real_t _version = 0.8f; // Set to ensure Godot always saves this
 	bool _modified = false;
 	bool _save_16_bit = false;
 	RegionSize _region_size = SIZE_1024;
 	Vector2i _region_sizev = Vector2i(_region_size, _region_size);
-	real_t _mesh_vertex_spacing = 1.0f; // Set by Terrain3D for get_normal()
 
 	// Stored Data
 	Vector2 _height_range = Vector2(0.f, 0.f);
@@ -106,7 +105,8 @@ private:
 	void _clear();
 
 public:
-	Terrain3DStorage();
+	Terrain3DStorage() {}
+	void initialize(Terrain3D *p_terrain);
 	~Terrain3DStorage();
 
 	void set_version(real_t p_version);
@@ -127,8 +127,10 @@ public:
 	// Regions
 	void set_region_size(RegionSize p_size);
 	RegionSize get_region_size() const { return _region_size; }
+	Vector2i get_region_sizev() const { return _region_sizev; }
 	void set_region_offsets(const TypedArray<Vector2i> &p_offsets);
 	TypedArray<Vector2i> get_region_offsets() const { return _region_offsets; }
+	PackedInt32Array get_region_map() const { return _region_map; }
 	int get_region_count() const { return _region_offsets.size(); }
 	Vector2i get_region_offset(Vector3 p_global_position);
 	int get_region_index(Vector3 p_global_position);
@@ -145,10 +147,13 @@ public:
 	TypedArray<Image> get_maps_copy(MapType p_map_type) const;
 	void set_height_maps(const TypedArray<Image> &p_maps) { set_maps(TYPE_HEIGHT, p_maps); }
 	TypedArray<Image> get_height_maps() const { return _height_maps; }
+	RID get_height_rid() { return _generated_height_maps.get_rid(); }
 	void set_control_maps(const TypedArray<Image> &p_maps) { set_maps(TYPE_CONTROL, p_maps); }
 	TypedArray<Image> get_control_maps() const { return _control_maps; }
+	RID get_control_rid() { return _generated_control_maps.get_rid(); }
 	void set_color_maps(const TypedArray<Image> &p_maps) { set_maps(TYPE_COLOR, p_maps); }
 	TypedArray<Image> get_color_maps() const { return _color_maps; }
+	RID get_color_rid() { return _generated_color_maps.get_rid(); }
 	void set_pixel(MapType p_map_type, Vector3 p_global_position, Color p_pixel);
 	Color get_pixel(MapType p_map_type, Vector3 p_global_position);
 	void set_height(Vector3 p_global_position, real_t p_height);

--- a/src/terrain_3d_texture_list.cpp
+++ b/src/terrain_3d_texture_list.cpp
@@ -40,7 +40,7 @@ void Terrain3DTextureList::_update_texture_files() {
 	_generated_albedo_textures.clear();
 	_generated_normal_textures.clear();
 	if (_textures.is_empty()) {
-		emit_signal("textures_changed", Ref<Terrain3DTextureList>(this));
+		emit_signal("textures_changed");
 		return;
 	}
 
@@ -168,7 +168,7 @@ void Terrain3DTextureList::_update_texture_files() {
 		}
 	}
 
-	emit_signal("textures_changed", Ref<Terrain3DTextureList>(this));
+	emit_signal("textures_changed");
 }
 
 void Terrain3DTextureList::_update_texture_settings() {
@@ -189,7 +189,7 @@ void Terrain3DTextureList::_update_texture_settings() {
 			_texture_uv_rotations.push_back(texture_set->get_uv_rotation());
 		}
 	}
-	emit_signal("textures_changed", Ref<Terrain3DTextureList>(this));
+	emit_signal("textures_changed");
 }
 
 ///////////////////////////


### PR DESCRIPTION
Terrain3D is now accessible by Storage and Material so they can call child classes and talk to each other.