### PR TITLE
Fix baker script transforming nav source geometry incorrectly

### DIFF
--- a/project/addons/terrain_3d/src/baker.gd
+++ b/project/addons/terrain_3d/src/baker.gd
@@ -193,7 +193,7 @@ func _bake_nav_region_nav_mesh(p_nav_region: NavigationRegion3D) -> void:
 		aabb = p_nav_region.global_transform * aabb
 		var faces: PackedVector3Array = terrain.generate_nav_mesh_source_geometry(aabb)
 		if not faces.is_empty():
-			source_geometry_data.add_faces(faces, p_nav_region.global_transform.inverse())
+			source_geometry_data.add_faces(faces, Transform3D.IDENTITY)
 	
 	NavigationMeshGenerator.bake_from_source_geometry_data(nav_mesh, source_geometry_data)
 	


### PR DESCRIPTION
Fixes #392.

The issue was the baker de-transforming source geometry vertices after they've been generated. Source geometry is generated from the terrain heightmap (masked to the navigable areas), and used as the input to the navmesh baking process.

As well as being translated, the nav region can now be rotated/scaled and still bake correctly:

![image](https://github.com/TokisanGames/Terrain3D/assets/165720/b1f41fd4-3cbd-4789-a94e-31adf2de954a)
