### PR TITLE
Add 'Raise Only Lower Terrain' setting to Raise Terrain tool #275

### DIFF
--- a/project/addons/terrain_3d/editor.gd
+++ b/project/addons/terrain_3d/editor.gd
@@ -22,11 +22,6 @@ var visible: bool
 var current_region_position: Vector2
 var mouse_global_position: Vector3 = Vector3.ZERO
 
-# Track negative input (CTRL)
-var _negative_input: bool = false
-# Track state prior to pressing CTRL: -1 not tracked, 0 false, 1 true
-var _prev_enable_state: int = -1
-
 
 func _enter_tree() -> void:
 	editor = Terrain3DEditor.new()
@@ -124,26 +119,12 @@ func _forward_3d_gui_input(p_viewport_camera: Camera3D, p_event: InputEvent) -> 
 	if not is_terrain_valid():
 		return AFTER_GUI_INPUT_PASS
 	
-	## Track negative input (CTRL)
-	if p_event is InputEventKey and not p_event.echo and p_event.keycode == KEY_CTRL:
-		if p_event.is_pressed():
-			_negative_input = true
-			_prev_enable_state = int(ui.toolbar_settings.get_setting("enable"))
-			ui.toolbar_settings.set_setting("enable", false)
-		else:
-			_negative_input = false
-			ui.toolbar_settings.set_setting("enable", bool(_prev_enable_state))
-			_prev_enable_state = -1
+	ui.update_modifiers()
 	
 	## Handle mouse movement
 	if p_event is InputEventMouseMotion:
 		if Input.is_mouse_button_pressed(MOUSE_BUTTON_RIGHT):
 			return AFTER_GUI_INPUT_PASS
-
-		if _prev_enable_state >= 0 and not Input.is_key_pressed(KEY_CTRL):
-			_negative_input = false
-			ui.toolbar_settings.set_setting("enable", bool(_prev_enable_state))
-			_prev_enable_state = -1
 
 		## Setup for active camera & viewport
 		

--- a/project/addons/terrain_3d/src/tool_settings.gd
+++ b/project/addons/terrain_3d/src/tool_settings.gd
@@ -59,6 +59,11 @@ func _ready() -> void:
 	add_setting({ "name":"strength", "type":SettingType.SLIDER, "list":main_list, "default":10, 
 								"unit":"%", "range":Vector3(1, 100, 1), "flags":ALLOW_LARGER })
 
+	add_setting({ "name":"lift_floor", "type":SettingType.CHECKBOX, "list":main_list,
+								"default":false })
+	add_setting({ "name":"flatten_peaks", "type":SettingType.CHECKBOX, "list":main_list,
+								"default":false })
+
 	add_setting({ "name":"enable", "type":SettingType.CHECKBOX, "list":main_list, "default":true })
 
 	add_setting({ "name":"height", "type":SettingType.SLIDER, "list":main_list, "default":50, 

--- a/project/addons/terrain_3d/src/ui.gd
+++ b/project/addons/terrain_3d/src/ui.gd
@@ -123,6 +123,10 @@ func _on_tool_changed(p_tool: Terrain3DEditor.Tool, p_operation: Terrain3DEditor
 			if p_operation == Terrain3DEditor.GRADIENT:
 				to_show.push_back("gradient_points")
 				to_show.push_back("drawable")
+			if p_operation == Terrain3DEditor.ADD:
+				to_show.push_back("lift_floor")
+			if p_operation == Terrain3DEditor.SUBTRACT:
+				to_show.push_back("flatten_peaks")
 		
 		Terrain3DEditor.TEXTURE:
 			to_show.push_back("brush")


### PR DESCRIPTION
This implements the feature requested in #275. It allows you to touch up the bottoms of cliffs without affecting the cliff itself, blending into the existing terrain:

https://github.com/TokisanGames/Terrain3D/assets/165720/68ffe6f9-1208-4929-b4e1-391ced71b6ce

With the setting off, the result of the operation would instead be this, where the top of the hill is pushed up, which matches Terrain3D's existing behavior:

https://github.com/TokisanGames/Terrain3D/assets/165720/5823d239-5b40-47c0-afc9-5639c2a7c0cc

I'd like to ask for feedback, especially on the naming/position of the new toggle. Would "Blend Into Existing Terrain" be a clearer name, or is that less specific? Or should we hide this behind a modifier key rather than a visible toggle?

**Limitations:**

While it works perfectly for touching up small areas, when used over a large area, it tends to produce flatter-looking hilltops than the default.

![Screenshot from 2024-07-03 16-17-12](https://github.com/TokisanGames/Terrain3D/assets/165720/11dec079-d279-494e-afe8-2ac6286d4097)

The reason is that Terrain3D brush operations overlap and this pushes up the area under the middle of the brush stroke. Whereas there isn't as much overlap when the new setting is on:

![raise_only_lower](https://github.com/TokisanGames/Terrain3D/assets/165720/292687f4-1c51-46b4-9634-f0ba85b14e5f)

A "solution" for this would probably be pretty complex, but I'm not sure that it's necessary. What do you think?