### PR TITLE
Terrain3DObjects fixes

### DIFF
--- a/project/addons/terrain_3d/editor.gd
+++ b/project/addons/terrain_3d/editor.gd
@@ -85,7 +85,7 @@ func _edit(p_object: Object) -> void:
 			terrain.storage_changed.connect(_load_storage)
 		_load_storage()
 	else:
-		terrain = null
+		_clear()
 
 	if is_instance_valid(_last_terrain) and _last_terrain.is_inside_tree():
 		if p_object is NavigationRegion3D:

--- a/project/addons/terrain_3d/editor.gd
+++ b/project/addons/terrain_3d/editor.gd
@@ -54,11 +54,17 @@ func _exit_tree() -> void:
 func _handles(p_object: Object) -> bool:
 	if p_object is Terrain3D:
 		return true
-	if is_instance_valid(_last_terrain) and _last_terrain.is_inside_tree():
-		if p_object is NavigationRegion3D:
-			return true
-		if p_object is Terrain3DObjects or (p_object is Node3D and p_object.get_parent() is Terrain3DObjects):
-			return true
+	
+	# Terrain3DObjects requires access to EditorUndoRedoManager. The only way to make sure it
+	# always has it, is to pass it in here. _edit is NOT called if the node is cut and pasted.
+	if p_object is Terrain3DObjects:
+		p_object.editor_setup(self)
+	elif p_object is Node3D and p_object.get_parent() is Terrain3DObjects:
+		p_object.get_parent().editor_setup(self)
+	
+	if is_instance_valid(_last_terrain) and _last_terrain.is_inside_tree() and p_object is NavigationRegion3D:
+		return true
+	
 	return false
 
 
@@ -93,12 +99,7 @@ func _edit(p_object: Object) -> void:
 		else:
 			nav_region = null
 
-		if p_object is Terrain3DObjects:
-			p_object.editor_setup(self)
-		elif p_object is Node3D and p_object.get_parent() is Terrain3DObjects:
-			p_object.get_parent().editor_setup(self)
-	
-		
+
 func _make_visible(p_visible: bool, p_redraw: bool = false) -> void:
 	visible = p_visible
 	ui.set_visible(visible)

--- a/project/addons/terrain_3d/utils/terrain_3d_objects.gd
+++ b/project/addons/terrain_3d/utils/terrain_3d_objects.gd
@@ -7,15 +7,25 @@ const TransformChangedNotifier: Script = preload("res://addons/terrain_3d/utils/
 const CHILD_HELPER_NAME: StringName = &"TransformChangedSignaller"
 const CHILD_HELPER_PATH: NodePath = ^"TransformChangedSignaller"
 
-var _editor_interface = null
 var _undo_redo = null
 var _terrain_id: int
 var _offsets: Dictionary # Object ID -> Vector3(X, Y offset relative to terrain height, Z)
 var _ignore_transform_change: bool = false
 
 
+func _enter_tree() -> void:
+	if not Engine.is_editor_hint():
+		return
+	
+	for child in get_children():
+		_on_child_entered_tree(child)
+	
+	child_entered_tree.connect(_on_child_entered_tree)
+	child_exiting_tree.connect(_on_child_exiting_tree)
+
+
 func _exit_tree() -> void:
-	if not Engine.is_editor_hint() or not _editor_interface:
+	if not Engine.is_editor_hint():
 		return
 	
 	child_entered_tree.disconnect(_on_child_entered_tree)
@@ -26,23 +36,13 @@ func _exit_tree() -> void:
 
 
 func editor_setup(p_plugin) -> void:
-	if _editor_interface:
-		return
-	
-	_editor_interface = p_plugin.get_editor_interface()
 	_undo_redo = p_plugin.get_undo_redo()
-	
-	for child in get_children():
-		_on_child_entered_tree(child)
-	
-	child_entered_tree.connect(_on_child_entered_tree)
-	child_exiting_tree.connect(_on_child_exiting_tree)
 
 
 func get_terrain() -> Terrain3D:
 	var terrain := instance_from_id(_terrain_id) as Terrain3D
 	if not terrain or terrain.is_queued_for_deletion() or not terrain.is_inside_tree():
-		var terrains: Array[Node] = _editor_interface.get_edited_scene_root().find_children("", "Terrain3D")
+		var terrains: Array[Node] = EditorInterface.get_edited_scene_root().find_children("", "Terrain3D")
 		if terrains.size() > 0:
 			terrain = terrains[0]
 		_terrain_id = terrain.get_instance_id() if terrain else 0
@@ -74,14 +74,21 @@ func _on_child_entered_tree(p_node: Node) -> void:
 		helper = TransformChangedNotifier.new()
 		helper.name = CHILD_HELPER_NAME
 		p_node.add_child(helper, true, INTERNAL_MODE_BACK)
-	helper.transform_changed.connect(_on_child_transform_changed.bind(p_node))
 	assert(p_node.has_node(CHILD_HELPER_PATH))
 	
-	var id: int = p_node.get_instance_id()
-	if not _offsets.has(id):
-		_update_child_offset(p_node)
-	else:
-		_update_child_position(p_node)
+	# When reparenting a Node3D, Godot changes its transform _after_ reparenting it. So here,
+	# we must use call_deferred, to avoid receiving transform_changed as a result of reparenting.
+	_setup_child_signal.call_deferred(p_node, helper)
+
+
+func _setup_child_signal(p_node: Node, helper: TransformChangedNotifier) -> void:
+	if not p_node.is_inside_tree():
+		return
+	if helper.transform_changed.is_connected(_on_child_transform_changed):
+		return
+	
+	helper.transform_changed.connect(_on_child_transform_changed.bind(p_node))
+	_update_child_offset(p_node)
 
 
 func _on_child_exiting_tree(p_node: Node) -> void:
@@ -90,12 +97,15 @@ func _on_child_exiting_tree(p_node: Node) -> void:
 	
 	var helper: TransformChangedNotifier = p_node.get_node_or_null(CHILD_HELPER_PATH)
 	if helper:
+		helper.transform_changed.disconnect(_on_child_transform_changed)
 		p_node.remove_child(helper)
 		helper.queue_free()
+	
+	_offsets.erase(p_node.get_instance_id())
 
 
 func _is_node_selected(p_node: Node) -> bool:
-	var editor_sel = _editor_interface.get_selection()
+	var editor_sel = EditorInterface.get_selection()
 	return editor_sel.get_transformable_selected_nodes().has(p_node)
 
 
@@ -129,19 +139,20 @@ func _on_child_transform_changed(p_node: Node3D) -> void:
 	
 	# Make sure that when the user undo's the translation, the offset change gets undone too!
 	_undo_redo.create_action("Translate", UndoRedo.MERGE_ALL)
-	_undo_redo.add_do_property(self, &"_ignore_transform_change", true)
-	_undo_redo.add_undo_property(self, &"_ignore_transform_change", true)
-	_undo_redo.add_do_property(p_node, &"global_position", new_position)
-	_undo_redo.add_undo_property(p_node, &"global_position", old_position)
-	_undo_redo.add_do_method(self, &"_set_offset", p_node.get_instance_id(), new_offset)
-	_undo_redo.add_undo_method(self, &"_set_offset", p_node.get_instance_id(), old_offset)
-	_undo_redo.add_do_property(self, &"_ignore_transform_change", false)
-	_undo_redo.add_undo_property(self, &"_ignore_transform_change", false)
+	_undo_redo.add_do_method(self, &"_set_offset_and_position", p_node.get_instance_id(), new_offset, new_position)
+	_undo_redo.add_undo_method(self, &"_set_offset_and_position", p_node.get_instance_id(), old_offset, old_position)
 	_undo_redo.commit_action()
 
 
-func _set_offset(p_id: int, p_offset: Vector3) -> void:
+func _set_offset_and_position(p_id: int, p_offset: Vector3, p_position: Vector3) -> void:
+	var node := instance_from_id(p_id) as Node
+	if not is_instance_valid(node):
+		return
+	
+	_ignore_transform_change = true
+	node.global_position = p_position
 	_offsets[p_id] = p_offset
+	_ignore_transform_change = false
 
 
 # Overwrite current offset stored for node with its current Y position relative to the terrain

--- a/src/terrain_3d.cpp
+++ b/src/terrain_3d.cpp
@@ -1155,7 +1155,9 @@ void Terrain3D::_notification(int p_what) {
 		}
 
 		case NOTIFICATION_TRANSFORM_CHANGED: {
-			set_transform(Transform3D());
+			if (get_transform() != Transform3D()) {
+				set_transform(Transform3D());
+			}
 			break;
 		}
 


### PR DESCRIPTION
This PR fixes #390 and fixes #391.

- Gizmo errors are fixed by clearing gizmos when the Terrain3D node is deselected.
- Clicking a tool button re-selects the Terrain3D node.
- Terrain3DObjects reconnects when reparented.

The latter may look more complicated than it really is. I took this moment as an opportunity to clean up the script by making use of the new EditorInterface singleton that Godot gained in 4.2. The functional parts are:

1. Using `call_deferred` in `_on_child_entered_tree` to set up signals after Godot has updated the node's transform following reparenting.
2. Some code that moved from `_edit` to `_handles` to fix cut-and-pasting of Terrain3DObjects.
