### PR TITLE
Use separate resource files for each region

### DIFF
--- a/Terrain3D.vcxproj
+++ b/Terrain3D.vcxproj
@@ -149,6 +149,7 @@
     <ClInclude Include="src\logger.h" />
     <ClInclude Include="src\terrain_3d_instancer.h" />
     <ClInclude Include="src\terrain_3d_mesh_asset.h" />
+    <ClInclude Include="src\terrain_3d_region.h" />
     <ClInclude Include="src\terrain_3d_texture_asset.h" />
     <ClInclude Include="src\terrain_3d_util.h" />
     <ClInclude Include="src\terrain_3d_material.h" />
@@ -164,6 +165,7 @@
     <ClCompile Include="src\terrain_3d_instancer.cpp" />
     <ClCompile Include="src\terrain_3d_material.cpp" />
     <ClCompile Include="src\terrain_3d_mesh_asset.cpp" />
+    <ClCompile Include="src\terrain_3d_region.cpp" />
     <ClCompile Include="src\terrain_3d_storage.cpp" />
     <ClCompile Include="src\terrain_3d_texture_asset.cpp" />
     <ClCompile Include="src\terrain_3d_assets.cpp" />

--- a/Terrain3D.vcxproj.filters
+++ b/Terrain3D.vcxproj.filters
@@ -69,6 +69,9 @@
     <ClInclude Include="src\terrain_3d_asset_resource.h">
       <Filter>4. Headers</Filter>
     </ClInclude>
+    <ClInclude Include="src\terrain_3d_region.h">
+      <Filter>4. Headers</Filter>
+    </ClInclude>
   </ItemGroup>
   <ItemGroup>
     <ClCompile Include="src\geoclipmap.cpp">
@@ -105,6 +108,9 @@
       <Filter>5. C++</Filter>
     </ClCompile>
     <ClCompile Include="src\terrain_3d_mesh_asset.cpp">
+      <Filter>5. C++</Filter>
+    </ClCompile>
+    <ClCompile Include="src\terrain_3d_region.cpp">
       <Filter>5. C++</Filter>
     </ClCompile>
   </ItemGroup>

--- a/project/addons/terrain_3d/editor.gd
+++ b/project/addons/terrain_3d/editor.gd
@@ -180,9 +180,8 @@ func _forward_3d_gui_input(p_viewport_camera: Camera3D, p_event: InputEvent) -> 
 		ui.update_decal()
 
 		## Update region highlight
-		var region_size = terrain.get_storage().get_region_size()
 		var region_position: Vector2 = ( Vector2(mouse_global_position.x, mouse_global_position.z) \
-			/ (region_size * terrain.get_mesh_vertex_spacing()) ).floor()
+			/ (terrain.get_region_size() * terrain.get_mesh_vertex_spacing()) ).floor()
 		if current_region_position != region_position:
 			current_region_position = region_position
 			update_region_grid()
@@ -246,7 +245,7 @@ func update_region_grid() -> void:
 		region_gizmo.show_rect = editor.get_tool() == Terrain3DEditor.REGION
 		region_gizmo.use_secondary_color = editor.get_operation() == Terrain3DEditor.SUBTRACT
 		region_gizmo.region_position = current_region_position
-		region_gizmo.region_size = terrain.get_storage().get_region_size() * terrain.get_mesh_vertex_spacing()
+		region_gizmo.region_size = terrain.get_region_size() * terrain.get_mesh_vertex_spacing()
 		region_gizmo.grid = terrain.get_storage().get_region_locations()
 		
 		terrain.update_gizmos()

--- a/project/addons/terrain_3d/editor.gd
+++ b/project/addons/terrain_3d/editor.gd
@@ -103,11 +103,11 @@ func _edit(p_object: Object) -> void:
 		ui.set_visible(true)
 		terrain.set_meta("_edit_lock_", true)
 		
-        # Get alerted when a new asset list is loaded
+		# Get alerted when a new asset list is loaded
 		if not terrain.assets_changed.is_connected(asset_dock.update_assets):
 			terrain.assets_changed.connect(asset_dock.update_assets)
 		asset_dock.update_assets()
-        # Get alerted when the region map changes
+		# Get alerted when the region map changes
 		if not terrain.get_storage().region_map_changed.is_connected(update_region_grid):
 			terrain.get_storage().region_map_changed.connect(update_region_grid)
 		update_region_grid()

--- a/project/addons/terrain_3d/editor.gd
+++ b/project/addons/terrain_3d/editor.gd
@@ -213,7 +213,7 @@ func _forward_3d_gui_input(p_viewport_camera: Camera3D, p_event: InputEvent) -> 
 				# If adjusting regions
 				if editor.get_tool() == Terrain3DEditor.REGION:
 					# Skip regions that already exist or don't
-					var has_region: bool = terrain.get_storage().has_region(mouse_global_position)
+					var has_region: bool = terrain.get_storage().has_regionp(mouse_global_position)
 					var op: int = editor.get_operation()
 					if	( has_region and op == Terrain3DEditor.ADD) or \
 						( not has_region and op == Terrain3DEditor.SUBTRACT ):

--- a/project/addons/terrain_3d/src/ui.gd
+++ b/project/addons/terrain_3d/src/ui.gd
@@ -412,9 +412,9 @@ func pick(p_global_position: Vector3) -> void:
 		var color: Color
 		match picking:
 			Terrain3DEditor.HEIGHT:
-				color = plugin.terrain.get_storage().get_pixel(Terrain3DStorage.TYPE_HEIGHT, p_global_position)
+				color = plugin.terrain.get_storage().get_pixel(Terrain3DRegion.TYPE_HEIGHT, p_global_position)
 			Terrain3DEditor.ROUGHNESS:
-				color = plugin.terrain.get_storage().get_pixel(Terrain3DStorage.TYPE_COLOR, p_global_position)
+				color = plugin.terrain.get_storage().get_pixel(Terrain3DRegion.TYPE_COLOR, p_global_position)
 			Terrain3DEditor.COLOR:
 				color = plugin.terrain.get_storage().get_color(p_global_position)
 			Terrain3DEditor.ANGLE:

--- a/project/addons/terrain_3d/tools/importer.gd
+++ b/project/addons/terrain_3d/tools/importer.gd
@@ -61,19 +61,19 @@ func start_import(p_value: bool) -> void:
 			storage = Terrain3DStorage.new()
 
 		var imported_images: Array[Image]
-		imported_images.resize(Terrain3DStorage.TYPE_MAX)
+		imported_images.resize(Terrain3DRegion.TYPE_MAX)
 		var min_max := Vector2(0, 1)
 		var img: Image
 		if height_file_name:
 			img = Terrain3DUtil.load_image(height_file_name, ResourceLoader.CACHE_MODE_IGNORE, r16_range, r16_size)
 			min_max = Terrain3DUtil.get_min_max(img)
-			imported_images[Terrain3DStorage.TYPE_HEIGHT] = img
+			imported_images[Terrain3DRegion.TYPE_HEIGHT] = img
 		if control_file_name:
 			img = Terrain3DUtil.load_image(control_file_name, ResourceLoader.CACHE_MODE_IGNORE)
-			imported_images[Terrain3DStorage.TYPE_CONTROL] = img
+			imported_images[Terrain3DRegion.TYPE_CONTROL] = img
 		if color_file_name:
 			img = Terrain3DUtil.load_image(color_file_name, ResourceLoader.CACHE_MODE_IGNORE)
-			imported_images[Terrain3DStorage.TYPE_COLOR] = img
+			imported_images[Terrain3DRegion.TYPE_COLOR] = img
 			if assets.get_texture_count() == 0:
 				material.show_checkered = false
 				material.show_colormap = true

--- a/src/constants.h
+++ b/src/constants.h
@@ -18,11 +18,17 @@ using namespace godot;
 #define COLOR_NORMAL Color(0.5f, 0.5f, 1.0f, 1.0f)
 #define COLOR_CONTROL Color(as_float(enc_auto(true)), 0.f, 0.f, 1.0f)
 
-// For consistency between msvc, gcc, clang
-
-#ifndef __FLT_MAX__
-#define __FLT_MAX__ FLT_MAX
+#ifndef FLT_MAX
+// For consistency between MSVC, gcc, clang
+#define FLT_MAX __FLT_MAX__
 #endif
+
+#define V2_ZERO Vector2(0.f, 0.f)
+#define V2_MAX Vector2(FLT_MAX, FLT_MAX)
+#define V3_ZERO Vector3(0.f, 0.f, 0.f)
+#define V3_MAX Vector3(FLT_MAX, FLT_MAX, FLT_MAX)
+#define V2I_ZERO Vector2i(0, 0)
+#define V2I_MAX Vector2i(INT32_MAX, INT32_MAX)
 
 // Set class name for logger.h
 

--- a/src/constants.h
+++ b/src/constants.h
@@ -68,15 +68,15 @@ using namespace godot;
 		return ret;                                                    \
 	}
 
-#define IS_STORAGE_INIT(ret)                                        \
-	if (_terrain == nullptr || _terrain->get_storage().is_null()) { \
-		return ret;                                                 \
+#define IS_STORAGE_INIT(ret)                                         \
+	if (_terrain == nullptr || _terrain->get_storage() == nullptr) { \
+		return ret;                                                  \
 	}
 
-#define IS_STORAGE_INIT_MESG(mesg, ret)                             \
-	if (_terrain == nullptr || _terrain->get_storage().is_null()) { \
-		LOG(ERROR, mesg);                                           \
-		return ret;                                                 \
+#define IS_STORAGE_INIT_MESG(mesg, ret)                              \
+	if (_terrain == nullptr || _terrain->get_storage() == nullptr) { \
+		LOG(ERROR, mesg);                                            \
+		return ret;                                                  \
 	}
 
 #endif // CONSTANTS_CLASS_H

--- a/src/geoclipmap.cpp
+++ b/src/geoclipmap.cpp
@@ -95,7 +95,7 @@ Vector<RID> GeoClipMap::generate(const int p_size, const int p_levels) {
 			}
 		}
 
-		aabb = AABB(Vector3(0.f, 0.f, 0.f), Vector3(PATCH_VERT_RESOLUTION, 0.1f, PATCH_VERT_RESOLUTION));
+		aabb = AABB(V3_ZERO, Vector3(PATCH_VERT_RESOLUTION, 0.1f, PATCH_VERT_RESOLUTION));
 		tile_mesh = _create_mesh(vertices, indices, aabb);
 	}
 

--- a/src/register_types.cpp
+++ b/src/register_types.cpp
@@ -20,6 +20,7 @@ void initialize_terrain_3d(ModuleInitializationLevel p_level) {
 	ClassDB::register_class<Terrain3DMaterial>();
 	ClassDB::register_class<Terrain3DMeshAsset>();
 	ClassDB::register_class<Terrain3DStorage>();
+	ClassDB::register_class<Terrain3DStorage::Terrain3DRegion>();
 	ClassDB::register_class<Terrain3DTextureAsset>();
 	ClassDB::register_class<Terrain3DUtil>();
 	ClassDB::register_class<Terrain3DTexture>(); // Deprecated 0.9.2 - Remove 0.9.3+

--- a/src/register_types.cpp
+++ b/src/register_types.cpp
@@ -20,7 +20,7 @@ void initialize_terrain_3d(ModuleInitializationLevel p_level) {
 	ClassDB::register_class<Terrain3DMaterial>();
 	ClassDB::register_class<Terrain3DMeshAsset>();
 	ClassDB::register_class<Terrain3DStorage>();
-	ClassDB::register_class<Terrain3DStorage::Terrain3DRegion>();
+	ClassDB::register_class<Terrain3DRegion>();
 	ClassDB::register_class<Terrain3DTextureAsset>();
 	ClassDB::register_class<Terrain3DUtil>();
 	ClassDB::register_class<Terrain3DTexture>(); // Deprecated 0.9.2 - Remove 0.9.3+

--- a/src/terrain_3d.cpp
+++ b/src/terrain_3d.cpp
@@ -71,9 +71,9 @@ void Terrain3D::_initialize() {
 		_assets->connect("textures_changed", callable_mp(_material.ptr(), &Terrain3DMaterial::_update_texture_arrays));
 	}
 	// MeshAssets changed, update instancer
-	if (!_assets->is_connected("meshes_changed", callable_mp(_instancer, &Terrain3DInstancer::_update_mmis).bind(Vector2i(INT32_MAX, INT32_MAX), -1))) {
+	if (!_assets->is_connected("meshes_changed", callable_mp(_instancer, &Terrain3DInstancer::_update_mmis).bind(V2I_MAX, -1))) {
 		LOG(DEBUG, "Connecting _assets.meshes_changed to _instancer->_update_mmis()");
-		_assets->connect("meshes_changed", callable_mp(_instancer, &Terrain3DInstancer::_update_mmis).bind(Vector2i(INT32_MAX, INT32_MAX), -1));
+		_assets->connect("meshes_changed", callable_mp(_instancer, &Terrain3DInstancer::_update_mmis).bind(V2I_MAX, -1));
 	}
 	// New multimesh added to storage, rebuild instancer
 	if (!_storage->is_connected("multimeshes_changed", callable_mp(_instancer, &Terrain3DInstancer::_rebuild_mmis))) {
@@ -269,7 +269,7 @@ void Terrain3D::_build_meshes(const int p_mesh_lods, const int p_mesh_size) {
 
 	update_aabbs();
 	// Force a snap update
-	_camera_last_position = Vector2(__FLT_MAX__, __FLT_MAX__);
+	_camera_last_position = V2_MAX;
 }
 
 /**
@@ -401,7 +401,7 @@ void Terrain3D::_update_collision() {
 	float hole_const = NAN;
 	// DEPRECATED - Jolt v0.12 supports NAN. Remove check when it's old.
 	if (ProjectSettings::get_singleton()->get_setting("physics/3d/physics_engine") == "JoltPhysics3D") {
-		hole_const = __FLT_MAX__;
+		hole_const = FLT_MAX;
 	}
 
 	for (int i = 0; i < _storage->get_region_count(); i++) {
@@ -1040,7 +1040,7 @@ Vector3 Terrain3D::get_intersection(const Vector3 &p_src_pos, const Vector3 &p_d
 		Vector2 screen_rg = Vector2(screen_depth.r, screen_depth.g);
 		real_t normalized_distance = screen_rg.dot(Vector2(1.f, 1.f / 255.f));
 		if (normalized_distance < 0.00001f) {
-			return Vector3(__FLT_MAX__, __FLT_MAX__, __FLT_MAX__);
+			return V3_MAX;
 		}
 		// Necessary for a correct value depth = 1
 		if (normalized_distance > 0.9999f) {

--- a/src/terrain_3d.cpp
+++ b/src/terrain_3d.cpp
@@ -711,6 +711,11 @@ String Terrain3D::get_storage_directory() const {
 	return _storage_directory;
 }
 
+void Terrain3D::set_save_16_bit(const bool p_enabled) {
+	LOG(INFO, p_enabled);
+	_save_16_bit = p_enabled;
+}
+
 // This is run after the object has loaded and initialized
 void Terrain3D::set_storage(Terrain3DStorage *p_storage) {
 	if (_storage != p_storage) {
@@ -1291,10 +1296,15 @@ void Terrain3D::_notification(const int p_what) {
 
 void Terrain3D::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("get_version"), &Terrain3D::get_version);
-	ClassDB::bind_method(D_METHOD("set_storage_directory", "directory"), &Terrain3D::set_storage_directory);
-	ClassDB::bind_method(D_METHOD("get_storage_directory"), &Terrain3D::get_storage_directory);
 	ClassDB::bind_method(D_METHOD("set_debug_level", "level"), &Terrain3D::set_debug_level);
 	ClassDB::bind_method(D_METHOD("get_debug_level"), &Terrain3D::get_debug_level);
+
+	ClassDB::bind_method(D_METHOD("set_storage_directory", "directory"), &Terrain3D::set_storage_directory);
+	ClassDB::bind_method(D_METHOD("get_storage_directory"), &Terrain3D::get_storage_directory);
+	ClassDB::bind_method(D_METHOD("set_save_16_bit", "enabled"), &Terrain3D::set_save_16_bit);
+	ClassDB::bind_method(D_METHOD("get_save_16_bit"), &Terrain3D::get_save_16_bit);
+	ClassDB::bind_method(D_METHOD("get_storage"), &Terrain3D::get_storage);
+
 	ClassDB::bind_method(D_METHOD("set_mesh_lods", "count"), &Terrain3D::set_mesh_lods);
 	ClassDB::bind_method(D_METHOD("get_mesh_lods"), &Terrain3D::get_mesh_lods);
 	ClassDB::bind_method(D_METHOD("set_mesh_size", "size"), &Terrain3D::set_mesh_size);
@@ -1304,7 +1314,6 @@ void Terrain3D::_bind_methods() {
 
 	ClassDB::bind_method(D_METHOD("set_material", "material"), &Terrain3D::set_material);
 	ClassDB::bind_method(D_METHOD("get_material"), &Terrain3D::get_material);
-	ClassDB::bind_method(D_METHOD("get_storage"), &Terrain3D::get_storage);
 	ClassDB::bind_method(D_METHOD("set_assets", "assets"), &Terrain3D::set_assets);
 	ClassDB::bind_method(D_METHOD("get_assets"), &Terrain3D::get_assets);
 	ClassDB::bind_method(D_METHOD("get_instancer"), &Terrain3D::get_instancer);
@@ -1343,6 +1352,7 @@ void Terrain3D::_bind_methods() {
 
 	ADD_PROPERTY(PropertyInfo(Variant::STRING, "version", PROPERTY_HINT_NONE, "", PROPERTY_USAGE_EDITOR | PROPERTY_USAGE_READ_ONLY), "", "get_version");
 	ADD_PROPERTY(PropertyInfo(Variant::STRING, "storage_directory", PROPERTY_HINT_DIR), "set_storage_directory", "get_storage_directory");
+	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "save_16_bit", PROPERTY_HINT_NONE), "set_save_16_bit", "get_save_16_bit");
 	ADD_PROPERTY(PropertyInfo(Variant::OBJECT, "material", PROPERTY_HINT_RESOURCE_TYPE, "Terrain3DMaterial"), "set_material", "get_material");
 	ADD_PROPERTY(PropertyInfo(Variant::OBJECT, "assets", PROPERTY_HINT_RESOURCE_TYPE, "Terrain3DAssets"), "set_assets", "get_assets");
 	ADD_PROPERTY(PropertyInfo(Variant::OBJECT, "instancer", PROPERTY_HINT_NONE, "Terrain3DInstancer", PROPERTY_USAGE_NONE), "", "get_instancer");

--- a/src/terrain_3d.cpp
+++ b/src/terrain_3d.cpp
@@ -415,17 +415,17 @@ void Terrain3D::_update_collision() {
 		Ref<Image> cmap, cmap_x, cmap_z, cmap_xz;
 		map = _storage->get_map_region(TYPE_HEIGHT, i);
 		cmap = _storage->get_map_region(TYPE_CONTROL, i);
-		int region_id = _storage->get_region_id(Vector3(global_pos.x + region_size, 0.f, global_pos.z) * _mesh_vertex_spacing);
+		int region_id = _storage->get_region_idp(Vector3(global_pos.x + region_size, 0.f, global_pos.z) * _mesh_vertex_spacing);
 		if (region_id >= 0) {
 			map_x = _storage->get_map_region(TYPE_HEIGHT, region_id);
 			cmap_x = _storage->get_map_region(TYPE_CONTROL, region_id);
 		}
-		region_id = _storage->get_region_id(Vector3(global_pos.x, 0.f, global_pos.z + region_size) * _mesh_vertex_spacing);
+		region_id = _storage->get_region_idp(Vector3(global_pos.x, 0.f, global_pos.z + region_size) * _mesh_vertex_spacing);
 		if (region_id >= 0) {
 			map_z = _storage->get_map_region(TYPE_HEIGHT, region_id);
 			cmap_z = _storage->get_map_region(TYPE_CONTROL, region_id);
 		}
-		region_id = _storage->get_region_id(Vector3(global_pos.x + region_size, 0.f, global_pos.z + region_size) * _mesh_vertex_spacing);
+		region_id = _storage->get_region_idp(Vector3(global_pos.x + region_size, 0.f, global_pos.z + region_size) * _mesh_vertex_spacing);
 		if (region_id >= 0) {
 			map_xz = _storage->get_map_region(TYPE_HEIGHT, region_id);
 			cmap_xz = _storage->get_map_region(TYPE_CONTROL, region_id);

--- a/src/terrain_3d.cpp
+++ b/src/terrain_3d.cpp
@@ -39,7 +39,6 @@ void Terrain3D::_initialize() {
 	if (_storage == nullptr) {
 		LOG(DEBUG, "Creating blank storage");
 		_storage = memnew(Terrain3DStorage);
-		_storage->set_version(Terrain3DStorage::CURRENT_VERSION);
 	}
 	if (_assets.is_null()) {
 		LOG(DEBUG, "Creating blank texture list");
@@ -694,7 +693,6 @@ void Terrain3D::set_storage_directory(String p_dir) {
 	if (_storage == nullptr) {
 		LOG(DEBUG, "Creating blank storage");
 		_storage = memnew(Terrain3DStorage);
-		_storage->set_version(Terrain3DStorage::CURRENT_VERSION);
 		_storage->initialize(this);
 	}
 	if (_storage_directory != p_dir) {

--- a/src/terrain_3d.cpp
+++ b/src/terrain_3d.cpp
@@ -1407,6 +1407,7 @@ void Terrain3D::_bind_methods() {
 	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "save_16_bit", PROPERTY_HINT_NONE), "set_save_16_bit", "get_save_16_bit");
 	ADD_PROPERTY(PropertyInfo(Variant::OBJECT, "material", PROPERTY_HINT_RESOURCE_TYPE, "Terrain3DMaterial"), "set_material", "get_material");
 	ADD_PROPERTY(PropertyInfo(Variant::OBJECT, "assets", PROPERTY_HINT_RESOURCE_TYPE, "Terrain3DAssets"), "set_assets", "get_assets");
+	ADD_PROPERTY(PropertyInfo(Variant::OBJECT, "storage", PROPERTY_HINT_NONE, "Terrain3DStorage", PROPERTY_USAGE_NONE), "", "get_storage");
 	ADD_PROPERTY(PropertyInfo(Variant::OBJECT, "instancer", PROPERTY_HINT_NONE, "Terrain3DInstancer", PROPERTY_USAGE_NONE), "", "get_instancer");
 
 	ADD_GROUP("Renderer", "render_");

--- a/src/terrain_3d.h
+++ b/src/terrain_3d.h
@@ -24,12 +24,24 @@ class Terrain3D : public Node3D {
 	GDCLASS(Terrain3D, Node3D);
 	CLASS_NAME();
 
+public: // Constants
+	enum RegionSize {
+		//SIZE_64 = 64,
+		//SIZE_128 = 128,
+		//SIZE_256 = 256,
+		//SIZE_512 = 512,
+		SIZE_1024 = 1024,
+		//SIZE_2048 = 2048,
+	};
+
+private:
 	// Terrain state
 	String _version = "0.9.3-dev";
 	bool _is_inside_world = false;
 	bool _initialized = false;
 
 	// Terrain settings
+	RegionSize _region_size = SIZE_1024;
 	int _mesh_size = 48;
 	int _mesh_lods = 7;
 	real_t _mesh_vertex_spacing = 1.0f;
@@ -122,6 +134,8 @@ public:
 	String get_version() const { return _version; }
 	void set_debug_level(const int p_level);
 	int get_debug_level() const { return debug_level; }
+	void set_region_size(const RegionSize p_size);
+	RegionSize get_region_size() const { return _region_size; }
 	void set_mesh_lods(const int p_count);
 	int get_mesh_lods() const { return _mesh_lods; }
 	void set_mesh_size(const int p_size);
@@ -199,5 +213,7 @@ protected:
 	void _notification(const int p_what);
 	static void _bind_methods();
 };
+
+VARIANT_ENUM_CAST(Terrain3D::RegionSize);
 
 #endif // TERRAIN3D_CLASS_H

--- a/src/terrain_3d.h
+++ b/src/terrain_3d.h
@@ -34,6 +34,7 @@ class Terrain3D : public Node3D {
 	int _mesh_lods = 7;
 	real_t _mesh_vertex_spacing = 1.0f;
 	String _storage_directory;
+	bool _save_16_bit = false;
 
 	Terrain3DStorage *_storage = nullptr;
 	Ref<Terrain3DMaterial> _material;
@@ -120,6 +121,8 @@ public:
 	real_t get_mesh_vertex_spacing() const { return _mesh_vertex_spacing; }
 	void set_storage_directory(String p_dir);
 	String get_storage_directory() const;
+	void set_save_16_bit(const bool p_enabled);
+	bool get_save_16_bit() const { return _save_16_bit; }
 
 	void set_storage(Terrain3DStorage *p_storage);
 	Terrain3DStorage *get_storage() const { return _storage; }

--- a/src/terrain_3d.h
+++ b/src/terrain_3d.h
@@ -49,7 +49,7 @@ class Terrain3D : public Node3D {
 	uint64_t _camera_instance_id = 0;
 
 	// X,Z Position of the camera during the previous snapping. Set to max real_t value to force a snap update.
-	Vector2 _camera_last_position = Vector2(__FLT_MAX__, __FLT_MAX__);
+	Vector2 _camera_last_position = V2_MAX;
 
 	// Meshes and Mesh instances
 	Vector<RID> _meshes;

--- a/src/terrain_3d.h
+++ b/src/terrain_3d.h
@@ -124,7 +124,6 @@ public:
 	void set_save_16_bit(const bool p_enabled);
 	bool get_save_16_bit() const { return _save_16_bit; }
 
-	void set_storage(Terrain3DStorage *p_storage);
 	Terrain3DStorage *get_storage() const { return _storage; }
 	void set_material(const Ref<Terrain3DMaterial> &p_material);
 	Ref<Terrain3DMaterial> get_material() const { return _material; }

--- a/src/terrain_3d.h
+++ b/src/terrain_3d.h
@@ -173,7 +173,7 @@ public:
 	Ref<Mesh> bake_mesh(const int p_lod, const Terrain3DStorage::HeightFilter p_filter = Terrain3DStorage::HEIGHT_FILTER_NEAREST) const;
 	PackedVector3Array generate_nav_mesh_source_geometry(const AABB &p_global_aabb, const bool p_require_nav = true) const;
 
-	// Misc
+	// Godot Callbacks
 	PackedStringArray _get_configuration_warnings() const override;
 
 	// DEPRECATED 0.9.2 - Remove 0.9.3+

--- a/src/terrain_3d.h
+++ b/src/terrain_3d.h
@@ -35,12 +35,17 @@ class Terrain3D : public Node3D {
 	real_t _mesh_vertex_spacing = 1.0f;
 	String _storage_directory;
 	bool _save_16_bit = false;
+	bool _show_region_labels = false;
 
 	Terrain3DStorage *_storage = nullptr;
 	Ref<Terrain3DMaterial> _material;
 	Ref<Terrain3DAssets> _assets;
 	Terrain3DInstancer *_instancer = nullptr;
 	Terrain3DEditor *_editor = nullptr;
+
+	// Parent containers for child nodes
+	Node *_label_nodes;
+	Node *_mmi_nodes;
 
 	// Editor components
 	EditorPlugin *_plugin = nullptr;
@@ -84,6 +89,10 @@ class Terrain3D : public Node3D {
 	void _initialize();
 	void __process(const double p_delta);
 
+	void _build_containers();
+	void _destroy_containers();
+	void _destroy_labels();
+
 	void _setup_mouse_picking();
 	void _destroy_mouse_picking();
 	void _grab_camera();
@@ -119,12 +128,13 @@ public:
 	int get_mesh_size() const { return _mesh_size; }
 	void set_mesh_vertex_spacing(const real_t p_spacing);
 	real_t get_mesh_vertex_spacing() const { return _mesh_vertex_spacing; }
+
+	Terrain3DStorage *get_storage() const { return _storage; }
 	void set_storage_directory(String p_dir);
 	String get_storage_directory() const;
 	void set_save_16_bit(const bool p_enabled);
 	bool get_save_16_bit() const { return _save_16_bit; }
 
-	Terrain3DStorage *get_storage() const { return _storage; }
 	void set_material(const Ref<Terrain3DMaterial> &p_material);
 	Ref<Terrain3DMaterial> get_material() const { return _material; }
 	void set_assets(const Ref<Terrain3DAssets> &p_assets);
@@ -132,6 +142,7 @@ public:
 
 	// Instancer
 	Terrain3DInstancer *get_instancer() const { return _instancer; }
+	Node *get_mmi_parent() const { return _mmi_nodes; }
 
 	// Editor components
 	void set_editor(Terrain3DEditor *p_editor);
@@ -168,6 +179,10 @@ public:
 	void snap(const Vector3 &p_cam_pos);
 	void update_aabbs();
 	Vector3 get_intersection(const Vector3 &p_src_pos, const Vector3 &p_direction);
+
+	void set_show_region_labels(const bool p_enabled);
+	bool get_show_region_labels() const { return _show_region_labels; }
+	void update_region_labels();
 
 	// Baking methods
 	Ref<Mesh> bake_mesh(const int p_lod, const Terrain3DStorage::HeightFilter p_filter = Terrain3DStorage::HEIGHT_FILTER_NEAREST) const;

--- a/src/terrain_3d.h
+++ b/src/terrain_3d.h
@@ -33,9 +33,10 @@ class Terrain3D : public Node3D {
 	int _mesh_size = 48;
 	int _mesh_lods = 7;
 	real_t _mesh_vertex_spacing = 1.0f;
+	String _storage_directory;
 
+	Terrain3DStorage *_storage = nullptr;
 	Ref<Terrain3DMaterial> _material;
-	Ref<Terrain3DStorage> _storage;
 	Ref<Terrain3DAssets> _assets;
 	Terrain3DInstancer *_instancer = nullptr;
 	Terrain3DEditor *_editor = nullptr;
@@ -117,11 +118,13 @@ public:
 	int get_mesh_size() const { return _mesh_size; }
 	void set_mesh_vertex_spacing(const real_t p_spacing);
 	real_t get_mesh_vertex_spacing() const { return _mesh_vertex_spacing; }
+	void set_storage_directory(String p_dir);
+	String get_storage_directory() const;
 
+	void set_storage(Terrain3DStorage *p_storage);
+	Terrain3DStorage *get_storage() const { return _storage; }
 	void set_material(const Ref<Terrain3DMaterial> &p_material);
 	Ref<Terrain3DMaterial> get_material() const { return _material; }
-	void set_storage(const Ref<Terrain3DStorage> &p_storage);
-	Ref<Terrain3DStorage> get_storage() const { return _storage; }
 	void set_assets(const Ref<Terrain3DAssets> &p_assets);
 	Ref<Terrain3DAssets> get_assets() const { return _assets; }
 

--- a/src/terrain_3d_asset_resource.h
+++ b/src/terrain_3d_asset_resource.h
@@ -15,8 +15,8 @@ class Terrain3DAssetResource : public Resource {
 	friend class Terrain3DAssets;
 
 public:
-	Terrain3DAssetResource(){};
-	~Terrain3DAssetResource(){};
+	Terrain3DAssetResource() {}
+	~Terrain3DAssetResource() {}
 
 	virtual void clear() = 0;
 	virtual void set_name(const String &p_name) = 0;

--- a/src/terrain_3d_assets.cpp
+++ b/src/terrain_3d_assets.cpp
@@ -166,8 +166,8 @@ void Terrain3DAssets::_update_texture_files() {
 	// Detect image sizes and formats
 
 	LOG(INFO, "Validating texture sizes");
-	Vector2i albedo_size = Vector2i(0, 0);
-	Vector2i normal_size = Vector2i(0, 0);
+	Vector2i albedo_size = V2I_ZERO;
+	Vector2i normal_size = V2I_ZERO;
 
 	Image::Format albedo_format = Image::FORMAT_MAX;
 	Image::Format normal_format = Image::FORMAT_MAX;
@@ -221,19 +221,19 @@ void Terrain3DAssets::_update_texture_files() {
 		}
 	}
 
-	if (normal_size == Vector2i(0, 0)) {
+	if (normal_size == V2I_ZERO) {
 		normal_size = albedo_size;
-	} else if (albedo_size == Vector2i(0, 0)) {
+	} else if (albedo_size == V2I_ZERO) {
 		albedo_size = normal_size;
 	}
-	if (albedo_size == Vector2i(0, 0)) {
+	if (albedo_size == V2I_ZERO) {
 		albedo_size = Vector2i(1024, 1024);
 		normal_size = Vector2i(1024, 1024);
 	}
 
 	// Generate TextureArrays and replace nulls with a empty image
 
-	if (_generated_albedo_textures.is_dirty() && albedo_size != Vector2i(0, 0)) {
+	if (_generated_albedo_textures.is_dirty() && albedo_size != V2I_ZERO) {
 		LOG(INFO, "Regenerating albedo texture array");
 		Array albedo_texture_array;
 		for (int i = 0; i < _texture_list.size(); i++) {
@@ -259,7 +259,7 @@ void Terrain3DAssets::_update_texture_files() {
 		}
 	}
 
-	if (_generated_normal_textures.is_dirty() && normal_size != Vector2i(0, 0)) {
+	if (_generated_normal_textures.is_dirty() && normal_size != V2I_ZERO) {
 		LOG(INFO, "Regenerating normal texture arrays");
 
 		Array normal_texture_array;

--- a/src/terrain_3d_editor.cpp
+++ b/src/terrain_3d_editor.cpp
@@ -38,7 +38,8 @@ Ref<Terrain3DRegion> Terrain3DEditor::_operate_region(const Vector2i &p_region_l
 	}
 	if (storage->get_region_map_index(p_region_loc) < 0) {
 		if (can_print) {
-			LOG(ERROR, "Specified position outside of maximum bounds");
+			LOG(ERROR, "Location ", p_region_loc, " out of bounds. Max: ",
+					-Terrain3DStorage::REGION_MAP_SIZE / 2, " to ", Terrain3DStorage::REGION_MAP_SIZE / 2 - 1);
 		}
 		return Ref<Terrain3DRegion>();
 	}
@@ -447,6 +448,13 @@ void Terrain3DEditor::_operate_map(const Vector3 &p_global_position, const real_
 				backup_region(region);
 				map->set_pixelv(map_pixel_position, dest);
 			}
+		}
+	}
+	// Regenerate color mipmaps for edited regions
+	if (map_type == TYPE_COLOR) {
+		for (int i = 0; i < _edited_regions.size(); i++) {
+			Ref<Terrain3DRegion> region = _edited_regions[i];
+			region->get_map(map_type)->generate_mipmaps();
 		}
 	}
 	storage->force_update_maps(map_type);

--- a/src/terrain_3d_editor.cpp
+++ b/src/terrain_3d_editor.cpp
@@ -14,7 +14,7 @@
 
 // Sends the whole region aabb to edited_area
 void Terrain3DEditor::_send_region_aabb(const Vector2i &p_region_loc, const Vector2 &p_height_range) {
-	Terrain3DStorage::RegionSize region_size = _terrain->get_storage()->get_region_size();
+	Terrain3D::RegionSize region_size = _terrain->get_region_size();
 	AABB edited_area;
 	edited_area.position = Vector3(p_region_loc.x * region_size, p_height_range.x, p_region_loc.y * region_size);
 	edited_area.size = Vector3(region_size, p_height_range.y - p_height_range.x, region_size);
@@ -94,11 +94,11 @@ void Terrain3DEditor::_operate_map(const Vector3 &p_global_position, const real_
 		return;
 	}
 
-	Terrain3DStorage *storage = _terrain->get_storage();
-	int region_size = storage->get_region_size();
+	int region_size = _terrain->get_region_size();
 	Vector2i region_vsize = Vector2i(region_size, region_size);
 
 	// If no region and can't add one, skip whole function. Checked again later
+	Terrain3DStorage *storage = _terrain->get_storage();
 	if (!storage->has_regionp(p_global_position) && (!_brush_data["auto_regions"] || _tool != HEIGHT)) {
 		return;
 	}

--- a/src/terrain_3d_editor.cpp
+++ b/src/terrain_3d_editor.cpp
@@ -79,8 +79,8 @@ void Terrain3DEditor::_operate_map(const Vector3 &p_global_position, const real_
 	int region_size = storage->get_region_size();
 	Vector2i region_vsize = Vector2i(region_size, region_size);
 
-	// If no region and not height, skip whole function
-	if (storage->has_regionp(p_global_position) && (!_brush_data["auto_regions"] || _tool != HEIGHT)) {
+	// If no region and not height, skip whole function. Checked again later
+	if (!storage->has_regionp(p_global_position) && (!_brush_data["auto_regions"] || _tool != HEIGHT)) {
 		return;
 	}
 
@@ -449,6 +449,7 @@ void Terrain3DEditor::_operate_map(const Vector3 &p_global_position, const real_
 
 Dictionary Terrain3DEditor::_get_undo_data() const {
 	Dictionary data;
+	return data; // ignore undo for now
 	if (_tool < 0 || _tool >= TOOL_MAX) {
 		return data;
 	}
@@ -489,7 +490,7 @@ Dictionary Terrain3DEditor::_get_undo_data() const {
 
 		case HOLES:
 			// Holes can remove instances
-			data["multimeshes"] = _terrain->get_storage()->get_multimeshes().duplicate(true);
+			//data["multimeshes"] = _terrain->get_storage()->get_multimeshes().duplicate(true);
 			LOG(DEBUG, "Storing Multimesh: ", data["multimeshes"]);
 		case TEXTURE:
 		case AUTOSHADER:
@@ -505,7 +506,7 @@ Dictionary Terrain3DEditor::_get_undo_data() const {
 			break;
 
 		case INSTANCER:
-			data["multimeshes"] = _terrain->get_storage()->get_multimeshes().duplicate(true);
+			//data["multimeshes"] = _terrain->get_storage()->get_multimeshes().duplicate(true);
 			LOG(DEBUG, "Storing Multimesh: ", data["multimeshes"]);
 			break;
 
@@ -622,18 +623,18 @@ void Terrain3DEditor::_apply_undo(const Dictionary &p_set) {
 			if (key == "region_locations") {
 				_terrain->get_storage()->set_region_locations(p_set[key]);
 			} else if (key == "height_map") {
-				_terrain->get_storage()->set_maps(TYPE_HEIGHT, p_set[key], e_regions);
+				//_terrain->get_storage()->set_maps(TYPE_HEIGHT, p_set[key], e_regions);
 			} else if (key == "control_map") {
-				_terrain->get_storage()->set_maps(TYPE_CONTROL, p_set[key], e_regions);
+				//_terrain->get_storage()->set_maps(TYPE_CONTROL, p_set[key], e_regions);
 			} else if (key == "color_map") {
-				_terrain->get_storage()->set_maps(TYPE_COLOR, p_set[key], e_regions);
+				//_terrain->get_storage()->set_maps(TYPE_COLOR, p_set[key], e_regions);
 			} else if (key == "height_range") {
 				//_terrain->get_storage()->set_height_range(p_set[key]);
 			} else if (key == "edited_area") {
 				_terrain->get_storage()->clear_edited_area();
 				_terrain->get_storage()->add_edited_area(p_set[key]);
 			} else if (key == "multimeshes") {
-				_terrain->get_storage()->set_multimeshes(p_set[key], e_regions);
+				//_terrain->get_storage()->set_multimeshes(p_set[key], e_regions);
 			}
 		}
 	}

--- a/src/terrain_3d_editor.cpp
+++ b/src/terrain_3d_editor.cpp
@@ -531,7 +531,7 @@ void Terrain3DEditor::_apply_undo(const Dictionary &p_data) {
 				LOG(ERROR, "Null region saved in undo data. Please report this error.");
 				continue;
 			}
-			region->sanitize_map(); // Live data may not have some maps so must be sanitized
+			region->sanitize_maps(); // Live data may not have some maps so must be sanitized
 			Dictionary regions = storage->get_regions_all();
 			regions[region->get_location()] = region;
 			region->set_modified(true);

--- a/src/terrain_3d_editor.cpp
+++ b/src/terrain_3d_editor.cpp
@@ -465,7 +465,7 @@ Dictionary Terrain3DEditor::_get_undo_data() const {
 	TypedArray<int> e_regions;
 	Array regions = _terrain->get_storage()->get_regions().values();
 	for (int i = 0; i < regions.size(); i++) {
-		bool is_modified = static_cast<Ref<Terrain3DStorage::Terrain3DRegion>>(regions[i])->is_modified();
+		bool is_modified = static_cast<Ref<Terrain3DRegion>>(regions[i])->is_modified();
 		if (is_modified) {
 			e_regions.push_back(i);
 		}
@@ -571,7 +571,7 @@ void Terrain3DEditor::_apply_undo(const Dictionary &p_set) {
 			TypedArray<int> current;
 			Array regions = _terrain->get_storage()->get_regions().values();
 			for (int i = 0; i < regions.size(); i++) {
-				bool is_modified = static_cast<Ref<Terrain3DStorage::Terrain3DRegion>>(regions[i])->is_modified();
+				bool is_modified = static_cast<Ref<Terrain3DRegion>>(regions[i])->is_modified();
 				if (is_modified) {
 					current.push_back(i);
 				}
@@ -593,7 +593,7 @@ void Terrain3DEditor::_apply_undo(const Dictionary &p_set) {
 			TypedArray<int> current;
 			Array regions = _terrain->get_storage()->get_regions().values();
 			for (int i = 0; i < regions.size(); i++) {
-				bool is_modified = static_cast<Ref<Terrain3DStorage::Terrain3DRegion>>(regions[i])->is_modified();
+				bool is_modified = static_cast<Ref<Terrain3DRegion>>(regions[i])->is_modified();
 				if (is_modified) {
 					current.push_back(i);
 				}

--- a/src/terrain_3d_editor.cpp
+++ b/src/terrain_3d_editor.cpp
@@ -464,10 +464,10 @@ Dictionary Terrain3DEditor::_get_undo_data() const {
 	}
 
 	TypedArray<int> e_regions;
-	for (size_t i = 0; i < _terrain->get_storage()->get_region_count(); i++) {
+	for (int i = 0; i < _terrain->get_storage()->get_region_count(); i++) {
 		bool is_modified = _terrain->get_storage()->get_modified()[i];
 		if (is_modified) {
-			e_regions.append(i);
+			e_regions.push_back(i);
 		}
 	}
 
@@ -569,44 +569,44 @@ void Terrain3DEditor::_apply_undo(const Dictionary &p_set) {
 			LOG(DEBUG, "Removing region...");
 
 			TypedArray<int> current;
-			for (size_t i = 0; i < _terrain->get_storage()->get_region_count(); i++) {
+			for (int i = 0; i < _terrain->get_storage()->get_region_count(); i++) {
 				bool is_modified = _terrain->get_storage()->get_modified()[i];
 				if (is_modified) {
-					current.append(i);
+					current.push_back(i);
 				}
 			}
 
 			TypedArray<int> diff;
 
-			for (size_t i = 0; i < current.size(); i++) {
+			for (int i = 0; i < current.size(); i++) {
 				if (!regions.has(current[i])) {
-					diff.append(current[i]);
+					diff.push_back(current[i]);
 				}
 			}
 
-			for (size_t i = 0; i < diff.size(); i++) {
+			for (int i = 0; i < diff.size(); i++) {
 				_terrain->get_storage()->remove_region(diff[i]);
 			}
 		} else {
 			// Add region
 			TypedArray<int> current;
-			for (size_t i = 0; i < _terrain->get_storage()->get_region_count(); i++) {
+			for (int i = 0; i < _terrain->get_storage()->get_region_count(); i++) {
 				bool is_modified = _terrain->get_storage()->get_modified()[i];
 				if (is_modified) {
-					current.append(i);
+					current.push_back(i);
 				}
 			}
 
 			TypedArray<int> diff;
 
-			for (size_t i = 0; i < current.size(); i++) {
+			for (int i = 0; i < current.size(); i++) {
 				if (!regions.has(current[i])) {
-					diff.append(current[i]);
+					diff.push_back(current[i]);
 				}
 			}
 
 			LOG(DEBUG, "Re-adding regions...");
-			for (size_t i = 0; i < diff.size(); i++) {
+			for (int i = 0; i < diff.size(); i++) {
 				Vector2i new_region = ((TypedArray<Vector2i>)p_set["region_locations"])[regions[0]];
 				int size = _terrain->get_storage()->get_region_size();
 				Vector3 new_region_position = Vector3(new_region.x * size, 0, new_region.y * size);
@@ -644,7 +644,7 @@ void Terrain3DEditor::_apply_undo(const Dictionary &p_set) {
 
 	_terrain->get_storage()->clear_modified();
 	// Roll back to previous modified state
-	for (size_t i = 0; i < regions.size(); i++) {
+	for (int i = 0; i < regions.size(); i++) {
 		_terrain->get_storage()->set_modified(i);
 	}
 
@@ -754,7 +754,7 @@ void Terrain3DEditor::operate(const Vector3 &p_global_position, const real_t p_c
 
 	// Convolve the last 8 movement events, we dont clear on mouse release
 	// so as to make repeated mouse strokes in the same direction consistent
-	_operation_movement_history.append(_operation_movement);
+	_operation_movement_history.push_back(_operation_movement);
 	if (_operation_movement_history.size() > 8) {
 		_operation_movement_history.pop_front();
 	}

--- a/src/terrain_3d_editor.cpp
+++ b/src/terrain_3d_editor.cpp
@@ -27,7 +27,7 @@ void Terrain3DEditor::_region_modified(const Vector3 &p_global_position, const V
 }
 
 void Terrain3DEditor::_operate_region(const Vector3 &p_global_position) {
-	bool has_region = _terrain->get_storage()->has_region(p_global_position);
+	bool has_region = _terrain->get_storage()->has_regionp(p_global_position);
 	bool changed = false;
 	Vector2 height_range;
 
@@ -38,7 +38,7 @@ void Terrain3DEditor::_operate_region(const Vector3 &p_global_position) {
 		}
 	} else {
 		if (has_region) {
-			int region_id = _terrain->get_storage()->get_region_id(p_global_position);
+			int region_id = _terrain->get_storage()->get_region_idp(p_global_position);
 			Ref<Image> height_map = _terrain->get_storage()->get_map_region(TYPE_HEIGHT, region_id);
 			height_range = Util::get_min_max(height_map);
 
@@ -57,7 +57,7 @@ void Terrain3DEditor::_operate_map(const Vector3 &p_global_position, const real_
 	Terrain3DStorage *storage = _terrain->get_storage();
 	int region_size = storage->get_region_size();
 	Vector2i region_vsize = Vector2i(region_size, region_size);
-	int region_id = storage->get_region_id(p_global_position);
+	int region_id = storage->get_region_idp(p_global_position);
 	if (region_id == -1) {
 		if (!_brush_data["auto_regions"] || _tool != HEIGHT) {
 			return;
@@ -65,7 +65,7 @@ void Terrain3DEditor::_operate_map(const Vector3 &p_global_position, const real_
 			LOG(DEBUG, "No region to operate on, attempting to add");
 			storage->add_region(p_global_position);
 			region_size = storage->get_region_size();
-			region_id = storage->get_region_id(p_global_position);
+			region_id = storage->get_region_idp(p_global_position);
 			if (region_id == -1) {
 				LOG(ERROR, "Failed to add region, no region to operate on");
 				return;
@@ -173,7 +173,7 @@ void Terrain3DEditor::_operate_map(const Vector3 &p_global_position, const real_
 							p_global_position.z + brush_offset.y + .5f);
 
 			// If we're brushing across a region boundary, possibly add a region, and get the other map
-			int new_region_id = storage->get_region_id(brush_global_position);
+			int new_region_id = storage->get_region_idp(brush_global_position);
 			if (new_region_id == -1) {
 				if (!_brush_data["auto_regions"] || _tool != HEIGHT) {
 					continue;
@@ -182,7 +182,7 @@ void Terrain3DEditor::_operate_map(const Vector3 &p_global_position, const real_
 				if (err) {
 					continue;
 				}
-				new_region_id = storage->get_region_id(brush_global_position);
+				new_region_id = storage->get_region_idp(brush_global_position);
 				_region_modified(brush_global_position);
 			}
 

--- a/src/terrain_3d_editor.h
+++ b/src/terrain_3d_editor.h
@@ -7,6 +7,7 @@
 #include <godot_cpp/classes/image_texture.hpp>
 
 #include "terrain_3d.h"
+#include "terrain_3d_region.h"
 
 using namespace godot;
 
@@ -73,22 +74,25 @@ private:
 	Vector3 _operation_position = Vector3();
 	Vector3 _operation_movement = Vector3();
 	Array _operation_movement_history;
-	bool _pending_undo = false; // Undo created on each click
-	bool _modified = false; // Tracks if any region is actually modified
+	bool _is_operating = false;
+	uint64_t _last_region_bounds_error = 0;
+	TypedArray<Terrain3DRegion> _original_regions; // Queue for undo
+	TypedArray<Terrain3DRegion> _edited_regions; // Queue for redo
+	TypedArray<Vector2i> _added_removed_locations; // Queue for added/removed locations
 	AABB _modified_area;
 	Dictionary _undo_data; // See _get_undo_data for definition
 	uint64_t _last_pen_tick = 0;
 
 	void _send_region_aabb(const Vector2i &p_region_loc, const Vector2 &p_height_range = Vector2());
-	void _operate_region(const Vector3 &p_global_position);
+	Ref<Terrain3DRegion> _operate_region(const Vector2i &p_region_loc);
 	void _operate_map(const Vector3 &p_global_position, const real_t p_camera_direction);
+	MapType _get_map_type() const;
 	bool _is_in_bounds(const Vector2i &p_position, const Vector2i &p_max_position) const;
 	Vector2 _get_uv_position(const Vector3 &p_global_position, const int p_region_size, const real_t p_vertex_spacing) const;
 	Vector2 _get_rotated_uv(const Vector2 &p_uv, const real_t p_angle) const;
 
-	Dictionary _get_undo_data() const;
 	void _store_undo();
-	void _apply_undo(const Dictionary &p_set);
+	void _apply_undo(const Dictionary &p_data);
 
 public:
 	Terrain3DEditor() {}
@@ -104,9 +108,10 @@ public:
 	Operation get_operation() const { return _operation; }
 
 	void start_operation(const Vector3 &p_global_position);
+	bool is_operating() const { return _is_operating; }
 	void operate(const Vector3 &p_global_position, const real_t p_camera_direction);
+	void backup_region(const Ref<Terrain3DRegion> &p_region);
 	void stop_operation();
-	bool is_operating() const { return _pending_undo; }
 
 protected:
 	static void _bind_methods();
@@ -116,6 +121,29 @@ VARIANT_ENUM_CAST(Terrain3DEditor::Operation);
 VARIANT_ENUM_CAST(Terrain3DEditor::Tool);
 
 /// Inline functions
+
+inline MapType Terrain3DEditor::_get_map_type() const {
+	switch (_tool) {
+		case HEIGHT:
+		case INSTANCER:
+			return TYPE_HEIGHT;
+			break;
+		case TEXTURE:
+		case AUTOSHADER:
+		case HOLES:
+		case NAVIGATION:
+		case ANGLE:
+		case SCALE:
+			return TYPE_CONTROL;
+			break;
+		case COLOR:
+		case ROUGHNESS:
+			return TYPE_COLOR;
+			break;
+		default:
+			return TYPE_MAX;
+	}
+}
 
 inline bool Terrain3DEditor::_is_in_bounds(const Vector2i &p_position, const Vector2i &p_max_position) const {
 	bool more_than_min = p_position.x >= 0 && p_position.y >= 0;
@@ -134,7 +162,7 @@ inline Vector2 Terrain3DEditor::_get_uv_position(const Vector3 &p_global_positio
 inline Vector2 Terrain3DEditor::_get_rotated_uv(const Vector2 &p_uv, const real_t p_angle) const {
 	Vector2 rotation_offset = Vector2(0.5f, 0.5f);
 	Vector2 uv = (p_uv - rotation_offset).rotated(p_angle) + rotation_offset;
-	return uv.clamp(Vector2(0.f, 0.f), Vector2(1.f, 1.f));
+	return uv.clamp(V2_ZERO, Vector2(1.f, 1.f));
 }
 
 #endif // TERRAIN3D_EDITOR_CLASS_H

--- a/src/terrain_3d_editor.h
+++ b/src/terrain_3d_editor.h
@@ -73,13 +73,13 @@ private:
 	Vector3 _operation_position = Vector3();
 	Vector3 _operation_movement = Vector3();
 	Array _operation_movement_history;
-	bool _pending_undo = false;
-	bool _modified = false;
+	bool _pending_undo = false; // Undo created on each click
+	bool _modified = false; // Tracks if any region is actually modified
 	AABB _modified_area;
 	Dictionary _undo_data; // See _get_undo_data for definition
 	uint64_t _last_pen_tick = 0;
 
-	void _region_modified(const Vector3 &p_global_position, const Vector2 &p_height_range = Vector2());
+	void _send_region_aabb(const Vector2i &p_region_loc, const Vector2 &p_height_range = Vector2());
 	void _operate_region(const Vector3 &p_global_position);
 	void _operate_map(const Vector3 &p_global_position, const real_t p_camera_direction);
 	bool _is_in_bounds(const Vector2i &p_position, const Vector2i &p_max_position) const;

--- a/src/terrain_3d_instancer.cpp
+++ b/src/terrain_3d_instancer.cpp
@@ -482,7 +482,7 @@ void Terrain3DInstancer::update_transforms(const AABB &p_aabb) {
 			LOG(WARN, "No region found at: ", region_loc);
 			continue;
 		}
-		int region_size = _terrain->get_storage()->get_region_size();
+		int region_size = _terrain->get_region_size();
 		Rect2 region_rect;
 		region_rect.set_position(region_loc * region_size);
 		region_rect.set_size(Vector2(region_size, region_size));

--- a/src/terrain_3d_instancer.cpp
+++ b/src/terrain_3d_instancer.cpp
@@ -282,11 +282,11 @@ void Terrain3DInstancer::add_instances(const Vector3 &p_global_position, const D
 	}
 
 	// Append multimesh
+	Vector2i region_loc = _terrain->get_storage()->get_region_location(p_global_position);
 	if (xforms.size() > 0) {
-		Vector2i region_loc = _terrain->get_storage()->get_region_location(p_global_position);
 		append_multimesh(region_loc, mesh_id, xforms, colors);
 	}
-	_terrain->get_storage()->set_modified(_terrain->get_storage()->get_region_id(p_global_position));
+	_terrain->get_storage()->set_region_modified(region_loc, true);
 }
 
 void Terrain3DInstancer::remove_instances(const Vector3 &p_global_position, const Dictionary &p_params) {
@@ -344,7 +344,7 @@ void Terrain3DInstancer::remove_instances(const Vector3 &p_global_position, cons
 	} else {
 		append_multimesh(region_loc, mesh_id, xforms, colors, true);
 	}
-	_terrain->get_storage()->set_modified(_terrain->get_storage()->get_region_id(p_global_position));
+	_terrain->get_storage()->set_region_modified(region_loc, true);
 }
 
 void Terrain3DInstancer::add_multimesh(const int p_mesh_id, const Ref<MultiMesh> &p_multimesh, const Transform3D &p_xform) {
@@ -398,7 +398,7 @@ void Terrain3DInstancer::add_transforms(const int p_mesh_id, const TypedArray<Tr
 		xforms.push_back(trns);
 		colors.push_back(col);
 
-		_terrain->get_storage()->set_modified(_terrain->get_storage()->get_region_id(trns.origin)); // might be stupid
+		_terrain->get_storage()->set_region_modified(region_loc, true);
 	}
 
 	// Merge incoming transforms with existing transforms

--- a/src/terrain_3d_instancer.cpp
+++ b/src/terrain_3d_instancer.cpp
@@ -132,10 +132,6 @@ void Terrain3DInstancer::_destroy_mmi_by_location(const Vector2i &p_region_loc, 
 // Public Functions
 ///////////////////////////
 
-Terrain3DInstancer::~Terrain3DInstancer() {
-	destroy();
-}
-
 void Terrain3DInstancer::initialize(Terrain3D *p_terrain) {
 	if (p_terrain) {
 		_terrain = p_terrain;

--- a/src/terrain_3d_instancer.cpp
+++ b/src/terrain_3d_instancer.cpp
@@ -286,7 +286,7 @@ void Terrain3DInstancer::add_instances(const Vector3 &p_global_position, const D
 		Vector2i region_loc = _terrain->get_storage()->get_region_location(p_global_position);
 		append_multimesh(region_loc, mesh_id, xforms, colors);
 	}
-	_terrain->get_storage()->set_modified();
+	_terrain->get_storage()->set_modified(_terrain->get_storage()->get_region_id(p_global_position));
 }
 
 void Terrain3DInstancer::remove_instances(const Vector3 &p_global_position, const Dictionary &p_params) {
@@ -344,7 +344,7 @@ void Terrain3DInstancer::remove_instances(const Vector3 &p_global_position, cons
 	} else {
 		append_multimesh(region_loc, mesh_id, xforms, colors, true);
 	}
-	_terrain->get_storage()->set_modified();
+	_terrain->get_storage()->set_modified(_terrain->get_storage()->get_region_id(p_global_position));
 }
 
 void Terrain3DInstancer::add_multimesh(const int p_mesh_id, const Ref<MultiMesh> &p_multimesh, const Transform3D &p_xform) {
@@ -397,6 +397,8 @@ void Terrain3DInstancer::add_transforms(const int p_mesh_id, const TypedArray<Tr
 		TypedArray<Color> colors = colors_dict[region_loc];
 		xforms.push_back(trns);
 		colors.push_back(col);
+
+		_terrain->get_storage()->set_modified(_terrain->get_storage()->get_region_id(trns.origin)); // might be stupid
 	}
 
 	// Merge incoming transforms with existing transforms
@@ -408,8 +410,6 @@ void Terrain3DInstancer::add_transforms(const int p_mesh_id, const TypedArray<Tr
 		LOG(DEBUG, "Adding ", xforms.size(), " transforms to region location: ", region_loc);
 		append_multimesh(region_loc, p_mesh_id, xforms, colors);
 	}
-
-	_terrain->get_storage()->set_modified();
 }
 
 // Appends new transforms to existing multimeshes

--- a/src/terrain_3d_instancer.cpp
+++ b/src/terrain_3d_instancer.cpp
@@ -34,7 +34,7 @@ void Terrain3DInstancer::_update_mmis(const Vector2i &p_region_loc, const int p_
 
 	// For specified region_location, or max for all
 	Array region_locations;
-	if (p_region_loc == Vector2i(INT32_MAX, INT32_MAX)) {
+	if (p_region_loc.x == INT32_MAX) {
 		region_locations = region_dict.keys();
 	} else {
 		region_locations.push_back(p_region_loc);

--- a/src/terrain_3d_instancer.cpp
+++ b/src/terrain_3d_instancer.cpp
@@ -112,7 +112,7 @@ void Terrain3DInstancer::_update_mmis(const Vector2i &p_region_loc, const int p_
 }
 
 void Terrain3DInstancer::_destroy_mmi_by_region_id(const int p_region_id, const int p_mesh_id) {
-	Vector2i region_loc = _terrain->get_storage()->get_region_location_from_id(p_region_id);
+	Vector2i region_loc = _terrain->get_storage()->get_region_locationi(p_region_id);
 	_destroy_mmi_by_location(region_loc, p_mesh_id);
 }
 
@@ -161,7 +161,7 @@ void Terrain3DInstancer::clear_by_mesh(const int p_mesh_id) {
 }
 
 void Terrain3DInstancer::clear_by_region_id(const int p_region_id, const int p_mesh_id) {
-	Vector2i region_loc = _terrain->get_storage()->get_region_location_from_id(p_region_id);
+	Vector2i region_loc = _terrain->get_storage()->get_region_locationi(p_region_id);
 	clear_by_location(region_loc, p_mesh_id);
 }
 

--- a/src/terrain_3d_instancer.h
+++ b/src/terrain_3d_instancer.h
@@ -36,7 +36,7 @@ class Terrain3DInstancer : public Object {
 
 public:
 	Terrain3DInstancer() {}
-	~Terrain3DInstancer();
+	~Terrain3DInstancer() { destroy(); }
 
 	void initialize(Terrain3D *p_terrain);
 	void destroy();

--- a/src/terrain_3d_instancer.h
+++ b/src/terrain_3d_instancer.h
@@ -20,8 +20,8 @@ class Terrain3DInstancer : public Object {
 
 	Terrain3D *_terrain = nullptr;
 
-	// MM Resources stored in Terrain3DStorage::_multimeshes as
-	// Dictionary[region_location:Vector2i] -> Dictionary[mesh_id:int] -> MultiMesh
+	// MM Resources stored in Terrain3DRegion::_multimeshes as
+	// Dictionary[mesh_id:int] -> MultiMesh
 	// MMI Objects attached to tree, freed in destructor, stored as
 	// Dictionary[Vector3i(region_location.x, region_location.y, mesh_id)] -> MultiMeshInstance3D
 	Dictionary _mmis;
@@ -29,7 +29,6 @@ class Terrain3DInstancer : public Object {
 	uint32_t _instance_counter = 0;
 	int _get_instace_count(const real_t p_density);
 
-	void _rebuild_mmis();
 	void _update_mmis(const Vector2i &p_region_loc = V2I_MAX, const int p_mesh_id = -1);
 	void _destroy_mmi_by_region_id(const int p_region, const int p_mesh_id);
 	void _destroy_mmi_by_location(const Vector2i &p_region_loc, const int p_mesh_id);
@@ -60,6 +59,7 @@ public:
 	void set_cast_shadows(const int p_mesh_id, const GeometryInstance3D::ShadowCastingSetting p_cast_shadows);
 	void reset_instance_counter() { _instance_counter = 0; }
 
+	void force_update_mmis();
 	void print_multimesh_buffer(MultiMeshInstance3D *p_mmi) const;
 
 protected:

--- a/src/terrain_3d_instancer.h
+++ b/src/terrain_3d_instancer.h
@@ -32,6 +32,8 @@ class Terrain3DInstancer : public Object {
 	void _update_mmis(const Vector2i &p_region_loc = V2I_MAX, const int p_mesh_id = -1);
 	void _destroy_mmi_by_region_id(const int p_region, const int p_mesh_id);
 	void _destroy_mmi_by_location(const Vector2i &p_region_loc, const int p_mesh_id);
+	void _backup_regionl(const Vector2i &p_region_loc);
+	void _backup_region(const Ref<Terrain3DRegion> &p_region);
 
 public:
 	Terrain3DInstancer() {}

--- a/src/terrain_3d_instancer.h
+++ b/src/terrain_3d_instancer.h
@@ -30,7 +30,7 @@ class Terrain3DInstancer : public Object {
 	int _get_instace_count(const real_t p_density);
 
 	void _rebuild_mmis();
-	void _update_mmis(const Vector2i &p_region_loc = Vector2i(INT32_MAX, INT32_MAX), const int p_mesh_id = -1);
+	void _update_mmis(const Vector2i &p_region_loc = V2I_MAX, const int p_mesh_id = -1);
 	void _destroy_mmi_by_region_id(const int p_region, const int p_mesh_id);
 	void _destroy_mmi_by_location(const Vector2i &p_region_loc, const int p_mesh_id);
 

--- a/src/terrain_3d_material.cpp
+++ b/src/terrain_3d_material.cpp
@@ -320,7 +320,7 @@ void Terrain3DMaterial::_update_maps() {
 	LOG(DEBUG_CONT, "Region_locations size: ", region_locations.size(), " ", region_locations);
 	RS->material_set_param(_material, "_region_locations", region_locations);
 
-	real_t region_size = real_t(storage->get_region_size());
+	real_t region_size = real_t(_terrain->get_region_size());
 	LOG(DEBUG_CONT, "Setting region size in material: ", region_size);
 	RS->material_set_param(_material, "_region_size", region_size);
 	RS->material_set_param(_material, "_region_texel_size", 1.0f / region_size);

--- a/src/terrain_3d_material.cpp
+++ b/src/terrain_3d_material.cpp
@@ -298,18 +298,12 @@ void Terrain3DMaterial::_update_maps() {
 	IS_STORAGE_INIT(VOID);
 	LOG(DEBUG_CONT, "Updating maps in shader");
 
-	Ref<Terrain3DStorage> storage = _terrain->get_storage();
-	RS->material_set_param(_material, "_height_maps", storage->get_height_maps_rid());
-	RS->material_set_param(_material, "_control_maps", storage->get_control_maps_rid());
-	RS->material_set_param(_material, "_color_maps", storage->get_color_maps_rid());
-	LOG(DEBUG_CONT, "Height map RID: ", storage->get_height_maps_rid());
-	LOG(DEBUG_CONT, "Control map RID: ", storage->get_control_maps_rid());
-	LOG(DEBUG_CONT, "Color map RID: ", storage->get_color_maps_rid());
-
+	Terrain3DStorage *storage = _terrain->get_storage();
 	PackedInt32Array region_map = storage->get_region_map();
 	LOG(DEBUG_CONT, "region_map.size(): ", region_map.size());
 	if (region_map.size() != Terrain3DStorage::REGION_MAP_SIZE * Terrain3DStorage::REGION_MAP_SIZE) {
 		LOG(ERROR, "Expected region_map.size() of ", Terrain3DStorage::REGION_MAP_SIZE * Terrain3DStorage::REGION_MAP_SIZE);
+		return;
 	}
 	RS->material_set_param(_material, "_region_map", region_map);
 	RS->material_set_param(_material, "_region_map_size", Terrain3DStorage::REGION_MAP_SIZE);
@@ -330,6 +324,13 @@ void Terrain3DMaterial::_update_maps() {
 	LOG(DEBUG_CONT, "Setting region size in material: ", region_size);
 	RS->material_set_param(_material, "_region_size", region_size);
 	RS->material_set_param(_material, "_region_texel_size", 1.0f / region_size);
+
+	RS->material_set_param(_material, "_height_maps", storage->get_height_maps_rid());
+	RS->material_set_param(_material, "_control_maps", storage->get_control_maps_rid());
+	RS->material_set_param(_material, "_color_maps", storage->get_color_maps_rid());
+	LOG(DEBUG_CONT, "Height map RID: ", storage->get_height_maps_rid());
+	LOG(DEBUG_CONT, "Control map RID: ", storage->get_control_maps_rid());
+	LOG(DEBUG_CONT, "Color map RID: ", storage->get_color_maps_rid());
 
 	real_t spacing = _terrain->get_mesh_vertex_spacing();
 	LOG(DEBUG_CONT, "Setting mesh vertex spacing in material: ", spacing);

--- a/src/terrain_3d_region.cpp
+++ b/src/terrain_3d_region.cpp
@@ -170,33 +170,6 @@ void Terrain3DRegion::set_height_range(const Vector2 &p_range) {
 	}
 }
 
-void Terrain3DRegion::update_height(const real_t p_height) {
-	if (p_height < _height_range.x) {
-		_height_range.x = p_height;
-		_modified = true;
-	} else if (p_height > _height_range.y) {
-		_height_range.y = p_height;
-		_modified = true;
-	}
-	if (_modified) {
-		LOG(DEBUG_CONT, "Expanded range: ", _height_range);
-	}
-}
-
-void Terrain3DRegion::update_heights(const Vector2 &p_low_high) {
-	if (p_low_high.x < _height_range.x) {
-		_height_range.x = p_low_high.x;
-		_modified = true;
-	}
-	if (p_low_high.y > _height_range.y) {
-		_height_range.y = p_low_high.y;
-		_modified = true;
-	}
-	if (_modified) {
-		LOG(DEBUG_CONT, "Expanded range: ", _height_range);
-	}
-}
-
 void Terrain3DRegion::calc_height_range() {
 	Vector2 range = Util::get_min_max(_height_map);
 	if (_height_range != range) {

--- a/src/terrain_3d_region.cpp
+++ b/src/terrain_3d_region.cpp
@@ -1,0 +1,103 @@
+// Copyright © 2024 Cory Petkovsek, Roope Palmroos, and Contributors.
+
+#include <godot_cpp/classes/resource_saver.hpp>
+
+#include "logger.h"
+#include "terrain_3d_region.h"
+
+/////////////////////
+// Public Functions
+/////////////////////
+
+void Terrain3DRegion::set_version(const real_t p_version) {
+	LOG(INFO, vformat("%.3f", p_version));
+	_version = p_version;
+	if (_version < Terrain3DStorage::CURRENT_VERSION) {
+		LOG(WARN, "Region ", get_path(), " version ", vformat("%.3f", _version),
+				" will be updated to ", vformat("%.3f", Terrain3DStorage::CURRENT_VERSION), " upon save");
+	}
+}
+
+void Terrain3DRegion::set_height_map(const Ref<Image> &p_map) {
+	Image::Format format = Terrain3DStorage::FORMAT[Terrain3DStorage::TYPE_HEIGHT];
+	if (p_map.is_valid() && p_map->get_format() != format) {
+		LOG(DEBUG, "Converting file format: ", p_map->get_format(), " to ", format);
+		if (_height_map.is_null()) {
+			_height_map.instantiate();
+		}
+		_height_map->copy_from(p_map);
+		_height_map->convert(format);
+	} else {
+		_height_map = p_map;
+	}
+}
+
+Error Terrain3DRegion::save(const String &p_path, const bool p_16_bit) {
+	// Initiate save to external file. The scene will save itself.
+	if (!_modified) {
+		LOG(INFO, "Save requested, but not modified. Skipping");
+		return ERR_SKIP;
+	}
+	if (p_path.is_empty() && get_path().is_empty()) {
+		LOG(ERROR, "No valid path provided");
+		return ERR_FILE_NOT_FOUND;
+	}
+	String path = p_path;
+	if (path.is_empty()) {
+		path = get_path();
+	}
+	set_version(Terrain3DStorage::CURRENT_VERSION);
+	LOG(INFO, "Writing", (p_16_bit) ? " 16-bit" : "", " region ", _region_loc, " to ", path);
+
+	Error err;
+	if (p_16_bit) {
+		Ref<Image> original_map;
+		original_map.instantiate();
+		original_map->copy_from(_height_map);
+		_height_map->convert(Image::FORMAT_RH);
+		err = ResourceSaver::get_singleton()->save(this, path, ResourceSaver::FLAG_COMPRESS);
+		_height_map = original_map;
+	} else {
+		err = ResourceSaver::get_singleton()->save(this, path, ResourceSaver::FLAG_COMPRESS);
+	}
+	if (err == OK) {
+		_modified = false;
+		LOG(INFO, "File saved successfully");
+	} else {
+		LOG(ERROR, "Can't save region file: ", path, ". Error code: ", ERROR, ". Look up @GlobalScope Error enum in the Godot docs");
+	}
+	return err;
+}
+
+/////////////////////
+// Protected Functions
+/////////////////////
+
+void Terrain3DRegion::_bind_methods() {
+	ClassDB::bind_method(D_METHOD("set_version"), &Terrain3DRegion::set_version);
+	ClassDB::bind_method(D_METHOD("get_version"), &Terrain3DRegion::get_version);
+	ClassDB::bind_method(D_METHOD("is_modified"), &Terrain3DRegion::is_modified);
+	ClassDB::bind_method(D_METHOD("get_region_loc"), &Terrain3DRegion::get_region_loc);
+
+	ClassDB::bind_method(D_METHOD("set_height_map", "map"), &Terrain3DRegion::set_height_map);
+	ClassDB::bind_method(D_METHOD("get_height_map"), &Terrain3DRegion::get_height_map);
+	ClassDB::bind_method(D_METHOD("set_control_map", "map"), &Terrain3DRegion::set_control_map);
+	ClassDB::bind_method(D_METHOD("get_control_map"), &Terrain3DRegion::get_control_map);
+	ClassDB::bind_method(D_METHOD("set_color_map", "map"), &Terrain3DRegion::set_color_map);
+	ClassDB::bind_method(D_METHOD("get_color_map"), &Terrain3DRegion::get_color_map);
+	ClassDB::bind_method(D_METHOD("set_multimeshes", "multimeshes"), &Terrain3DRegion::set_multimeshes);
+	ClassDB::bind_method(D_METHOD("get_multimeshes"), &Terrain3DRegion::get_multimeshes);
+
+	ClassDB::bind_method(D_METHOD("save", "path", "16-bit"), &Terrain3DRegion::save, DEFVAL(""), DEFVAL(false));
+
+	// These two show what's on the disk (defaults) not what is in memory, so hide them
+	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "modified", PROPERTY_HINT_NONE, "", PROPERTY_USAGE_NONE), "", "is_modified");
+	ADD_PROPERTY(PropertyInfo(Variant::VECTOR2I, "location", PROPERTY_HINT_NONE, "", PROPERTY_USAGE_NONE), "", "get_region_loc");
+
+	int ro_flags = PROPERTY_USAGE_STORAGE | PROPERTY_USAGE_EDITOR | PROPERTY_USAGE_READ_ONLY;
+	ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "version", PROPERTY_HINT_NONE, "", ro_flags), "set_version", "get_version");
+	ADD_PROPERTY(PropertyInfo(Variant::OBJECT, "heightmap", PROPERTY_HINT_RESOURCE_TYPE, "Image", ro_flags), "set_height_map", "get_height_map");
+	ADD_PROPERTY(PropertyInfo(Variant::OBJECT, "controlmap", PROPERTY_HINT_RESOURCE_TYPE, "Image", ro_flags), "set_control_map", "get_control_map");
+	ADD_PROPERTY(PropertyInfo(Variant::OBJECT, "colormap", PROPERTY_HINT_RESOURCE_TYPE, "Image", ro_flags), "set_color_map", "get_color_map");
+	ADD_PROPERTY(PropertyInfo(Variant::DICTIONARY, "multimeshes", PROPERTY_HINT_NONE, "", ro_flags), "set_multimeshes", "get_multimeshes");
+}

--- a/src/terrain_3d_region.cpp
+++ b/src/terrain_3d_region.cpp
@@ -47,7 +47,7 @@ Error Terrain3DRegion::save(const String &p_path, const bool p_16_bit) {
 		path = get_path();
 	}
 	set_version(Terrain3DStorage::CURRENT_VERSION);
-	LOG(INFO, "Writing", (p_16_bit) ? " 16-bit" : "", " region ", _region_loc, " to ", path);
+	LOG(INFO, "Writing", (p_16_bit) ? " 16-bit" : "", " region ", _location, " to ", path);
 
 	Error err;
 	if (p_16_bit) {
@@ -76,8 +76,6 @@ Error Terrain3DRegion::save(const String &p_path, const bool p_16_bit) {
 void Terrain3DRegion::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("set_version"), &Terrain3DRegion::set_version);
 	ClassDB::bind_method(D_METHOD("get_version"), &Terrain3DRegion::get_version);
-	ClassDB::bind_method(D_METHOD("is_modified"), &Terrain3DRegion::is_modified);
-	ClassDB::bind_method(D_METHOD("get_region_loc"), &Terrain3DRegion::get_region_loc);
 
 	ClassDB::bind_method(D_METHOD("set_height_map", "map"), &Terrain3DRegion::set_height_map);
 	ClassDB::bind_method(D_METHOD("get_height_map"), &Terrain3DRegion::get_height_map);
@@ -90,9 +88,9 @@ void Terrain3DRegion::_bind_methods() {
 
 	ClassDB::bind_method(D_METHOD("save", "path", "16-bit"), &Terrain3DRegion::save, DEFVAL(""), DEFVAL(false));
 
-	// These two show what's on the disk (defaults) not what is in memory, so hide them
-	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "modified", PROPERTY_HINT_NONE, "", PROPERTY_USAGE_NONE), "", "is_modified");
-	ADD_PROPERTY(PropertyInfo(Variant::VECTOR2I, "location", PROPERTY_HINT_NONE, "", PROPERTY_USAGE_NONE), "", "get_region_loc");
+	ClassDB::bind_method(D_METHOD("is_modified"), &Terrain3DRegion::is_modified);
+	ClassDB::bind_method(D_METHOD("set_location"), &Terrain3DRegion::set_location);
+	ClassDB::bind_method(D_METHOD("get_location"), &Terrain3DRegion::get_location);
 
 	int ro_flags = PROPERTY_USAGE_STORAGE | PROPERTY_USAGE_EDITOR | PROPERTY_USAGE_READ_ONLY;
 	ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "version", PROPERTY_HINT_NONE, "", ro_flags), "set_version", "get_version");
@@ -100,4 +98,8 @@ void Terrain3DRegion::_bind_methods() {
 	ADD_PROPERTY(PropertyInfo(Variant::OBJECT, "controlmap", PROPERTY_HINT_RESOURCE_TYPE, "Image", ro_flags), "set_control_map", "get_control_map");
 	ADD_PROPERTY(PropertyInfo(Variant::OBJECT, "colormap", PROPERTY_HINT_RESOURCE_TYPE, "Image", ro_flags), "set_color_map", "get_color_map");
 	ADD_PROPERTY(PropertyInfo(Variant::DICTIONARY, "multimeshes", PROPERTY_HINT_NONE, "", ro_flags), "set_multimeshes", "get_multimeshes");
+
+	// The inspector only shows what's on disk, not what is in memory, so hide them. Being generated, they only show defaults
+	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "modified", PROPERTY_HINT_NONE, "", PROPERTY_USAGE_NONE), "", "is_modified");
+	ADD_PROPERTY(PropertyInfo(Variant::VECTOR2I, "location", PROPERTY_HINT_NONE, "", PROPERTY_USAGE_NONE), "set_location", "get_location");
 }

--- a/src/terrain_3d_region.cpp
+++ b/src/terrain_3d_region.cpp
@@ -126,6 +126,9 @@ void Terrain3DRegion::sanitize_map(const MapType p_map_type) {
 					if (type == TYPE_HEIGHT) {
 						calc_height_range();
 					}
+					if (type == TYPE_COLOR && !map->has_mipmaps()) {
+						map->generate_mipmaps();
+					}
 					continue;
 				} else {
 					LOG(DEBUG, "Provided ", type_str, " map wrong format: ", map->get_format(), ". Converting copy to: ", format);
@@ -146,10 +149,7 @@ void Terrain3DRegion::sanitize_map(const MapType p_map_type) {
 		} else {
 			LOG(DEBUG, "No provided ", type_str, " map. Creating blank");
 		}
-		set_map(type, Util::get_filled_image(Vector2i(_region_size, _region_size), color, false, format));
-		if (type == TYPE_HEIGHT) {
-			set_height_range(V2_ZERO);
-		}
+		set_map(type, Util::get_filled_image(Vector2i(_region_size, _region_size), color, type == TYPE_COLOR, format));
 	}
 }
 
@@ -207,7 +207,7 @@ Error Terrain3DRegion::save(const String &p_path, const bool p_16_bit) {
 		LOG(ERROR, "Region has not been setup. Location is INT32_MAX. Skipping ", p_path);
 	}
 	if (!_modified) {
-		LOG(DEBUG, "Save requested for region ", _location, ", but not modified. Skipping ", p_path);
+		LOG(DEBUG, "Region ", _location, " not modified. Skipping ", p_path);
 		return ERR_SKIP;
 	}
 	if (p_path.is_empty() && get_path().is_empty()) {

--- a/src/terrain_3d_region.h
+++ b/src/terrain_3d_region.h
@@ -44,7 +44,7 @@ public: // Constants
 private:
 	/// Saved data
 	real_t _version = 0.8f; // Set to first version to ensure Godot always upgrades this
-	int _region_size = 1024;
+	int _region_size = 0;
 	Vector2 _height_range = V2_ZERO;
 	// Maps
 	Ref<Image> _height_map;
@@ -77,7 +77,9 @@ public:
 	Ref<Image> get_control_map() const { return _control_map; }
 	void set_color_map(const Ref<Image> &p_map);
 	Ref<Image> get_color_map() const { return _color_map; }
-	void sanitize_map(const MapType p_map_type = TYPE_MAX);
+	bool validate_map_size(const Ref<Image> &p_map) const;
+	void sanitize_maps();
+	Ref<Image> sanitize_map(const MapType p_map_type, const Ref<Image> &p_map) const;
 
 	void set_height_range(const Vector2 &p_range);
 	Vector2 get_height_range() const { return _height_range; }

--- a/src/terrain_3d_region.h
+++ b/src/terrain_3d_region.h
@@ -54,9 +54,10 @@ private:
 	Dictionary _multimeshes; // Dictionary[mesh_id:int] -> MultiMesh
 
 	// Working data not saved to disk
+	bool _deleted = false; // Marked for deletion on save
+	bool _edited = false; // Marked for undo/redo storage
+	bool _modified = false; // Marked for saving
 	Vector2i _location = V2I_MAX;
-	bool _modified = false;
-	bool _deleted = false;
 
 public:
 	Terrain3DRegion() {}
@@ -92,14 +93,21 @@ public:
 	Error save(const String &p_path = "", const bool p_16_bit = false);
 
 	// Working Data
-	void set_modified(const bool p_modified) { _modified = p_modified; }
-	bool is_modified() const { return _modified; }
 	void set_deleted(const bool p_deleted) { _deleted = p_deleted; }
 	bool is_deleted() const { return _deleted; }
+	void set_edited(const bool p_edited) { _edited = p_edited; }
+	bool is_edited() const { return _edited; }
+	void set_modified(const bool p_modified) { _modified = p_modified; }
+	bool is_modified() const { return _modified; }
 	void set_location(const Vector2i &p_location);
 	Vector2i get_location() const { return _location; }
 	void set_region_size(const int p_region_size) { _region_size = CLAMP(p_region_size, 1024, 1024); }
 	int get_region_size() const { return _region_size; }
+
+	// Utility
+	void set_data(const Dictionary &p_data);
+	Dictionary get_data() const;
+	Ref<Terrain3DRegion> duplicate(const bool p_deep = false);
 
 protected:
 	static void _bind_methods();

--- a/src/terrain_3d_region.h
+++ b/src/terrain_3d_region.h
@@ -12,24 +12,22 @@ class Terrain3DRegion : public Resource {
 	CLASS_NAME();
 
 private:
+	// Saved data
 	real_t _version = 0.8f; // Set to first version to ensure Godot always upgrades this
-	bool _modified = false;
-	Vector2i _region_loc = Vector2i(INT32_MIN, INT32_MIN);
 	// Maps
 	Ref<Image> _height_map;
 	Ref<Image> _control_map;
 	Ref<Image> _color_map;
-	// Instancer MultiMeshes saved to disk
 	// Dictionary[mesh_id:int] -> MultiMesh
 	Dictionary _multimeshes;
+
+	// Workind data not saved to disk
+	Vector2i _location = Vector2i(INT32_MAX, INT32_MAX);
+	bool _modified = false;
 
 public:
 	void set_version(const real_t p_version);
 	real_t get_version() const { return _version; }
-	void set_modified(const bool p_modified) { _modified = p_modified; }
-	bool is_modified() const { return _modified; }
-	void set_region_loc(const Vector2i &p_region_loc) { _region_loc = p_region_loc; }
-	Vector2i get_region_loc() const { return _region_loc; }
 
 	// Maps
 	void set_height_map(const Ref<Image> &p_map);
@@ -45,6 +43,12 @@ public:
 
 	// File I/O
 	Error save(const String &p_path = "", const bool p_16_bit = false);
+
+	// Working
+	void set_modified(const bool p_modified) { _modified = p_modified; }
+	bool is_modified() const { return _modified; }
+	void set_location(const Vector2i &p_location) { _location = p_location; }
+	Vector2i get_location() const { return _location; }
 
 protected:
 	static void _bind_methods();

--- a/src/terrain_3d_region.h
+++ b/src/terrain_3d_region.h
@@ -123,4 +123,27 @@ constexpr inline const Image::Format *FORMAT = Terrain3DRegion::FORMAT;
 constexpr inline const char **TYPESTR = Terrain3DRegion::TYPESTR;
 constexpr inline const Color *COLOR = Terrain3DRegion::COLOR;
 
+/// Inline functions
+
+inline void Terrain3DRegion::update_height(const real_t p_height) {
+	if (p_height < _height_range.x) {
+		_height_range.x = p_height;
+		_modified = true;
+	} else if (p_height > _height_range.y) {
+		_height_range.y = p_height;
+		_modified = true;
+	}
+}
+
+inline void Terrain3DRegion::update_heights(const Vector2 &p_low_high) {
+	if (p_low_high.x < _height_range.x) {
+		_height_range.x = p_low_high.x;
+		_modified = true;
+	}
+	if (p_low_high.y > _height_range.y) {
+		_height_range.y = p_low_high.y;
+		_modified = true;
+	}
+}
+
 #endif // TERRAIN3D_REGION_CLASS_H

--- a/src/terrain_3d_region.h
+++ b/src/terrain_3d_region.h
@@ -1,0 +1,53 @@
+// Copyright © 2024 Cory Petkovsek, Roope Palmroos, and Contributors.
+
+#ifndef TERRAIN3D_REGION_CLASS_H
+#define TERRAIN3D_REGION_CLASS_H
+
+#include "constants.h"
+
+using namespace godot;
+
+class Terrain3DRegion : public Resource {
+	GDCLASS(Terrain3DRegion, Resource);
+	CLASS_NAME();
+
+private:
+	real_t _version = 0.8f; // Set to first version to ensure Godot always upgrades this
+	bool _modified = false;
+	Vector2i _region_loc = Vector2i(INT32_MIN, INT32_MIN);
+	// Maps
+	Ref<Image> _height_map;
+	Ref<Image> _control_map;
+	Ref<Image> _color_map;
+	// Instancer MultiMeshes saved to disk
+	// Dictionary[mesh_id:int] -> MultiMesh
+	Dictionary _multimeshes;
+
+public:
+	void set_version(const real_t p_version);
+	real_t get_version() const { return _version; }
+	void set_modified(const bool p_modified) { _modified = p_modified; }
+	bool is_modified() const { return _modified; }
+	void set_region_loc(const Vector2i &p_region_loc) { _region_loc = p_region_loc; }
+	Vector2i get_region_loc() const { return _region_loc; }
+
+	// Maps
+	void set_height_map(const Ref<Image> &p_map);
+	Ref<Image> get_height_map() const { return _height_map; }
+	void set_control_map(const Ref<Image> &p_map) { _control_map = p_map; }
+	Ref<Image> get_control_map() const { return _control_map; }
+	void set_color_map(const Ref<Image> &p_map) { _color_map = p_map; }
+	Ref<Image> get_color_map() const { return _color_map; }
+
+	// Instancer
+	void set_multimeshes(const Dictionary &p_multimeshes) { _multimeshes = p_multimeshes; }
+	Dictionary get_multimeshes() const { return _multimeshes; }
+
+	// File I/O
+	Error save(const String &p_path = "", const bool p_16_bit = false);
+
+protected:
+	static void _bind_methods();
+};
+
+#endif // TERRAIN3D_REGION_CLASS_H

--- a/src/terrain_3d_region.h
+++ b/src/terrain_3d_region.h
@@ -4,6 +4,7 @@
 #define TERRAIN3D_REGION_CLASS_H
 
 #include "constants.h"
+#include "terrain_3d_util.h"
 
 using namespace godot;
 
@@ -11,9 +12,39 @@ class Terrain3DRegion : public Resource {
 	GDCLASS(Terrain3DRegion, Resource);
 	CLASS_NAME();
 
+public: // Constants
+	enum MapType {
+		TYPE_HEIGHT,
+		TYPE_CONTROL,
+		TYPE_COLOR,
+		TYPE_MAX,
+	};
+
+	static inline const Image::Format FORMAT[] = {
+		Image::FORMAT_RF, // TYPE_HEIGHT
+		Image::FORMAT_RF, // TYPE_CONTROL
+		Image::FORMAT_RGBA8, // TYPE_COLOR
+		Image::Format(TYPE_MAX), // Proper size of array instead of FORMAT_MAX
+	};
+
+	static inline const char *TYPESTR[] = {
+		"TYPE_HEIGHT",
+		"TYPE_CONTROL",
+		"TYPE_COLOR",
+		"TYPE_MAX",
+	};
+
+	static inline const Color COLOR[] = {
+		COLOR_BLACK, // TYPE_HEIGHT
+		COLOR_CONTROL, // TYPE_CONTROL
+		COLOR_ROUGHNESS, // TYPE_COLOR
+		COLOR_NAN, // TYPE_MAX, unused just in case someone indexes the array
+	};
+
 private:
 	// Saved data
 	real_t _version = 0.8f; // Set to first version to ensure Godot always upgrades this
+	int _region_size = 1024;
 	// Maps
 	Ref<Image> _height_map;
 	Ref<Image> _control_map;
@@ -26,16 +57,22 @@ private:
 	bool _modified = false;
 
 public:
+	Terrain3DRegion() {}
+	Terrain3DRegion(const Ref<Image> &p_height_map, const Ref<Image> &p_control_map, const Ref<Image> &p_color_map, const int p_region_size = 1024);
+	~Terrain3DRegion() {}
+
 	void set_version(const real_t p_version);
 	real_t get_version() const { return _version; }
 
 	// Maps
 	void set_height_map(const Ref<Image> &p_map);
 	Ref<Image> get_height_map() const { return _height_map; }
-	void set_control_map(const Ref<Image> &p_map) { _control_map = p_map; }
+	void set_control_map(const Ref<Image> &p_map);
 	Ref<Image> get_control_map() const { return _control_map; }
-	void set_color_map(const Ref<Image> &p_map) { _color_map = p_map; }
+	void set_color_map(const Ref<Image> &p_map);
 	Ref<Image> get_color_map() const { return _color_map; }
+	void sanitize_maps(const MapType p_map_type = TYPE_MAX);
+	Ref<Image> sanitize_map(const MapType p_map_type, const Ref<Image> &p_img) const;
 
 	// Instancer
 	void set_multimeshes(const Dictionary &p_multimeshes) { _multimeshes = p_multimeshes; }
@@ -49,9 +86,21 @@ public:
 	bool is_modified() const { return _modified; }
 	void set_location(const Vector2i &p_location) { _location = p_location; }
 	Vector2i get_location() const { return _location; }
+	void set_region_size(const int p_region_size) { _region_size = p_region_size; }
+	int get_region_size() const { return _region_size; }
 
 protected:
 	static void _bind_methods();
 };
+
+typedef Terrain3DRegion::MapType MapType;
+VARIANT_ENUM_CAST(Terrain3DRegion::MapType);
+constexpr Terrain3DRegion::MapType TYPE_HEIGHT = Terrain3DRegion::MapType::TYPE_HEIGHT;
+constexpr Terrain3DRegion::MapType TYPE_CONTROL = Terrain3DRegion::MapType::TYPE_CONTROL;
+constexpr Terrain3DRegion::MapType TYPE_COLOR = Terrain3DRegion::MapType::TYPE_COLOR;
+constexpr Terrain3DRegion::MapType TYPE_MAX = Terrain3DRegion::MapType::TYPE_MAX;
+constexpr inline const Image::Format *FORMAT = Terrain3DRegion::FORMAT;
+constexpr inline const char **TYPESTR = Terrain3DRegion::TYPESTR;
+constexpr inline const Color *COLOR = Terrain3DRegion::COLOR;
 
 #endif // TERRAIN3D_REGION_CLASS_H

--- a/src/terrain_3d_region.h
+++ b/src/terrain_3d_region.h
@@ -42,37 +42,47 @@ public: // Constants
 	};
 
 private:
-	// Saved data
+	/// Saved data
 	real_t _version = 0.8f; // Set to first version to ensure Godot always upgrades this
 	int _region_size = 1024;
+	Vector2 _height_range = V2_ZERO;
 	// Maps
 	Ref<Image> _height_map;
 	Ref<Image> _control_map;
 	Ref<Image> _color_map;
-	// Dictionary[mesh_id:int] -> MultiMesh
-	Dictionary _multimeshes;
+	// Instancer
+	Dictionary _multimeshes; // Dictionary[mesh_id:int] -> MultiMesh
 
-	// Workind data not saved to disk
+	// Working data not saved to disk
 	Vector2i _location = V2I_MAX;
 	bool _modified = false;
+	bool _deleted = false;
 
 public:
 	Terrain3DRegion() {}
-	Terrain3DRegion(const Ref<Image> &p_height_map, const Ref<Image> &p_control_map, const Ref<Image> &p_color_map, const int p_region_size = 1024);
 	~Terrain3DRegion() {}
 
 	void set_version(const real_t p_version);
 	real_t get_version() const { return _version; }
 
 	// Maps
+	void set_map(const MapType p_map_type, const Ref<Image> &p_image);
+	Ref<Image> get_map(const MapType p_map_type) const;
+	void set_maps(const TypedArray<Image> &p_maps);
+	TypedArray<Image> get_maps() const;
 	void set_height_map(const Ref<Image> &p_map);
 	Ref<Image> get_height_map() const { return _height_map; }
 	void set_control_map(const Ref<Image> &p_map);
 	Ref<Image> get_control_map() const { return _control_map; }
 	void set_color_map(const Ref<Image> &p_map);
 	Ref<Image> get_color_map() const { return _color_map; }
-	void sanitize_maps(const MapType p_map_type = TYPE_MAX);
-	Ref<Image> sanitize_map(const MapType p_map_type, const Ref<Image> &p_img) const;
+	void sanitize_map(const MapType p_map_type = TYPE_MAX);
+
+	void set_height_range(const Vector2 &p_range);
+	Vector2 get_height_range() const { return _height_range; }
+	void update_height(const real_t p_height);
+	void update_heights(const Vector2 &p_low_high);
+	void calc_height_range();
 
 	// Instancer
 	void set_multimeshes(const Dictionary &p_multimeshes) { _multimeshes = p_multimeshes; }
@@ -81,12 +91,14 @@ public:
 	// File I/O
 	Error save(const String &p_path = "", const bool p_16_bit = false);
 
-	// Working
+	// Working Data
 	void set_modified(const bool p_modified) { _modified = p_modified; }
 	bool is_modified() const { return _modified; }
-	void set_location(const Vector2i &p_location) { _location = p_location; }
+	void set_deleted(const bool p_deleted) { _deleted = p_deleted; }
+	bool is_deleted() const { return _deleted; }
+	void set_location(const Vector2i &p_location);
 	Vector2i get_location() const { return _location; }
-	void set_region_size(const int p_region_size) { _region_size = p_region_size; }
+	void set_region_size(const int p_region_size) { _region_size = CLAMP(p_region_size, 1024, 1024); }
 	int get_region_size() const { return _region_size; }
 
 protected:

--- a/src/terrain_3d_region.h
+++ b/src/terrain_3d_region.h
@@ -53,7 +53,7 @@ private:
 	Dictionary _multimeshes;
 
 	// Workind data not saved to disk
-	Vector2i _location = Vector2i(INT32_MAX, INT32_MAX);
+	Vector2i _location = V2I_MAX;
 	bool _modified = false;
 
 public:

--- a/src/terrain_3d_storage.cpp
+++ b/src/terrain_3d_storage.cpp
@@ -317,7 +317,7 @@ void Terrain3DStorage::update_maps() {
 	}
 }
 
-void Terrain3DStorage::save_region(const String &p_dir, const Vector2i &p_region_loc, const bool p_16_bit) {
+void Terrain3DStorage::save_region(const Vector2i &p_region_loc, const String &p_dir, const bool p_16_bit) {
 	Ref<Terrain3DRegion> region = _regions[p_region_loc];
 	// looks like get isn't required
 	if (region.is_null()) {
@@ -331,7 +331,7 @@ void Terrain3DStorage::save_region(const String &p_dir, const Vector2i &p_region
 	region->save(path, p_16_bit);
 }
 
-void Terrain3DStorage::load_region(const String &p_dir, const Vector2i &p_region_loc) {
+void Terrain3DStorage::load_region(const Vector2i &p_region_loc, const String &p_dir) {
 	LOG(INFO, "Loading region from location ", p_region_loc);
 	String path = p_dir + String("/") + Util::location_to_filename(p_region_loc);
 	Ref<Terrain3DRegion> region = ResourceLoader::get_singleton()->load(path,
@@ -736,7 +736,7 @@ Dictionary Terrain3DStorage::get_multimeshes(const TypedArray<int> &p_region_ids
 void Terrain3DStorage::save_directory(const String &p_dir) {
 	LOG(INFO, "Saving data files to ", p_dir);
 	for (int i = 0; i < _region_locations.size(); i++) {
-		save_region(p_dir, _region_locations[i], _terrain->get_save_16_bit());
+		save_region(_region_locations[i], p_dir, _terrain->get_save_16_bit());
 	}
 }
 
@@ -1174,6 +1174,8 @@ void Terrain3DStorage::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("get_texture_id", "global_position"), &Terrain3DStorage::get_texture_id);
 	ClassDB::bind_method(D_METHOD("get_angle", "global_position"), &Terrain3DStorage::get_angle);
 	ClassDB::bind_method(D_METHOD("get_scale", "global_position"), &Terrain3DStorage::get_scale);
+	ClassDB::bind_method(D_METHOD("get_mesh_vertex", "lod", "filter", "global_position"), &Terrain3DStorage::get_mesh_vertex);
+	ClassDB::bind_method(D_METHOD("get_normal", "global_position"), &Terrain3DStorage::get_normal);
 	ClassDB::bind_method(D_METHOD("force_update_maps", "map_type"), &Terrain3DStorage::force_update_maps, DEFVAL(TYPE_MAX));
 
 	//ClassDB::bind_method(D_METHOD("set_multimeshes", "multimeshes"), &Terrain3DStorage::set_multimeshes);
@@ -1183,8 +1185,6 @@ void Terrain3DStorage::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("export_image", "file_name", "map_type"), &Terrain3DStorage::export_image);
 	ClassDB::bind_method(D_METHOD("layered_to_image", "map_type"), &Terrain3DStorage::layered_to_image);
 
-	ClassDB::bind_method(D_METHOD("get_mesh_vertex", "lod", "filter", "global_position"), &Terrain3DStorage::get_mesh_vertex);
-	ClassDB::bind_method(D_METHOD("get_normal", "global_position"), &Terrain3DStorage::get_normal);
 
 	int ro_flags = PROPERTY_USAGE_STORAGE | PROPERTY_USAGE_EDITOR | PROPERTY_USAGE_READ_ONLY;
 	//ADD_PROPERTY(PropertyInfo(Variant::INT, "region_size", PROPERTY_HINT_ENUM, "64:64, 128:128, 256:256, 512:512, 1024:1024, 2048:2048"), "set_region_size", "get_region_size");

--- a/src/terrain_3d_storage.cpp
+++ b/src/terrain_3d_storage.cpp
@@ -191,7 +191,7 @@ Error Terrain3DStorage::add_region(const Vector3 &p_global_position, const Typed
 
 	// Check this later, per region
 	// If we're importing data into a region, check its heights for aabbs
-	/*Vector2 min_max = Vector2(0.f, 0.f);
+	/*Vector2 min_max = V2_ZERO;
 	if (p_images.size() > TYPE_HEIGHT) {
 		min_max = Util::get_min_max(images[TYPE_HEIGHT]);
 		LOG(DEBUG, "Checking imported height range: ", min_max);
@@ -560,7 +560,7 @@ void Terrain3DStorage::set_pixel(const MapType p_map_type, const Vector3 &p_glob
 	Vector2i global_offset = region_loc * _region_size;
 	Vector3 descaled_pos = p_global_position / _mesh_vertex_spacing;
 	Vector2i img_pos = Vector2i(descaled_pos.x - global_offset.x, descaled_pos.z - global_offset.y);
-	img_pos = img_pos.clamp(Vector2i(), Vector2i(_region_size - 1, _region_size - 1));
+	img_pos = img_pos.clamp(V2I_ZERO, Vector2i(_region_size - 1, _region_size - 1));
 	Ref<Image> map = get_map_region(p_map_type, region_id);
 	map->set_pixelv(img_pos, p_pixel);
 	set_region_modified(region_loc, true);
@@ -579,7 +579,7 @@ Color Terrain3DStorage::get_pixel(const MapType p_map_type, const Vector3 &p_glo
 	Vector2i global_offset = region_loc * _region_size;
 	Vector3 descaled_pos = p_global_position / _mesh_vertex_spacing;
 	Vector2i img_pos = Vector2i(descaled_pos.x - global_offset.x, descaled_pos.z - global_offset.y);
-	img_pos = img_pos.clamp(Vector2i(), Vector2i(_region_size - 1, _region_size - 1));
+	img_pos = img_pos.clamp(V2I_ZERO, Vector2i(_region_size - 1, _region_size - 1));
 	Ref<Image> map = get_map_region(p_map_type, region_id);
 	return map->get_pixelv(img_pos);
 }
@@ -756,7 +756,7 @@ void Terrain3DStorage::import_images(const TypedArray<Image> &p_images, const Ve
 		return;
 	}
 
-	Vector2i img_size = Vector2i(0, 0);
+	Vector2i img_size = V2I_ZERO;
 	for (int i = 0; i < TYPE_MAX; i++) {
 		Ref<Image> img = p_images[i];
 		if (img.is_valid() && !img->is_empty()) {
@@ -764,7 +764,7 @@ void Terrain3DStorage::import_images(const TypedArray<Image> &p_images, const Ve
 			if (i == TYPE_HEIGHT) {
 				LOG(INFO, "Applying offset: ", p_offset, ", scale: ", p_scale);
 			}
-			if (img_size == Vector2i(0, 0)) {
+			if (img_size == V2I_ZERO) {
 				img_size = img->get_size();
 			} else if (img_size != img->get_size()) {
 				LOG(ERROR, "Included Images in p_images have different dimensions. Aborting import");
@@ -772,7 +772,7 @@ void Terrain3DStorage::import_images(const TypedArray<Image> &p_images, const Ve
 			}
 		}
 	}
-	if (img_size == Vector2i(0, 0)) {
+	if (img_size == V2I_ZERO) {
 		LOG(ERROR, "All images are empty. Nothing to import");
 		return;
 	}
@@ -845,7 +845,7 @@ void Terrain3DStorage::import_images(const TypedArray<Image> &p_images, const Ve
 				Ref<Image> img_slice;
 				if (img.is_valid() && !img->is_empty()) {
 					img_slice = Util::get_filled_image(_region_sizev, COLOR[i], false, img->get_format());
-					img_slice->blit_rect(tmp_images[i], Rect2i(start_coords, size_to_copy), Vector2i(0, 0));
+					img_slice->blit_rect(tmp_images[i], Rect2i(start_coords, size_to_copy), V2I_ZERO);
 				} else {
 					img_slice = Util::get_filled_image(_region_sizev, COLOR[i], false, FORMAT[i]);
 				}
@@ -960,8 +960,8 @@ Ref<Image> Terrain3DStorage::layered_to_image(const MapType p_map_type) const {
 	if (map_type >= TYPE_MAX) {
 		map_type = TYPE_HEIGHT;
 	}
-	Vector2i top_left = Vector2i(0, 0);
-	Vector2i bottom_right = Vector2i(0, 0);
+	Vector2i top_left = V2I_ZERO;
+	Vector2i bottom_right = V2I_ZERO;
 	for (int i = 0; i < _region_locations.size(); i++) {
 		LOG(DEBUG, "Region locations[", i, "]: ", _region_locations[i]);
 		Vector2i region_loc = _region_locations[i];
@@ -987,7 +987,7 @@ Ref<Image> Terrain3DStorage::layered_to_image(const MapType p_map_type) const {
 		Vector2i img_location = (region_loc - top_left) * _region_size;
 		LOG(DEBUG, "Region to blit: ", region_loc, " Export image coords: ", img_location);
 		int region_id = get_region_idp(Vector3(region_loc.x, 0, region_loc.y) * _region_size);
-		img->blit_rect(get_map_region(map_type, region_id), Rect2i(Vector2i(0, 0), _region_sizev), img_location);
+		img->blit_rect(get_map_region(map_type, region_id), Rect2i(V2I_ZERO, _region_sizev), img_location);
 	}
 	return img;
 }

--- a/src/terrain_3d_storage.cpp
+++ b/src/terrain_3d_storage.cpp
@@ -157,6 +157,7 @@ Ref<Terrain3DRegion> Terrain3DStorage::add_region_blank(const Vector2i &p_region
 	Ref<Terrain3DRegion> region;
 	region.instantiate();
 	region->set_location(p_region_loc);
+	region->set_region_size(_region_size);
 	if (add_region(region, p_update) == OK) {
 		region->set_modified(true);
 		return region;
@@ -186,8 +187,7 @@ Error Terrain3DStorage::add_region(const Ref<Terrain3DRegion> &p_region, const b
 				-REGION_MAP_SIZE / 2, " to ", REGION_MAP_SIZE / 2 - 1);
 		return FAILED;
 	}
-
-	p_region->sanitize_map();
+	p_region->sanitize_maps();
 	p_region->set_deleted(false);
 	if (!_region_locations.has(region_loc)) {
 		_region_locations.push_back(region_loc);

--- a/src/terrain_3d_storage.cpp
+++ b/src/terrain_3d_storage.cpp
@@ -40,6 +40,9 @@ void Terrain3DStorage::initialize(Terrain3D *p_terrain) {
 	_terrain = p_terrain;
 	_region_map.resize(REGION_MAP_SIZE * REGION_MAP_SIZE);
 	_mesh_vertex_spacing = _terrain->get_mesh_vertex_spacing();
+	_region_size = _terrain->get_region_size();
+	_region_sizev = Vector2i(_region_size, _region_size);
+
 	if (!initialized && !_terrain->get_storage_directory().is_empty()) {
 		load_directory(_terrain->get_storage_directory());
 	}
@@ -124,16 +127,6 @@ bool Terrain3DStorage::is_region_deleted(const Vector2i &p_region_loc) const {
 		return true;
 	}
 	return region->is_deleted();
-}
-
-void Terrain3DStorage::set_region_size(const RegionSize p_size) {
-	LOG(INFO, p_size);
-	//ERR_FAIL_COND(p_size < SIZE_64);
-	//ERR_FAIL_COND(p_size > SIZE_2048);
-	ERR_FAIL_COND(p_size != SIZE_1024);
-	_region_size = p_size;
-	_region_sizev = Vector2i(_region_size, _region_size);
-	emit_signal("region_size_changed", _region_size);
 }
 
 void Terrain3DStorage::set_region_locations(const TypedArray<Vector2i> &p_locations) {
@@ -959,13 +952,6 @@ void Terrain3DStorage::print_audit_data() const {
 ///////////////////////////
 
 void Terrain3DStorage::_bind_methods() {
-	//BIND_ENUM_CONSTANT(SIZE_64);
-	//BIND_ENUM_CONSTANT(SIZE_128);
-	//BIND_ENUM_CONSTANT(SIZE_256);
-	//BIND_ENUM_CONSTANT(SIZE_512);
-	BIND_ENUM_CONSTANT(SIZE_1024);
-	//BIND_ENUM_CONSTANT(SIZE_2048);
-
 	BIND_ENUM_CONSTANT(HEIGHT_FILTER_NEAREST);
 	BIND_ENUM_CONSTANT(HEIGHT_FILTER_MINIMUM);
 
@@ -993,10 +979,6 @@ void Terrain3DStorage::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("get_region_locationi", "region_id"), &Terrain3DStorage::get_region_locationi);
 	ClassDB::bind_method(D_METHOD("get_region_id", "region_location"), &Terrain3DStorage::get_region_id);
 	ClassDB::bind_method(D_METHOD("get_region_idp", "global_position"), &Terrain3DStorage::get_region_idp);
-
-	ClassDB::bind_method(D_METHOD("set_region_size", "size"), &Terrain3DStorage::set_region_size);
-	ClassDB::bind_method(D_METHOD("get_region_size"), &Terrain3DStorage::get_region_size);
-	ClassDB::bind_method(D_METHOD("get_region_sizev"), &Terrain3DStorage::get_region_sizev);
 
 	ClassDB::bind_method(D_METHOD("add_region", "region", "update"), &Terrain3DStorage::add_region, DEFVAL(true));
 	ClassDB::bind_method(D_METHOD("add_regionl", "region_location", "update"), &Terrain3DStorage::add_regionl, DEFVAL(true));
@@ -1048,15 +1030,10 @@ void Terrain3DStorage::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("export_image", "file_name", "map_type"), &Terrain3DStorage::export_image);
 	ClassDB::bind_method(D_METHOD("layered_to_image", "map_type"), &Terrain3DStorage::layered_to_image);
 
-	int ro_flags = PROPERTY_USAGE_STORAGE | PROPERTY_USAGE_EDITOR | PROPERTY_USAGE_READ_ONLY;
-	//ADD_PROPERTY(PropertyInfo(Variant::INT, "region_size", PROPERTY_HINT_ENUM, "64:64, 128:128, 256:256, 512:512, 1024:1024, 2048:2048"), "set_region_size", "get_region_size");
-	ADD_PROPERTY(PropertyInfo(Variant::INT, "region_size", PROPERTY_HINT_ENUM, "1024:1024"), "set_region_size", "get_region_size");
-
 	ADD_SIGNAL(MethodInfo("maps_changed"));
 	ADD_SIGNAL(MethodInfo("region_map_changed"));
 	ADD_SIGNAL(MethodInfo("height_maps_changed"));
 	ADD_SIGNAL(MethodInfo("control_maps_changed"));
 	ADD_SIGNAL(MethodInfo("color_maps_changed"));
-	ADD_SIGNAL(MethodInfo("region_size_changed"));
 	ADD_SIGNAL(MethodInfo("maps_edited", PropertyInfo(Variant::AABB, "edited_area")));
 }

--- a/src/terrain_3d_storage.cpp
+++ b/src/terrain_3d_storage.cpp
@@ -457,7 +457,7 @@ TypedArray<int> Terrain3DStorage::get_regions_under_aabb(const AABB &p_aabb) {
 			LOG(INFO, "Region id ", region_id, " location ", Vector3(x, 0, y));
 			// If found, append to array
 			if (region_id != -1) {
-				found.append(region_id);
+				found.push_back(region_id);
 			}
 		}
 	}

--- a/src/terrain_3d_storage.cpp
+++ b/src/terrain_3d_storage.cpp
@@ -58,23 +58,6 @@ TypedArray<Terrain3DRegion> Terrain3DStorage::get_regions_active(const bool p_co
 	return region_arr;
 }
 
-void Terrain3DStorage::update_master_height(const real_t p_height) {
-	if (p_height < _master_height_range.x) {
-		_master_height_range.x = p_height;
-	} else if (p_height > _master_height_range.y) {
-		_master_height_range.y = p_height;
-	}
-}
-
-void Terrain3DStorage::update_master_heights(const Vector2 &p_low_high) {
-	if (p_low_high.x < _master_height_range.x) {
-		_master_height_range.x = p_low_high.x;
-	}
-	if (p_low_high.y > _master_height_range.y) {
-		_master_height_range.y = p_low_high.y;
-	}
-}
-
 // Recalculates master height range from all active regions current height ranges
 // Recursive mode has all regions to recalculate from each heightmap pixel
 void Terrain3DStorage::calc_height_range(const bool p_recursive) {

--- a/src/terrain_3d_storage.h
+++ b/src/terrain_3d_storage.h
@@ -6,7 +6,6 @@
 #include "constants.h"
 #include "generated_texture.h"
 #include "terrain_3d_region.h"
-#include "terrain_3d_util.h"
 
 class Terrain3D;
 
@@ -21,34 +20,6 @@ public: // Constants
 	static inline const real_t CURRENT_VERSION = 0.92f;
 	static inline const int REGION_MAP_SIZE = 16;
 	static inline const Vector2i REGION_MAP_VSIZE = Vector2i(REGION_MAP_SIZE, REGION_MAP_SIZE);
-
-	enum MapType {
-		TYPE_HEIGHT,
-		TYPE_CONTROL,
-		TYPE_COLOR,
-		TYPE_MAX,
-	};
-
-	static inline const Image::Format FORMAT[] = {
-		Image::FORMAT_RF, // TYPE_HEIGHT
-		Image::FORMAT_RF, // TYPE_CONTROL
-		Image::FORMAT_RGBA8, // TYPE_COLOR
-		Image::Format(TYPE_MAX), // Proper size of array instead of FORMAT_MAX
-	};
-
-	static inline const char *TYPESTR[] = {
-		"TYPE_HEIGHT",
-		"TYPE_CONTROL",
-		"TYPE_COLOR",
-		"TYPE_MAX",
-	};
-
-	static inline const Color COLOR[] = {
-		COLOR_BLACK, // TYPE_HEIGHT
-		COLOR_CONTROL, // TYPE_CONTROL
-		COLOR_ROUGHNESS, // TYPE_COLOR
-		COLOR_NAN, // TYPE_MAX, unused just in case someone indexes the array
-	};
 
 	enum RegionSize {
 		//SIZE_64 = 64,
@@ -180,7 +151,6 @@ public:
 	Vector3 get_texture_id(const Vector3 &p_global_position) const;
 	real_t get_angle(const Vector3 &p_global_position) const;
 	real_t get_scale(const Vector3 &p_global_position) const;
-	TypedArray<Image> sanitize_maps(const MapType p_map_type, const TypedArray<Image> &p_maps) const;
 	void force_update_maps(const MapType p_map = TYPE_MAX);
 
 	// Instancer
@@ -212,12 +182,6 @@ protected:
 	static void _bind_methods();
 };
 
-typedef Terrain3DStorage::MapType MapType;
-VARIANT_ENUM_CAST(Terrain3DStorage::MapType);
-constexpr Terrain3DStorage::MapType TYPE_HEIGHT = Terrain3DStorage::MapType::TYPE_HEIGHT;
-constexpr Terrain3DStorage::MapType TYPE_CONTROL = Terrain3DStorage::MapType::TYPE_CONTROL;
-constexpr Terrain3DStorage::MapType TYPE_COLOR = Terrain3DStorage::MapType::TYPE_COLOR;
-constexpr Terrain3DStorage::MapType TYPE_MAX = Terrain3DStorage::MapType::TYPE_MAX;
 VARIANT_ENUM_CAST(Terrain3DStorage::RegionSize);
 VARIANT_ENUM_CAST(Terrain3DStorage::HeightFilter);
 

--- a/src/terrain_3d_storage.h
+++ b/src/terrain_3d_storage.h
@@ -73,7 +73,7 @@ private:
 	real_t _mesh_vertex_spacing = 1.f; // Set by Terrain3D::set_mesh_vertex_spacing
 	bool _loading = false; // tracking when we're loading so we don't add_region w/ update
 
-	// TODO: Should be in Terrain3D so its saved
+	// TODO: Should be in Terrain3D or per region so its saved
 	Vector2 _height_range = Vector2(0.f, 0.f);
 
 	// Work data
@@ -191,10 +191,10 @@ public:
 	// File I/O
 	void save_directory(const String &p_dir);
 	void load_directory(const String &p_dir);
-
 	void save_region(const String &p_dir, const Vector2i &p_region_loc, const bool p_16_bit = false);
 	void load_region(const String &p_dir, const Vector2i &p_region_loc);
-	void register_region(const Ref<Terrain3DRegion> &p_region, const Vector2i &p_region_loc);
+
+	void register_region(const Ref<Terrain3DRegion> &p_region);
 	TypedArray<int> get_regions_under_aabb(const AABB &p_aabb);
 
 	void import_images(const TypedArray<Image> &p_images, const Vector3 &p_global_position = Vector3(0.f, 0.f, 0.f),

--- a/src/terrain_3d_storage.h
+++ b/src/terrain_3d_storage.h
@@ -168,7 +168,7 @@ public:
 	void register_region(const Ref<Terrain3DRegion> &p_region);
 	TypedArray<int> get_regions_under_aabb(const AABB &p_aabb);
 
-	void import_images(const TypedArray<Image> &p_images, const Vector3 &p_global_position = Vector3(0.f, 0.f, 0.f),
+	void import_images(const TypedArray<Image> &p_images, const Vector3 &p_global_position = V3_ZERO,
 			const real_t p_offset = 0.f, const real_t p_scale = 1.f);
 	Error export_image(const String &p_file_name, const MapType p_map_type = TYPE_HEIGHT) const;
 	Ref<Image> layered_to_image(const MapType p_map_type) const;
@@ -208,7 +208,7 @@ inline Vector2i Terrain3DStorage::get_region_location(const Vector3 &p_global_po
 // Returns Vector2i(2147483647) if out of range
 inline Vector2i Terrain3DStorage::get_region_locationi(const int p_region_id) const {
 	if (p_region_id < 0 || p_region_id >= _region_locations.size()) {
-		return Vector2i(INT32_MAX, INT32_MAX);
+		return V2I_MAX;
 	}
 	return _region_locations[p_region_id];
 }

--- a/src/terrain_3d_storage.h
+++ b/src/terrain_3d_storage.h
@@ -21,15 +21,6 @@ public: // Constants
 	static inline const int REGION_MAP_SIZE = 16;
 	static inline const Vector2i REGION_MAP_VSIZE = Vector2i(REGION_MAP_SIZE, REGION_MAP_SIZE);
 
-	enum RegionSize {
-		//SIZE_64 = 64,
-		//SIZE_128 = 128,
-		//SIZE_256 = 256,
-		//SIZE_512 = 512,
-		SIZE_1024 = 1024,
-		//SIZE_2048 = 2048,
-	};
-
 	enum HeightFilter {
 		HEIGHT_FILTER_NEAREST,
 		HEIGHT_FILTER_MINIMUM
@@ -39,6 +30,8 @@ private:
 	Terrain3D *_terrain = nullptr;
 
 	// Storage Settings & flags
+	int _region_size = 0;
+	Vector2i _region_sizev = Vector2i(_region_size, _region_size);
 	real_t _mesh_vertex_spacing = 1.f; // Set by Terrain3D::set_mesh_vertex_spacing
 
 	AABB _edited_area;
@@ -79,10 +72,6 @@ private:
 	GeneratedTexture _generated_control_maps;
 	GeneratedTexture _generated_color_maps;
 
-	/// Move to Region?
-	RegionSize _region_size = SIZE_1024;
-	Vector2i _region_sizev = Vector2i(_region_size, _region_size);
-
 	// Functions
 	void _clear();
 
@@ -120,10 +109,6 @@ public:
 	Vector2i get_region_locationi(const int p_region_id) const;
 	int get_region_id(const Vector2i &p_region_loc) const;
 	int get_region_idp(const Vector3 &p_global_position) const;
-
-	void set_region_size(const RegionSize p_size);
-	RegionSize get_region_size() const { return _region_size; }
-	Vector2i get_region_sizev() const { return _region_sizev; }
 
 	Error add_region(const Ref<Terrain3DRegion> &p_region, const bool p_update = true);
 	Error add_regionl(const Vector2i &p_region_loc, const Ref<Terrain3DRegion> &p_region, const bool p_update = true);
@@ -192,7 +177,6 @@ protected:
 	static void _bind_methods();
 };
 
-VARIANT_ENUM_CAST(Terrain3DStorage::RegionSize);
 VARIANT_ENUM_CAST(Terrain3DStorage::HeightFilter);
 
 /// Inline Region Functions

--- a/src/terrain_3d_storage.h
+++ b/src/terrain_3d_storage.h
@@ -65,45 +65,54 @@ public: // Constants
 		HEIGHT_FILTER_MINIMUM
 	};
 
+	///////////////////////////
+	// 	Terrain3DRegion
+	///////////////////////////
+
 	class Terrain3DRegion : public Resource {
 		GDCLASS(Terrain3DRegion, Resource);
 		CLASS_NAME();
 
 	private:
-		// Map info
+		bool _modified = false;
+		real_t _version = 0.8f; // Set to first version to ensure Godot always upgrades this
+		// Maps
 		Ref<Image> _height_map;
 		Ref<Image> _control_map;
 		Ref<Image> _color_map;
-		// Foliage Instancer contains MultiMeshes saved to disk
+		// Instancer MultiMeshes saved to disk
 		// Dictionary[mesh_id:int] -> MultiMesh
 		Dictionary _multimeshes;
-		real_t _version = 0.8f; // Set to ensure Godot always saves this
 
 	public:
-		// Map Info
-		void set_height_map(Ref<Image> p_map) { _height_map = p_map; }
+		void set_modified(const bool p_modified) { _modified = p_modified; }
+		bool get_modified() const { return _modified; }
+		bool is_modified() const { return _modified == true; }
+		void set_version(const real_t p_version);
+		real_t get_version() const { return _version; }
+
+		// Maps
+		void set_height_map(const Ref<Image> &p_map) { _height_map = p_map; }
 		Ref<Image> get_height_map() const { return _height_map; }
-		void set_control_map(Ref<Image> p_map) { _control_map = p_map; }
+		void set_control_map(const Ref<Image> &p_map) { _control_map = p_map; }
 		Ref<Image> get_control_map() const { return _control_map; }
-		void set_color_map(Ref<Image> p_map) { _color_map = p_map; }
+		void set_color_map(const Ref<Image> &p_map) { _color_map = p_map; }
 		Ref<Image> get_color_map() const { return _color_map; }
 
-		// Foliage Instancer
-		void set_multimeshes(Dictionary p_instances) { _multimeshes = p_instances; }
+		// Instancer
+		void set_multimeshes(const Dictionary &p_multimeshes) { _multimeshes = p_multimeshes; }
 		Dictionary get_multimeshes() const { return _multimeshes; }
-
-		void set_version(real_t p_version) { _version = p_version; }
-		real_t get_version() { return _version; }
 
 	protected:
 		static void _bind_methods();
 	};
 
+	///////////////////////////
+
 private:
 	Terrain3D *_terrain = nullptr;
 
 	// Storage Settings & flags
-	real_t _version = 0.8f; // Set to ensure Godot always saves this
 	TypedArray<bool> _modified = TypedArray<bool>(); // TODO: Make sure this is the right size
 	bool _save_16_bit = false;
 	RegionSize _region_size = SIZE_1024;
@@ -149,8 +158,6 @@ public:
 	void initialize(Terrain3D *p_terrain);
 	~Terrain3DStorage();
 
-	void set_version(const real_t p_version);
-	real_t get_version() const { return _version; }
 	void set_save_16_bit(const bool p_enabled);
 	bool get_save_16_bit() const { return _save_16_bit; }
 

--- a/src/terrain_3d_storage.h
+++ b/src/terrain_3d_storage.h
@@ -120,7 +120,6 @@ private:
 	Terrain3D *_terrain = nullptr;
 
 	// Storage Settings & flags
-	TypedArray<bool> _modified = TypedArray<bool>(); // TODO: Make sure this is the right size
 	RegionSize _region_size = SIZE_1024;
 	Vector2i _region_sizev = Vector2i(_region_size, _region_size);
 	bool _loading = false; // I am a little hesitant to include state like this.
@@ -177,6 +176,10 @@ public:
 	AABB get_edited_area() const { return _edited_area; }
 
 	// Regions
+	Dictionary get_regions() { return _regions; }
+	void set_region_modified(const Vector2i &p_region_loc, const bool p_modified = true);
+	bool get_region_modified(const Vector2i &p_region_loc) const;
+
 	void set_region_size(const RegionSize p_size);
 	RegionSize get_region_size() const { return _region_size; }
 	Vector2i get_region_sizev() const { return _region_sizev; }
@@ -193,7 +196,8 @@ public:
 	String get_region_filename_from_id(const int p_region_id) const;
 	bool has_region(const Vector3 &p_global_position) const { return get_region_id(p_global_position) != -1; }
 	Error add_region(const Vector3 &p_global_position,
-			const TypedArray<Image> &p_images = TypedArray<Image>(), const bool p_update = true,
+			const TypedArray<Image> &p_images = TypedArray<Image>(),
+			const bool p_update = true,
 			const String &p_path = "");
 	void remove_region(const Vector3 &p_global_position, const bool p_update = true, const String &p_path = "");
 	void remove_region_by_id(const int p_region_id, const bool p_update = true, const String &p_path = "");
@@ -237,11 +241,7 @@ public:
 	Dictionary get_multimeshes(const TypedArray<int> &p_region_ids) const;
 
 	// File I/O
-	void save(const String &p_path);
-	void clear_modified() { _modified.fill(false); }
-	void set_all_regions_modified() { _modified.fill(true); }
-	void set_modified(int p_index);
-	TypedArray<bool> get_modified() const { return _modified; }
+	void save(const String &p_dir);
 	void load_directory(const String &p_dir);
 
 	void save_region(const String &p_dir, const int p_region_id, const bool p_16_bit = false);

--- a/src/terrain_3d_storage.h
+++ b/src/terrain_3d_storage.h
@@ -76,6 +76,8 @@ public: // Constants
 	private:
 		bool _modified = false;
 		real_t _version = 0.8f; // Set to first version to ensure Godot always upgrades this
+		Vector2i _region_loc = Vector2i(INT32_MIN, INT32_MIN);
+
 		// Maps
 		Ref<Image> _height_map;
 		Ref<Image> _control_map;
@@ -90,9 +92,11 @@ public: // Constants
 		bool is_modified() const { return _modified == true; }
 		void set_version(const real_t p_version);
 		real_t get_version() const { return _version; }
+		void set_region_loc(const Vector2i &p_region_loc) { _region_loc = p_region_loc; }
+		Vector2i get_region_loc() const { return _region_loc; }
 
 		// Maps
-		void set_height_map(const Ref<Image> &p_map) { _height_map = p_map; }
+		void set_height_map(const Ref<Image> &p_map);
 		Ref<Image> get_height_map() const { return _height_map; }
 		void set_control_map(const Ref<Image> &p_map) { _control_map = p_map; }
 		Ref<Image> get_control_map() const { return _control_map; }
@@ -102,6 +106,9 @@ public: // Constants
 		// Instancer
 		void set_multimeshes(const Dictionary &p_multimeshes) { _multimeshes = p_multimeshes; }
 		Dictionary get_multimeshes() const { return _multimeshes; }
+
+		// File I/O
+		Error save(const String &p_path = "", const bool p_16_bit = false);
 
 	protected:
 		static void _bind_methods();
@@ -114,7 +121,6 @@ private:
 
 	// Storage Settings & flags
 	TypedArray<bool> _modified = TypedArray<bool>(); // TODO: Make sure this is the right size
-	bool _save_16_bit = false;
 	RegionSize _region_size = SIZE_1024;
 	Vector2i _region_sizev = Vector2i(_region_size, _region_size);
 	bool _loading = false; // I am a little hesitant to include state like this.
@@ -145,6 +151,8 @@ private:
 	TypedArray<Image> _control_maps;
 	TypedArray<Image> _color_maps;
 
+	Dictionary _regions;
+
 	// Foliage Instancer contains MultiMeshes saved to disk
 	// Dictionary[region_location:Vector2i] -> Dictionary[mesh_id:int] -> MultiMesh
 	Dictionary _multimeshes;
@@ -157,9 +165,6 @@ public:
 	Terrain3DStorage() {}
 	void initialize(Terrain3D *p_terrain);
 	~Terrain3DStorage();
-
-	void set_save_16_bit(const bool p_enabled);
-	bool get_save_16_bit() const { return _save_16_bit; }
 
 	void set_height_range(const Vector2 &p_range);
 	Vector2 get_height_range() const { return _height_range; }
@@ -193,12 +198,6 @@ public:
 	void remove_region(const Vector3 &p_global_position, const bool p_update = true, const String &p_path = "");
 	void remove_region_by_id(const int p_region_id, const bool p_update = true, const String &p_path = "");
 	void update_maps();
-
-	void save_region(const String &p_path, const int p_region_id);
-	void load_region(const String &p_path, const int p_region_id);
-	void load_region_by_location(const String &p_path, const Vector2i &p_region_loc);
-	void register_region(const Ref<Terrain3DRegion> &p_region, const Vector2i &p_region_loc);
-	TypedArray<int> get_regions_under_aabb(const AABB &p_aabb);
 
 	// Maps
 	void set_map_region(const MapType p_map_type, const int p_region_id, const Ref<Image> &p_image);
@@ -244,6 +243,12 @@ public:
 	void set_modified(int p_index);
 	TypedArray<bool> get_modified() const { return _modified; }
 	void load_directory(const String &p_dir);
+
+	void save_region(const String &p_dir, const int p_region_id, const bool p_16_bit = false);
+	void load_region(const String &p_dir, const int p_region_id);
+	void load_region_by_location(const String &p_path, const Vector2i &p_region_loc);
+	void register_region(const Ref<Terrain3DRegion> &p_region, const Vector2i &p_region_loc);
+	TypedArray<int> get_regions_under_aabb(const AABB &p_aabb);
 
 	void import_images(const TypedArray<Image> &p_images, const Vector3 &p_global_position = Vector3(0.f, 0.f, 0.f),
 			const real_t p_offset = 0.f, const real_t p_scale = 1.f);

--- a/src/terrain_3d_storage.h
+++ b/src/terrain_3d_storage.h
@@ -278,4 +278,21 @@ inline real_t Terrain3DStorage::get_roughness(const Vector3 &p_global_position) 
 	return get_pixel(TYPE_COLOR, p_global_position).a;
 }
 
+inline void Terrain3DStorage::update_master_height(const real_t p_height) {
+	if (p_height < _master_height_range.x) {
+		_master_height_range.x = p_height;
+	} else if (p_height > _master_height_range.y) {
+		_master_height_range.y = p_height;
+	}
+}
+
+inline void Terrain3DStorage::update_master_heights(const Vector2 &p_low_high) {
+	if (p_low_high.x < _master_height_range.x) {
+		_master_height_range.x = p_low_high.x;
+	}
+	if (p_low_high.y > _master_height_range.y) {
+		_master_height_range.y = p_low_high.y;
+	}
+}
+
 #endif // TERRAIN3D_STORAGE_CLASS_H

--- a/src/terrain_3d_texture_asset.cpp
+++ b/src/terrain_3d_texture_asset.cpp
@@ -37,9 +37,6 @@ Terrain3DTextureAsset::Terrain3DTextureAsset() {
 	clear();
 }
 
-Terrain3DTextureAsset::~Terrain3DTextureAsset() {
-}
-
 void Terrain3DTextureAsset::clear() {
 	_name = "New Texture";
 	_id = 0;

--- a/src/terrain_3d_texture_asset.h
+++ b/src/terrain_3d_texture_asset.h
@@ -25,7 +25,7 @@ class Terrain3DTextureAsset : public Terrain3DAssetResource {
 
 public:
 	Terrain3DTextureAsset();
-	~Terrain3DTextureAsset();
+	~Terrain3DTextureAsset() {}
 
 	void clear() override;
 

--- a/src/terrain_3d_util.cpp
+++ b/src/terrain_3d_util.cpp
@@ -30,6 +30,28 @@ void Terrain3DUtil::dump_maps(const TypedArray<Image> &p_maps, const String &p_n
 	}
 }
 
+// Expects a filename in a String like: "terrain3d-01_02.res" which returns (-1, 2)
+Vector2i Terrain3DUtil::filename_to_location(const String &p_filename) {
+	String working_string = p_filename.trim_suffix(".res");
+	String y_str = working_string.right(3).replace("_", "");
+	working_string = working_string.erase(working_string.length() - 3, 3);
+	String x_str = working_string.right(3).replace("_", "");
+	if (!x_str.is_valid_int() || !y_str.is_valid_int()) {
+		LOG(ERROR, "Malformed filename at ", p_filename, ": got x ", x_str, " y ", y_str);
+		return Vector2i(INT32_MAX, INT32_MAX);
+	}
+	return Vector2i(x_str.to_int(), y_str.to_int());
+}
+
+String Terrain3DUtil::location_to_filename(const Vector2i &p_region_loc) {
+	const String POS_REGION_FORMAT = "_%02d";
+	const String NEG_REGION_FORMAT = "%03d";
+	String x_str, y_str;
+	x_str = vformat((p_region_loc.x >= 0) ? POS_REGION_FORMAT : NEG_REGION_FORMAT, p_region_loc.x);
+	y_str = vformat((p_region_loc.y >= 0) ? POS_REGION_FORMAT : NEG_REGION_FORMAT, p_region_loc.y);
+	return "terrain3d" + x_str + y_str + ".res";
+}
+
 Ref<Image> Terrain3DUtil::black_to_alpha(const Ref<Image> &p_image) {
 	if (p_image.is_null()) {
 		return Ref<Image>();
@@ -320,6 +342,10 @@ void Terrain3DUtil::_bind_methods() {
 	ClassDB::bind_static_method("Terrain3DUtil", D_METHOD("enc_uv_rotation", "rotation"), &gd_enc_uv_rotation);
 	ClassDB::bind_static_method("Terrain3DUtil", D_METHOD("get_uv_scale", "pixel"), &gd_get_uv_scale);
 	ClassDB::bind_static_method("Terrain3DUtil", D_METHOD("enc_uv_scale", "scale"), &gd_enc_uv_scale);
+
+	// String functions
+	ClassDB::bind_static_method("Terrain3DUtil", D_METHOD("filename_to_location", "filename"), &Terrain3DUtil::filename_to_location);
+	ClassDB::bind_static_method("Terrain3DUtil", D_METHOD("location_to_filename", "region_location"), &Terrain3DUtil::location_to_filename);
 
 	// Image handling
 	ClassDB::bind_static_method("Terrain3DUtil", D_METHOD("black_to_alpha", "image"), &Terrain3DUtil::black_to_alpha);

--- a/src/terrain_3d_util.cpp
+++ b/src/terrain_3d_util.cpp
@@ -10,11 +10,56 @@
 // Public Functions
 ///////////////////////////
 
+void Terrain3DUtil::print_arr(const String &p_name, const Array &p_arr, const int p_level) {
+	LOG(p_level, "Array[", p_arr.size(), "]: ", p_name);
+	for (int i = 0; i < p_arr.size(); i++) {
+		Variant var = p_arr[i];
+		switch (var.get_type()) {
+			case Variant::ARRAY: {
+				print_arr(p_name + String::num_int64(i), var, p_level);
+				break;
+			}
+			case Variant::DICTIONARY: {
+				print_dict(p_name + String::num_int64(i), var, p_level);
+				break;
+			}
+			case Variant::OBJECT: {
+				String inst = "Object#" + String::num_uint64(cast_to<Object>(var)->get_instance_id());
+				LOG(p_level, i, ": ", inst);
+				break;
+			}
+			default: {
+				LOG(p_level, i, ": ", p_arr[i]);
+				break;
+			}
+		}
+	}
+}
+
 void Terrain3DUtil::print_dict(const String &p_name, const Dictionary &p_dict, const int p_level) {
-	LOG(p_level, "Printing Dictionary: ", p_name);
+	LOG(p_level, "Dictionary: ", p_name);
 	Array keys = p_dict.keys();
 	for (int i = 0; i < keys.size(); i++) {
-		LOG(p_level, "Key: ", keys[i], ", Value: ", p_dict[keys[i]]);
+		Variant var = p_dict[keys[i]];
+		switch (var.get_type()) {
+			case Variant::ARRAY: {
+				print_arr(p_name + String::num_int64(i), var, p_level);
+				break;
+			}
+			case Variant::DICTIONARY: {
+				print_dict(p_name + String::num_int64(i), var, p_level);
+				break;
+			}
+			case Variant::OBJECT: {
+				String inst = "Object#" + String::num_uint64(cast_to<Object>(var)->get_instance_id());
+				LOG(p_level, "\"", keys[i], "\": ", inst);
+				break;
+			}
+			default: {
+				LOG(p_level, "\"", keys[i], "\": Value: ", var);
+				break;
+			}
+		}
 	}
 }
 

--- a/src/terrain_3d_util.cpp
+++ b/src/terrain_3d_util.cpp
@@ -38,7 +38,7 @@ Vector2i Terrain3DUtil::filename_to_location(const String &p_filename) {
 	String x_str = working_string.right(3).replace("_", "");
 	if (!x_str.is_valid_int() || !y_str.is_valid_int()) {
 		LOG(ERROR, "Malformed filename at ", p_filename, ": got x ", x_str, " y ", y_str);
-		return Vector2i(INT32_MAX, INT32_MAX);
+		return V2I_MAX;
 	}
 	return Vector2i(x_str.to_int(), y_str.to_int());
 }
@@ -79,7 +79,7 @@ Vector2 Terrain3DUtil::get_min_max(const Ref<Image> &p_image) {
 		return Vector2(INFINITY, INFINITY);
 	}
 
-	Vector2 min_max = Vector2(0.f, 0.f);
+	Vector2 min_max = V2_ZERO;
 
 	for (int y = 0; y < p_image->get_height(); y++) {
 		for (int x = 0; x < p_image->get_width(); x++) {
@@ -200,7 +200,7 @@ Ref<Image> Terrain3DUtil::get_filled_image(const Vector2i &p_size, const Color &
 			color.a = 1.0f;
 			Color col_a = Color(0.8f, 0.8f, 0.8f, 1.0) * color;
 			Color col_b = Color(0.5f, 0.5f, 0.5f, 1.0) * color;
-			img->fill_rect(Rect2i(Vector2i(0, 0), p_size / 2), col_a);
+			img->fill_rect(Rect2i(V2I_ZERO, p_size / 2), col_a);
 			img->fill_rect(Rect2i(p_size / 2, p_size / 2), col_a);
 			img->fill_rect(Rect2i(Vector2(p_size.x, 0) / 2, p_size / 2), col_b);
 			img->fill_rect(Rect2i(Vector2(0, p_size.y) / 2, p_size / 2), col_b);
@@ -247,7 +247,7 @@ Ref<Image> Terrain3DUtil::load_image(const String &p_file_name, const int p_cach
 		Ref<FileAccess> file = FileAccess::open(p_file_name, FileAccess::READ);
 		// If p_size is zero, assume square and try to auto detect size
 		Vector2i r16_size = p_r16_size;
-		if (r16_size <= Vector2i(0, 0)) {
+		if (r16_size <= V2I_ZERO) {
 			file->seek_end();
 			int fsize = file->get_position();
 			int fwidth = sqrt(fsize / 2);
@@ -352,6 +352,6 @@ void Terrain3DUtil::_bind_methods() {
 	ClassDB::bind_static_method("Terrain3DUtil", D_METHOD("get_min_max", "image"), &Terrain3DUtil::get_min_max);
 	ClassDB::bind_static_method("Terrain3DUtil", D_METHOD("get_thumbnail", "image", "size"), &Terrain3DUtil::get_thumbnail, DEFVAL(Vector2i(256, 256)));
 	ClassDB::bind_static_method("Terrain3DUtil", D_METHOD("get_filled_image", "size", "color", "create_mipmaps", "format"), &Terrain3DUtil::get_filled_image);
-	ClassDB::bind_static_method("Terrain3DUtil", D_METHOD("load_image", "file_name", "cache_mode", "r16_height_range", "r16_size"), &Terrain3DUtil::load_image, DEFVAL(ResourceLoader::CACHE_MODE_IGNORE), DEFVAL(Vector2(0, 255)), DEFVAL(Vector2i(0, 0)));
+	ClassDB::bind_static_method("Terrain3DUtil", D_METHOD("load_image", "file_name", "cache_mode", "r16_height_range", "r16_size"), &Terrain3DUtil::load_image, DEFVAL(ResourceLoader::CACHE_MODE_IGNORE), DEFVAL(Vector2(0, 255)), DEFVAL(V2I_ZERO));
 	ClassDB::bind_static_method("Terrain3DUtil", D_METHOD("pack_image", "src_rgb", "src_r", "invert_green_channel"), &Terrain3DUtil::pack_image, DEFVAL(false));
 }

--- a/src/terrain_3d_util.cpp
+++ b/src/terrain_3d_util.cpp
@@ -255,7 +255,7 @@ Ref<Image> Terrain3DUtil::load_image(const String &p_file_name, const int p_cach
 			LOG(DEBUG, "Total file size is: ", fsize, " calculated width: ", fwidth, " dimensions: ", r16_size);
 			file->seek(0);
 		}
-		img = Image::create(r16_size.x, r16_size.y, false, Terrain3DStorage::FORMAT[TYPE_HEIGHT]);
+		img = Image::create(r16_size.x, r16_size.y, false, FORMAT[TYPE_HEIGHT]);
 		for (int y = 0; y < r16_size.y; y++) {
 			for (int x = 0; x < r16_size.x; x++) {
 				real_t h = real_t(file->get_16()) / 65535.0f;

--- a/src/terrain_3d_util.cpp
+++ b/src/terrain_3d_util.cpp
@@ -276,7 +276,7 @@ Ref<Image> Terrain3DUtil::load_image(const String &p_file_name, const int p_cach
 	}
 
 	if (!img.is_valid()) {
-		LOG(ERROR, "File", p_file_name, " could not be loaded.");
+		LOG(ERROR, "File", p_file_name, " cannot be loaded.");
 		return Ref<Image>();
 	}
 	if (img->is_empty()) {

--- a/src/terrain_3d_util.h
+++ b/src/terrain_3d_util.h
@@ -4,11 +4,17 @@
 #define TERRAIN3D_UTIL_CLASS_H
 
 #include <godot_cpp/classes/image.hpp>
+#include <godot_cpp/classes/resource_loader.hpp>
 
 #include "constants.h"
 #include "generated_texture.h"
 
 using namespace godot;
+
+// This file holds stateless utility functions for both C++ and GDScript
+// The class exposes static member and inline functions to GDscript
+// The inline functions below are not part of the class eg bilerp
+// However some of these inline functions are also exposed to GDScript
 
 class Terrain3DUtil : public Object {
 	GDCLASS(Terrain3DUtil, Object);
@@ -19,6 +25,10 @@ public:
 	static void print_dict(const String &name, const Dictionary &p_dict, const int p_level = 2); // Level 2: DEBUG
 	static void dump_gentex(const GeneratedTexture p_gen, const String &name = "", const int p_level = 2);
 	static void dump_maps(const TypedArray<Image> &p_maps, const String &p_name = "");
+
+	// String functions
+	static Vector2i filename_to_location(const String &p_filename);
+	static String location_to_filename(const Vector2i &p_region_loc);
 
 	// Image operations
 	static Ref<Image> black_to_alpha(const Ref<Image> &p_image);
@@ -44,6 +54,7 @@ typedef Terrain3DUtil Util;
 // Math
 ///////////////////////////
 
+// Rounds a decimal to the nearest multiple eg round_multiple(2.7, 4) -> 4
 template <typename T>
 T round_multiple(const T p_value, const T p_multiple) {
 	if (p_multiple == 0) {

--- a/src/terrain_3d_util.h
+++ b/src/terrain_3d_util.h
@@ -39,7 +39,7 @@ public:
 			const bool p_create_mipmaps = true,
 			const Image::Format p_format = Image::FORMAT_MAX);
 	static Ref<Image> load_image(const String &p_file_name, const int p_cache_mode = ResourceLoader::CACHE_MODE_IGNORE,
-			const Vector2 &p_r16_height_range = Vector2(0.f, 255.f), const Vector2i &p_r16_size = Vector2i(0, 0));
+			const Vector2 &p_r16_height_range = Vector2(0.f, 255.f), const Vector2i &p_r16_size = V2I_ZERO);
 	static Ref<Image> pack_image(const Ref<Image> &p_src_rgb, const Ref<Image> &p_src_r, const bool p_invert_green_channel = false);
 
 protected:

--- a/src/terrain_3d_util.h
+++ b/src/terrain_3d_util.h
@@ -64,6 +64,10 @@ T round_multiple(const T p_value, const T p_multiple) {
 	return static_cast<T>(std::round(static_cast<double>(p_value) / static_cast<double>(p_multiple)) * static_cast<double>(p_multiple));
 }
 
+inline bool is_power_of_2(const int p_n) {
+	return p_n && !(p_n & (p_n - 1));
+}
+
 // Returns the bilinearly interpolated value derived from parameters:
 // * 4 values to be interpolated
 // * Positioned at the 4 corners of the p_pos00 - p_pos11 rectangle

--- a/src/terrain_3d_util.h
+++ b/src/terrain_3d_util.h
@@ -22,7 +22,8 @@ class Terrain3DUtil : public Object {
 
 public:
 	// Print info to the console
-	static void print_dict(const String &name, const Dictionary &p_dict, const int p_level = 2); // Level 2: DEBUG
+	static void print_arr(const String &p_name, const Array &p_arr, const int p_level = 2); // Level 2: DEBUG
+	static void print_dict(const String &p_name, const Dictionary &p_dict, const int p_level = 2); // Level 2: DEBUG
 	static void dump_gentex(const GeneratedTexture p_gen, const String &name = "", const int p_level = 2);
 	static void dump_maps(const TypedArray<Image> &p_maps, const String &p_name = "");
 


### PR DESCRIPTION
## Update by TokisanGames
Separates the monolithic storage resource file into one file per region.

Fixes #356 
Fixes #165
Fixes #159 
Fixes #419

TODO:
* [x] Get separate region files working for editing, loading, and saving - finished by SlashScreen
* [x] Review updates to Storage
* [x] Adjust the API for more region location focus
* [x] Redesign and reimplement Storage & Region
    * Don't remove region files from disk until saved 
* [x] Rework height tracking f/ AABBs
* [x] Rework instancer storage
* [x] Add overlay to show region locations
* [x] Rework undo
    * Undo add/delete region doesn't work
    * Simplify
    * Work with foliage

Test:
* [x] get_texture_id
* [x] edited area AABB
* [x] setting heights

See #433 for API changes

More API changes
### Functions
|Old Name| New Name|
|--|--|
|**Terrain3DStorage**
|`get_region_location_from_id`|`get_region_locationi`
|`get_region_id(position)`|`get_region_idp(position)`, `get_region_id(location)`
|`has_region(position)`|`has_regionp(position)`, `has_region(location)`
|`get_height_rid`|`get_height_maps_rid`
|`get_control_rid`|`get_control_maps_rid`
|`get_color_rid`|`get_color_maps_rid`
|`set_height_maps` | removed
|`set_control_maps` | removed
|`set_color_maps` | removed
|`set_map_region` | removed
|`get_map_region` | removed
|`set_maps` | removed


### Enums / Constants
|Old Name| New Name|
|--|--|
|Terrain3DStorage::MapType | Terrain3DRegion::MapType


Future features not in these PRs:
* Expanding region limits from 256 to 2048
* Adjustable region sizes #77 
* Update #381

------
## Original by SlashScreen
Resolves #356 , ~~and expands terrain limit from 256 to 2048.~~ (admin)