### PR TITLE
Fix out-of-bounds access in Terrain3DAssets.

### DIFF
--- a/src/terrain_3d_assets.cpp
+++ b/src/terrain_3d_assets.cpp
@@ -370,7 +370,7 @@ Terrain3DAssets::~Terrain3DAssets() {
 }
 
 void Terrain3DAssets::set_texture(int p_id, const Ref<Terrain3DTextureAsset> &p_texture) {
-	if (_texture_list.is_empty() || p_texture != _texture_list[p_id]) {
+	if (_texture_list.size() <= p_id || p_texture != _texture_list[p_id]) {
 		LOG(INFO, "Setting texture id: ", p_id);
 		_set_asset(TYPE_TEXTURE, p_id, p_texture);
 		update_texture_list();


### PR DESCRIPTION
Previously, `Terrain3DAssets::set_texture` could perform an out-of-bounds access on line 373, potentially leading to a segmentation violation which would crash the editor. This notably happened when adding new textures to a resource of that type using the asset dock.

This occurred because even if `_texture_list.is_empty()` evaluates to `false`, `p_id` could still be outside the bounds of the `_texture_list` array. For example, when adding a texture to a Terrain3DAssets resource which already had items present, this code would cause a SIGSEGV on my machine, because p_id was equal to the length of the array rather than an index to an item within it.