### PR TITLE
Implement const correctness & pass all objects by reference

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -63,7 +63,14 @@ In addition:
 In general, follow the [Godot C++ style guidelines](https://docs.godotengine.org/en/stable/contributing/development/code_style_guidelines.html).
 In addition:
 
-Floats:
+Use const correctness:
+* Function parameters that won't be changed (almost all) should be marked const. Exceptions are pointers, or where passing a variable the function is supposed to modify, eg. Terrain3D::_generate_triangles
+* Functions that won't change the object should be marked const (e.g. most get_ functions)
+
+Pass by reference:
+* Pass everything larger than 4 bytes by reference, including Ref<> and arrays, dictionaries, RIDs. e.g. `const Transform3D &xform`
+
+* Floats:
 * Use `real_t` instead of `float`
 * Format float literals like `0.0f`
 * Float literals and `real_t` variables can share operations (e.g. `mydouble += 1.0f`) unless the compiler complains. e.g. `Math::lerp(mydouble, real_t(0.0f), real_t(1.0f))`

--- a/src/generated_texture.h
+++ b/src/generated_texture.h
@@ -19,11 +19,11 @@ private:
 
 public:
 	void clear();
-	bool is_dirty() { return _dirty; }
+	bool is_dirty() const { return _dirty; }
 	RID create(const TypedArray<Image> &p_layers);
 	RID create(const Ref<Image> &p_image);
 	Ref<Image> get_image() const { return _image; }
-	RID get_rid() { return _rid; }
+	RID get_rid() const { return _rid; }
 };
 
 #endif // GENERATEDTEXTURE_CLASS_H

--- a/src/geoclipmap.cpp
+++ b/src/geoclipmap.cpp
@@ -9,7 +9,7 @@
 // Private Functions
 ///////////////////////////
 
-RID GeoClipMap::_create_mesh(PackedVector3Array p_vertices, PackedInt32Array p_indices, AABB p_aabb) {
+RID GeoClipMap::_create_mesh(const PackedVector3Array &p_vertices, const PackedInt32Array &p_indices, const AABB &p_aabb) {
 	Array arrays;
 	arrays.resize(RenderingServer::ARRAY_MAX);
 	arrays[RenderingServer::ARRAY_VERTEX] = p_vertices;
@@ -45,7 +45,7 @@ RID GeoClipMap::_create_mesh(PackedVector3Array p_vertices, PackedInt32Array p_i
  * In email communication with Cory, Mike clarified that the code in his
  * repo can be considered either MIT or public domain.
  */
-Vector<RID> GeoClipMap::generate(int p_size, int p_levels) {
+Vector<RID> GeoClipMap::generate(const int p_size, const int p_levels) {
 	LOG(DEBUG, "Generating meshes of size: ", p_size, " levels: ", p_levels);
 
 	// TODO bit of a mess here. someone care to clean up?

--- a/src/geoclipmap.h
+++ b/src/geoclipmap.h
@@ -12,8 +12,8 @@ using namespace godot;
 class GeoClipMap {
 	CLASS_NAME_STATIC("Terrain3DGeoClipMap");
 
-	static inline int _patch_2d(int x, int y, int res);
-	static RID _create_mesh(PackedVector3Array p_vertices, PackedInt32Array p_indices, AABB p_aabb);
+	static inline int _patch_2d(const int x, const int y, const int res);
+	static RID _create_mesh(const PackedVector3Array &p_vertices, const PackedInt32Array &p_indices, const AABB &p_aabb);
 
 public:
 	enum MeshType {
@@ -24,12 +24,12 @@ public:
 		SEAM,
 	};
 
-	static Vector<RID> generate(int p_resolution, int p_clipmap_levels);
+	static Vector<RID> generate(const int p_resolution, const int p_clipmap_levels);
 };
 
 // Inline Functions
 
-inline int GeoClipMap::_patch_2d(int x, int y, int res) {
+inline int GeoClipMap::_patch_2d(const int x, const int y, const int res) {
 	return y * res + x;
 }
 

--- a/src/register_types.cpp
+++ b/src/register_types.cpp
@@ -2,8 +2,6 @@
 
 #include <gdextension_interface.h>
 #include <godot_cpp/core/class_db.hpp>
-#include <godot_cpp/core/defs.hpp>
-#include <godot_cpp/godot.hpp>
 
 #include "register_types.h"
 #include "terrain_3d.h"

--- a/src/register_types.h
+++ b/src/register_types.h
@@ -3,7 +3,11 @@
 #ifndef TERRAIN3D_REGISTER_TYPES_H
 #define TERRAIN3D_REGISTER_TYPES_H
 
-void initialize_terrain_3d();
-void uninitialize_terrain_3d();
+#include <godot_cpp/godot.hpp>
+
+using namespace godot;
+
+void initialize_terrain_3d(ModuleInitializationLevel p_level);
+void uninitialize_terrain_3d(ModuleInitializationLevel p_level);
 
 #endif // TERRAIN3D_REGISTER_TYPES_H

--- a/src/terrain_3d.cpp
+++ b/src/terrain_3d.cpp
@@ -534,6 +534,7 @@ void Terrain3D::_destroy_collision() {
 void Terrain3D::_destroy_instancer() {
 	if (_instancer != nullptr) {
 		_instancer->destroy();
+		memdelete_safely(_instancer);
 	}
 }
 
@@ -649,7 +650,7 @@ Terrain3D::Terrain3D() {
 }
 
 Terrain3D::~Terrain3D() {
-	memdelete_safely(_instancer);
+	_destroy_instancer();
 	_destroy_collision();
 }
 

--- a/src/terrain_3d.cpp
+++ b/src/terrain_3d.cpp
@@ -104,7 +104,7 @@ void Terrain3D::__ready() {
  * This is a proxy for _process(delta) called by _notification() due to
  * https://github.com/godotengine/godot-cpp/issues/1022
  */
-void Terrain3D::__process(double delta) {
+void Terrain3D::__process(const double p_delta) {
 	if (!_initialized)
 		return;
 
@@ -206,7 +206,7 @@ void Terrain3D::_grab_camera() {
 	}
 }
 
-void Terrain3D::_build_meshes(int p_mesh_lods, int p_mesh_size) {
+void Terrain3D::_build_meshes(const int p_mesh_lods, const int p_mesh_size) {
 	if (!is_inside_tree() || !_storage.is_valid()) {
 		LOG(DEBUG, "Not inside the tree or no valid storage, skipping build");
 		return;
@@ -537,7 +537,8 @@ void Terrain3D::_destroy_instancer() {
 	}
 }
 
-void Terrain3D::_generate_triangles(PackedVector3Array &p_vertices, PackedVector2Array *p_uvs, int32_t p_lod, Terrain3DStorage::HeightFilter p_filter, bool p_require_nav, const AABB &p_global_aabb) const {
+void Terrain3D::_generate_triangles(PackedVector3Array &p_vertices, PackedVector2Array *p_uvs, const int32_t p_lod,
+		const Terrain3DStorage::HeightFilter p_filter, const bool p_require_nav, const AABB &p_global_aabb) const {
 	ERR_FAIL_COND(!_storage.is_valid());
 	int32_t step = 1 << CLAMP(p_lod, 0, 8);
 
@@ -571,7 +572,11 @@ void Terrain3D::_generate_triangles(PackedVector3Array &p_vertices, PackedVector
 	}
 }
 
-void Terrain3D::_generate_triangle_pair(PackedVector3Array &p_vertices, PackedVector2Array *p_uvs, int32_t p_lod, Terrain3DStorage::HeightFilter p_filter, bool p_require_nav, int32_t x, int32_t z) const {
+// p_vertices is assumed to exist and the destination for data
+// p_uvs might not exist, so a pointer is fine
+void Terrain3D::_generate_triangle_pair(PackedVector3Array &p_vertices, PackedVector2Array *p_uvs,
+		const int32_t p_lod, const Terrain3DStorage::HeightFilter p_filter, const bool p_require_nav,
+		const int32_t x, const int32_t z) const {
 	int32_t step = 1 << CLAMP(p_lod, 0, 8);
 
 	Vector3 xz = Vector3(x, 0.0f, z) * _mesh_vertex_spacing;
@@ -648,12 +653,12 @@ Terrain3D::~Terrain3D() {
 	_destroy_collision();
 }
 
-void Terrain3D::set_debug_level(int p_level) {
+void Terrain3D::set_debug_level(const int p_level) {
 	LOG(INFO, "Setting debug level: ", p_level);
 	debug_level = CLAMP(p_level, 0, DEBUG_MAX);
 }
 
-void Terrain3D::set_mesh_lods(int p_count) {
+void Terrain3D::set_mesh_lods(const int p_count) {
 	if (_mesh_lods != p_count) {
 		_clear_meshes();
 		_destroy_collision();
@@ -663,7 +668,7 @@ void Terrain3D::set_mesh_lods(int p_count) {
 	}
 }
 
-void Terrain3D::set_mesh_size(int p_size) {
+void Terrain3D::set_mesh_size(const int p_size) {
 	if (_mesh_size != p_size) {
 		_clear_meshes();
 		_destroy_collision();
@@ -673,11 +678,11 @@ void Terrain3D::set_mesh_size(int p_size) {
 	}
 }
 
-void Terrain3D::set_mesh_vertex_spacing(real_t p_spacing) {
-	p_spacing = CLAMP(p_spacing, 0.25f, 100.0f);
-	if (_mesh_vertex_spacing != p_spacing) {
-		LOG(INFO, "Setting mesh vertex spacing: ", p_spacing);
-		_mesh_vertex_spacing = p_spacing;
+void Terrain3D::set_mesh_vertex_spacing(const real_t p_spacing) {
+	real_t spacing = CLAMP(p_spacing, 0.25f, 100.0f);
+	if (_mesh_vertex_spacing != spacing) {
+		LOG(INFO, "Setting mesh vertex spacing: ", spacing);
+		_mesh_vertex_spacing = spacing;
 		_clear_meshes();
 		_destroy_collision();
 		_destroy_instancer();
@@ -742,17 +747,17 @@ void Terrain3D::set_camera(Camera3D *p_camera) {
 	}
 }
 
-void Terrain3D::set_render_layers(uint32_t p_layers) {
+void Terrain3D::set_render_layers(const uint32_t p_layers) {
 	LOG(INFO, "Setting terrain render layers to: ", p_layers);
 	_render_layers = p_layers;
 	_update_mesh_instances();
 }
 
-void Terrain3D::set_mouse_layer(uint32_t p_layer) {
-	p_layer = CLAMP(p_layer, 21, 32);
-	_mouse_layer = p_layer;
+void Terrain3D::set_mouse_layer(const uint32_t p_layer) {
+	uint32_t layer = CLAMP(p_layer, 21, 32);
+	_mouse_layer = layer;
 	uint32_t mouse_mask = 1 << (_mouse_layer - 1);
-	LOG(INFO, "Setting mouse layer: ", p_layer, " (", mouse_mask, ") on terrain mesh, material, mouse camera, mouse quad");
+	LOG(INFO, "Setting mouse layer: ", layer, " (", mouse_mask, ") on terrain mesh, material, mouse camera, mouse quad");
 
 	// Set terrain meshes to mouse layer
 	// Mask off editor render layers by ORing user layers 1-20 and current mouse layer
@@ -771,18 +776,18 @@ void Terrain3D::set_mouse_layer(uint32_t p_layer) {
 	}
 }
 
-void Terrain3D::set_cast_shadows(GeometryInstance3D::ShadowCastingSetting p_cast_shadows) {
+void Terrain3D::set_cast_shadows(const GeometryInstance3D::ShadowCastingSetting p_cast_shadows) {
 	_cast_shadows = p_cast_shadows;
 	_update_mesh_instances();
 }
 
-void Terrain3D::set_cull_margin(real_t p_margin) {
+void Terrain3D::set_cull_margin(const real_t p_margin) {
 	LOG(INFO, "Setting extra cull margin: ", p_margin);
 	_cull_margin = p_margin;
 	update_aabbs();
 }
 
-void Terrain3D::set_collision_enabled(bool p_enabled) {
+void Terrain3D::set_collision_enabled(const bool p_enabled) {
 	LOG(INFO, "Setting collision enabled: ", p_enabled);
 	_collision_enabled = p_enabled;
 	if (_collision_enabled) {
@@ -792,7 +797,7 @@ void Terrain3D::set_collision_enabled(bool p_enabled) {
 	}
 }
 
-void Terrain3D::set_show_debug_collision(bool p_enabled) {
+void Terrain3D::set_show_debug_collision(const bool p_enabled) {
 	LOG(INFO, "Setting show collision: ", p_enabled);
 	_show_debug_collision = p_enabled;
 	_destroy_collision();
@@ -801,7 +806,7 @@ void Terrain3D::set_show_debug_collision(bool p_enabled) {
 	}
 }
 
-void Terrain3D::set_collision_layer(uint32_t p_layers) {
+void Terrain3D::set_collision_layer(const uint32_t p_layers) {
 	LOG(INFO, "Setting collision layers: ", p_layers);
 	_collision_layer = p_layers;
 	if (_show_debug_collision) {
@@ -815,7 +820,7 @@ void Terrain3D::set_collision_layer(uint32_t p_layers) {
 	}
 }
 
-void Terrain3D::set_collision_mask(uint32_t p_mask) {
+void Terrain3D::set_collision_mask(const uint32_t p_mask) {
 	LOG(INFO, "Setting collision mask: ", p_mask);
 	_collision_mask = p_mask;
 	if (_show_debug_collision) {
@@ -829,7 +834,7 @@ void Terrain3D::set_collision_mask(uint32_t p_mask) {
 	}
 }
 
-void Terrain3D::set_collision_priority(real_t p_priority) {
+void Terrain3D::set_collision_priority(const real_t p_priority) {
 	LOG(INFO, "Setting collision priority: ", p_priority);
 	_collision_priority = p_priority;
 	if (_show_debug_collision) {
@@ -1041,7 +1046,7 @@ Vector3 Terrain3D::get_intersection(const Vector3 &p_src_pos, const Vector3 &p_d
  *   This takes longer than ..._NEAREST, but can be used to create occluders, since it can guarantee the
  *   generated mesh will not extend above or outside the clipmap at any LOD.
  */
-Ref<Mesh> Terrain3D::bake_mesh(int p_lod, Terrain3DStorage::HeightFilter p_filter) const {
+Ref<Mesh> Terrain3D::bake_mesh(const int p_lod, const Terrain3DStorage::HeightFilter p_filter) const {
 	LOG(INFO, "Baking mesh at lod: ", p_lod, " with filter: ", p_filter);
 	Ref<Mesh> result;
 	ERR_FAIL_COND_V(!_storage.is_valid(), result);
@@ -1077,7 +1082,7 @@ Ref<Mesh> Terrain3D::bake_mesh(int p_lod, Terrain3DStorage::HeightFilter p_filte
  *  Otherwise, geometry is generated for the entire terrain within the AABB (which can be useful for
  *  dynamic and/or runtime nav mesh baking).
  */
-PackedVector3Array Terrain3D::generate_nav_mesh_source_geometry(const AABB &p_global_aabb, bool p_require_nav) const {
+PackedVector3Array Terrain3D::generate_nav_mesh_source_geometry(const AABB &p_global_aabb, const bool p_require_nav) const {
 	LOG(INFO, "Generating NavMesh source geometry from terrain");
 	PackedVector3Array faces;
 	_generate_triangles(faces, nullptr, 0, Terrain3DStorage::HEIGHT_FILTER_NEAREST, p_require_nav, p_global_aabb);
@@ -1116,7 +1121,7 @@ void Terrain3D::set_texture_list(const Ref<Terrain3DTextureList> &p_texture_list
 // Protected Functions
 ///////////////////////////
 
-void Terrain3D::_notification(int p_what) {
+void Terrain3D::_notification(const int p_what) {
 	switch (p_what) {
 		case NOTIFICATION_READY: {
 			LOG(INFO, "NOTIFICATION_READY");

--- a/src/terrain_3d.h
+++ b/src/terrain_3d.h
@@ -79,13 +79,13 @@ class Terrain3D : public Node3D {
 
 	void _initialize();
 	void __ready();
-	void __process(double delta);
+	void __process(const double p_delta);
 
 	void _setup_mouse_picking();
 	void _destroy_mouse_picking();
 	void _grab_camera();
 
-	void _build_meshes(int p_mesh_lods, int p_mesh_size);
+	void _build_meshes(const int p_mesh_lods, const int p_mesh_size);
 	void _update_mesh_instances();
 	void _clear_meshes();
 
@@ -95,8 +95,10 @@ class Terrain3D : public Node3D {
 
 	void _destroy_instancer();
 
-	void _generate_triangles(PackedVector3Array &p_vertices, PackedVector2Array *p_uvs, int32_t p_lod, Terrain3DStorage::HeightFilter p_filter, bool require_nav, const AABB &p_global_aabb) const;
-	void _generate_triangle_pair(PackedVector3Array &p_vertices, PackedVector2Array *p_uvs, int32_t p_lod, Terrain3DStorage::HeightFilter p_filter, bool require_nav, int32_t x, int32_t z) const;
+	void _generate_triangles(PackedVector3Array &p_vertices, PackedVector2Array *p_uvs, const int32_t p_lod,
+			const Terrain3DStorage::HeightFilter p_filter, const bool require_nav, const AABB &p_global_aabb) const;
+	void _generate_triangle_pair(PackedVector3Array &p_vertices, PackedVector2Array *p_uvs, const int32_t p_lod,
+			const Terrain3DStorage::HeightFilter p_filter, const bool require_nav, const int32_t x, const int32_t z) const;
 
 public:
 	static int debug_level;
@@ -106,13 +108,13 @@ public:
 
 	// Terrain settings
 	String get_version() const { return _version; }
-	void set_debug_level(int p_level);
+	void set_debug_level(const int p_level);
 	int get_debug_level() const { return debug_level; }
-	void set_mesh_lods(int p_count);
+	void set_mesh_lods(const int p_count);
 	int get_mesh_lods() const { return _mesh_lods; }
-	void set_mesh_size(int p_size);
+	void set_mesh_size(const int p_size);
 	int get_mesh_size() const { return _mesh_size; }
-	void set_mesh_vertex_spacing(real_t p_spacing);
+	void set_mesh_vertex_spacing(const real_t p_spacing);
 	real_t get_mesh_vertex_spacing() const { return _mesh_vertex_spacing; }
 
 	void set_material(const Ref<Terrain3DMaterial> &p_material);
@@ -130,25 +132,25 @@ public:
 	Camera3D *get_camera() const { return _camera; }
 
 	// Renderer settings
-	void set_render_layers(uint32_t p_layers);
+	void set_render_layers(const uint32_t p_layers);
 	uint32_t get_render_layers() const { return _render_layers; };
-	void set_mouse_layer(uint32_t p_layer);
+	void set_mouse_layer(const uint32_t p_layer);
 	uint32_t get_mouse_layer() const { return _mouse_layer; };
-	void set_cast_shadows(GeometryInstance3D::ShadowCastingSetting p_cast_shadows);
+	void set_cast_shadows(const GeometryInstance3D::ShadowCastingSetting p_cast_shadows);
 	GeometryInstance3D::ShadowCastingSetting get_cast_shadows() const { return _cast_shadows; };
-	void set_cull_margin(real_t p_margin);
+	void set_cull_margin(const real_t p_margin);
 	real_t get_cull_margin() const { return _cull_margin; };
 
 	// Physics body settings
-	void set_collision_enabled(bool p_enabled);
+	void set_collision_enabled(const bool p_enabled);
 	bool get_collision_enabled() const { return _collision_enabled; }
-	void set_show_debug_collision(bool p_enabled);
+	void set_show_debug_collision(const bool p_enabled);
 	bool get_show_debug_collision() const { return _show_debug_collision; }
-	void set_collision_layer(uint32_t p_layers);
+	void set_collision_layer(const uint32_t p_layers);
 	uint32_t get_collision_layer() const { return _collision_layer; };
-	void set_collision_mask(uint32_t p_mask);
+	void set_collision_mask(const uint32_t p_mask);
 	uint32_t get_collision_mask() const { return _collision_mask; };
-	void set_collision_priority(real_t p_priority);
+	void set_collision_priority(const real_t p_priority);
 	real_t get_collision_priority() const { return _collision_priority; }
 
 	// Terrain methods
@@ -157,18 +159,18 @@ public:
 	Vector3 get_intersection(const Vector3 &p_src_pos, const Vector3 &p_direction);
 
 	// Baking methods
-	Ref<Mesh> bake_mesh(int p_lod, Terrain3DStorage::HeightFilter p_filter = Terrain3DStorage::HEIGHT_FILTER_NEAREST) const;
-	PackedVector3Array generate_nav_mesh_source_geometry(const AABB &p_global_aabb, bool p_require_nav = true) const;
+	Ref<Mesh> bake_mesh(const int p_lod, const Terrain3DStorage::HeightFilter p_filter = Terrain3DStorage::HEIGHT_FILTER_NEAREST) const;
+	PackedVector3Array generate_nav_mesh_source_geometry(const AABB &p_global_aabb, const bool p_require_nav = true) const;
 
 	// Misc
 	PackedStringArray _get_configuration_warnings() const override;
 
 	// DEPRECATED 0.9.2 - Remove 0.9.3+
 	void set_texture_list(const Ref<Terrain3DTextureList> &p_texture_list);
-	Ref<Terrain3DTextureList> get_texture_list() { return Ref<Terrain3DTextureList>(); }
+	Ref<Terrain3DTextureList> get_texture_list() const { return Ref<Terrain3DTextureList>(); }
 
 protected:
-	void _notification(int p_what);
+	void _notification(const int p_what);
 	static void _bind_methods();
 };
 

--- a/src/terrain_3d.h
+++ b/src/terrain_3d.h
@@ -123,6 +123,8 @@ public:
 	Ref<Terrain3DStorage> get_storage() const { return _storage; }
 	void set_assets(const Ref<Terrain3DAssets> &p_assets);
 	Ref<Terrain3DAssets> get_assets() const { return _assets; }
+
+	// Instancer
 	Terrain3DInstancer *get_instancer() const { return _instancer; }
 
 	// Editor components

--- a/src/terrain_3d_asset_resource.h
+++ b/src/terrain_3d_asset_resource.h
@@ -10,6 +10,7 @@
 using namespace godot;
 class Terrain3DAssets;
 
+// Parent class of Terrain3DMeshAsset and Terrain3DTextureAsset
 class Terrain3DAssetResource : public Resource {
 	friend class Terrain3DAssets;
 
@@ -18,9 +19,9 @@ public:
 	~Terrain3DAssetResource(){};
 
 	virtual void clear() = 0;
-	virtual void set_name(String p_name) = 0;
+	virtual void set_name(const String &p_name) = 0;
 	virtual String get_name() const = 0;
-	virtual void set_id(int p_id) = 0;
+	virtual void set_id(const int p_id) = 0;
 	virtual int get_id() const = 0;
 
 protected:

--- a/src/terrain_3d_assets.cpp
+++ b/src/terrain_3d_assets.cpp
@@ -13,7 +13,7 @@
 // Private Functions
 ///////////////////////////
 
-void Terrain3DAssets::_swap_ids(AssetType p_type, int p_src_id, int p_dst_id) {
+void Terrain3DAssets::_swap_ids(const AssetType p_type, const int p_src_id, const int p_dst_id) {
 	LOG(INFO, "Swapping asset id: ", p_src_id, " and id: ", p_dst_id);
 	Array list;
 	switch (p_type) {
@@ -32,17 +32,17 @@ void Terrain3DAssets::_swap_ids(AssetType p_type, int p_src_id, int p_dst_id) {
 		return;
 	}
 	Ref<Terrain3DAssetResource> res_a = list[p_src_id];
-	p_dst_id = CLAMP(p_dst_id, 0, list.size() - 1);
-	if (p_dst_id == p_src_id) {
+	int dst_id = CLAMP(p_dst_id, 0, list.size() - 1);
+	if (dst_id == p_src_id) {
 		// Res_a new id was likely out of range, reset it
 		res_a->_id = p_src_id;
 		return;
 	}
 
-	Ref<Terrain3DAssetResource> res_b = list[p_dst_id];
-	res_a->_id = p_dst_id;
+	Ref<Terrain3DAssetResource> res_b = list[dst_id];
+	res_a->_id = dst_id;
 	res_b->_id = p_src_id;
-	list[p_dst_id] = res_a;
+	list[dst_id] = res_a;
 	list[p_src_id] = res_b;
 
 	switch (p_type) {
@@ -50,7 +50,7 @@ void Terrain3DAssets::_swap_ids(AssetType p_type, int p_src_id, int p_dst_id) {
 			update_texture_list();
 			break;
 		case TYPE_MESH:
-			_terrain->get_instancer()->swap_ids(p_src_id, p_dst_id);
+			_terrain->get_instancer()->swap_ids(p_src_id, dst_id);
 			update_mesh_list();
 			break;
 		default:
@@ -62,7 +62,7 @@ void Terrain3DAssets::_swap_ids(AssetType p_type, int p_src_id, int p_dst_id) {
  * _set_asset_list attempts to keep the asset id as saved in the resource file.
  * But if an ID is invalid or already taken, the new ID is changed to the next available one
  */
-void Terrain3DAssets::_set_asset_list(AssetType p_type, const TypedArray<Terrain3DAssetResource> &p_list) {
+void Terrain3DAssets::_set_asset_list(const AssetType p_type, const TypedArray<Terrain3DAssetResource> &p_list) {
 	Array list;
 	int max_size;
 	switch (p_type) {
@@ -106,7 +106,7 @@ void Terrain3DAssets::_set_asset_list(AssetType p_type, const TypedArray<Terrain
 	}
 }
 
-void Terrain3DAssets::_set_asset(AssetType p_type, int p_id, const Ref<Terrain3DAssetResource> &p_asset) {
+void Terrain3DAssets::_set_asset(const AssetType p_type, const int p_id, const Ref<Terrain3DAssetResource> &p_asset) {
 	Array list;
 	int max_size;
 	switch (p_type) {
@@ -311,7 +311,7 @@ void Terrain3DAssets::_update_texture_settings() {
 	emit_signal("textures_changed");
 }
 
-void Terrain3DAssets::_update_thumbnail(Ref<Terrain3DMeshAsset> p_mesh_asset) {
+void Terrain3DAssets::_update_thumbnail(const Ref<Terrain3DMeshAsset> &p_mesh_asset) {
 	if (p_mesh_asset.is_valid()) {
 		create_mesh_thumbnails(p_mesh_asset->get_id());
 	}
@@ -370,7 +370,7 @@ Terrain3DAssets::~Terrain3DAssets() {
 	RS->free_rid(scenario);
 }
 
-void Terrain3DAssets::set_texture(int p_id, const Ref<Terrain3DTextureAsset> &p_texture) {
+void Terrain3DAssets::set_texture(const int p_id, const Ref<Terrain3DTextureAsset> &p_texture) {
 	if (_texture_list.size() <= p_id || p_texture != _texture_list[p_id]) {
 		LOG(INFO, "Setting texture id: ", p_id);
 		_set_asset(TYPE_TEXTURE, p_id, p_texture);
@@ -407,7 +407,7 @@ void Terrain3DAssets::update_texture_list() {
 	_update_texture_settings();
 }
 
-void Terrain3DAssets::set_mesh_asset(int p_id, const Ref<Terrain3DMeshAsset> &p_mesh_asset) {
+void Terrain3DAssets::set_mesh_asset(const int p_id, const Ref<Terrain3DMeshAsset> &p_mesh_asset) {
 	LOG(INFO, "Setting mesh id: ", p_id, ", ", p_mesh_asset);
 	_set_asset(TYPE_MESH, p_id, p_mesh_asset);
 	if (p_mesh_asset.is_null()) {
@@ -417,7 +417,7 @@ void Terrain3DAssets::set_mesh_asset(int p_id, const Ref<Terrain3DMeshAsset> &p_
 	update_mesh_list();
 }
 
-Ref<Terrain3DMeshAsset> Terrain3DAssets::get_mesh_asset(int p_id) const {
+Ref<Terrain3DMeshAsset> Terrain3DAssets::get_mesh_asset(const int p_id) const {
 	if (p_id >= 0 && p_id < _mesh_list.size()) {
 		return _mesh_list[p_id];
 	}
@@ -432,7 +432,7 @@ void Terrain3DAssets::set_mesh_list(const TypedArray<Terrain3DMeshAsset> &p_mesh
 
 // p_id = -1 for all meshes
 // Adapted from godot\editor\plugins\editor_preview_plugins.cpp:EditorMeshPreviewPlugin
-void Terrain3DAssets::create_mesh_thumbnails(int p_id, Vector2i p_size) const {
+void Terrain3DAssets::create_mesh_thumbnails(const int p_id, const Vector2i &p_size) {
 	int start, end;
 	int max = get_mesh_count();
 	if (p_id < 0) {
@@ -442,7 +442,7 @@ void Terrain3DAssets::create_mesh_thumbnails(int p_id, Vector2i p_size) const {
 		start = CLAMP(p_id, 0, max - 1);
 		end = CLAMP(p_id + 1, 0, max);
 	}
-	p_size = CLAMP(p_size, Vector2i(1, 1), Vector2i(4096, 4096));
+	Vector2i size = CLAMP(p_size, Vector2i(1, 1), Vector2i(4096, 4096));
 
 	LOG(INFO, "Creating thumbnails for ids: ", start, " through ", end - 1);
 	for (int i = start; i < end; i++) {
@@ -478,7 +478,7 @@ void Terrain3DAssets::create_mesh_thumbnails(int p_id, Vector2i p_size) const {
 		xform.origin.z -= rot_aabb.size.z * 2.f;
 		RS->instance_set_transform(mesh_instance, xform);
 
-		RS->viewport_set_size(viewport, p_size.x, p_size.y);
+		RS->viewport_set_size(viewport, size.x, size.y);
 		RS->viewport_set_update_mode(viewport, RenderingServer::VIEWPORT_UPDATE_ONCE);
 		RS->force_draw();
 

--- a/src/terrain_3d_assets.h
+++ b/src/terrain_3d_assets.h
@@ -48,37 +48,37 @@ private:
 	RID fill_light_instance;
 	RID mesh_instance;
 
-	void _swap_ids(AssetType p_type, int p_src_id, int p_dst_id);
-	void _set_asset_list(AssetType p_type, const TypedArray<Terrain3DAssetResource> &p_list);
-	void _set_asset(AssetType p_type, int p_id, const Ref<Terrain3DAssetResource> &p_asset);
+	void _swap_ids(const AssetType p_type, const int p_src_id, const int p_dst_id);
+	void _set_asset_list(const AssetType p_type, const TypedArray<Terrain3DAssetResource> &p_list);
+	void _set_asset(const AssetType p_type, const int p_id, const Ref<Terrain3DAssetResource> &p_asset);
 
 	void _update_texture_files();
 	void _update_texture_settings();
-	void _update_thumbnail(Ref<Terrain3DMeshAsset> p_mesh_asset);
+	void _update_thumbnail(const Ref<Terrain3DMeshAsset> &p_mesh_asset);
 
 public:
 	Terrain3DAssets() {}
 	void initialize(Terrain3D *p_terrain);
 	~Terrain3DAssets();
 
-	void set_texture(int p_id, const Ref<Terrain3DTextureAsset> &p_texture);
-	Ref<Terrain3DTextureAsset> get_texture(int p_id) const { return _texture_list[p_id]; }
+	void set_texture(const int p_id, const Ref<Terrain3DTextureAsset> &p_texture);
+	Ref<Terrain3DTextureAsset> get_texture(const int p_id) const { return _texture_list[p_id]; }
 	void set_texture_list(const TypedArray<Terrain3DTextureAsset> &p_texture_list);
 	TypedArray<Terrain3DTextureAsset> get_texture_list() const { return _texture_list; }
 	int get_texture_count() const { return _texture_list.size(); }
-	RID get_albedo_array_rid() { return _generated_albedo_textures.get_rid(); }
-	RID get_normal_array_rid() { return _generated_normal_textures.get_rid(); }
-	PackedColorArray get_texture_colors() { return _texture_colors; }
-	PackedFloat32Array get_texture_uv_scales() { return _texture_uv_scales; }
-	PackedFloat32Array get_texture_detiles() { return _texture_detiles; }
+	RID get_albedo_array_rid() const { return _generated_albedo_textures.get_rid(); }
+	RID get_normal_array_rid() const { return _generated_normal_textures.get_rid(); }
+	PackedColorArray get_texture_colors() const { return _texture_colors; }
+	PackedFloat32Array get_texture_uv_scales() const { return _texture_uv_scales; }
+	PackedFloat32Array get_texture_detiles() const { return _texture_detiles; }
 	void update_texture_list();
 
-	void set_mesh_asset(int p_id, const Ref<Terrain3DMeshAsset> &p_mesh_asset);
-	Ref<Terrain3DMeshAsset> get_mesh_asset(int p_id) const;
+	void set_mesh_asset(const int p_id, const Ref<Terrain3DMeshAsset> &p_mesh_asset);
+	Ref<Terrain3DMeshAsset> get_mesh_asset(const int p_id) const;
 	void set_mesh_list(const TypedArray<Terrain3DMeshAsset> &p_mesh_list);
 	TypedArray<Terrain3DMeshAsset> get_mesh_list() const { return _mesh_list; }
 	int get_mesh_count() const { return _mesh_list.size(); }
-	void create_mesh_thumbnails(int p_id = -1, Vector2i p_size = Vector2i(128, 128)) const;
+	void create_mesh_thumbnails(const int p_id = -1, const Vector2i &p_size = Vector2i(128, 128));
 	void update_mesh_list();
 	void save();
 
@@ -100,7 +100,7 @@ public:
 	Terrain3DTexture() {}
 	~Terrain3DTexture() {}
 
-	void set_uv_rotation(real_t p_rotation) { _uv_rotation = p_rotation; }
+	void set_uv_rotation(const real_t p_rotation) { _uv_rotation = p_rotation; }
 	real_t get_uv_rotation() const { return _uv_rotation; }
 
 protected:

--- a/src/terrain_3d_editor.cpp
+++ b/src/terrain_3d_editor.cpp
@@ -11,7 +11,7 @@
 // Private Functions
 ///////////////////////////
 
-void Terrain3DEditor::_region_modified(Vector3 p_global_position, Vector2 p_height_range) {
+void Terrain3DEditor::_region_modified(const Vector3 &p_global_position, const Vector2 &p_height_range) {
 	Vector2i region_offset = _terrain->get_storage()->get_region_offset(p_global_position);
 	Terrain3DStorage::RegionSize region_size = _terrain->get_storage()->get_region_size();
 
@@ -25,14 +25,7 @@ void Terrain3DEditor::_region_modified(Vector3 p_global_position, Vector2 p_heig
 	_terrain->get_storage()->add_edited_area(edited_area);
 }
 
-real_t Terrain3DEditor::_get_brush_alpha(Vector2i p_position) {
-	if (_brush_image.is_valid()) {
-		return _brush_image->get_pixelv(p_position).r;
-	}
-	return NAN;
-}
-
-void Terrain3DEditor::_operate_region(Vector3 p_global_position) {
+void Terrain3DEditor::_operate_region(const Vector3 &p_global_position) {
 	bool has_region = _terrain->get_storage()->has_region(p_global_position);
 	bool modified = false;
 	Vector2 height_range;
@@ -59,7 +52,7 @@ void Terrain3DEditor::_operate_region(Vector3 p_global_position) {
 	}
 }
 
-void Terrain3DEditor::_operate_map(Vector3 p_global_position, real_t p_camera_direction) {
+void Terrain3DEditor::_operate_map(const Vector3 &p_global_position, const real_t p_camera_direction) {
 	if (_brush_image.is_null()) {
 		LOG(ERROR, "Invalid brush image. Returning");
 	}
@@ -198,7 +191,7 @@ void Terrain3DEditor::_operate_map(Vector3 p_global_position, real_t p_camera_di
 
 			if (_is_in_bounds(map_pixel_position, region_vsize)) {
 				Vector2 brush_uv = Vector2(x, y) / brush_size;
-				Vector2i brush_pixel_position = Vector2i(_rotate_uv(brush_uv, rot) * img_size);
+				Vector2i brush_pixel_position = Vector2i(_get_rotated_uv(brush_uv, rot) * img_size);
 
 				if (!_is_in_bounds(brush_pixel_position, img_size)) {
 					continue;
@@ -447,13 +440,20 @@ void Terrain3DEditor::_operate_map(Vector3 p_global_position, real_t p_camera_di
 	storage->add_edited_area(edited_area);
 }
 
-bool Terrain3DEditor::_is_in_bounds(Vector2i p_position, Vector2i p_max_position) {
+bool Terrain3DEditor::_is_in_bounds(const Vector2i &p_position, const Vector2i &p_max_position) const {
 	bool more_than_min = p_position.x >= 0 && p_position.y >= 0;
 	bool less_than_max = p_position.x < p_max_position.x && p_position.y < p_max_position.y;
 	return more_than_min && less_than_max;
 }
 
-Vector2 Terrain3DEditor::_get_uv_position(Vector3 p_global_position, int p_region_size) {
+real_t Terrain3DEditor::_get_brush_alpha(const Vector2i &p_position) const {
+	if (_brush_image.is_valid()) {
+		return _brush_image->get_pixelv(p_position).r;
+	}
+	return NAN;
+}
+
+Vector2 Terrain3DEditor::_get_uv_position(const Vector3 &p_global_position, const int p_region_size) const {
 	Vector2 descaled_position_2d = Vector2(p_global_position.x, p_global_position.z) / _terrain->get_mesh_vertex_spacing();
 	Vector2 region_position = descaled_position_2d / real_t(p_region_size);
 	region_position = region_position.floor();
@@ -461,13 +461,13 @@ Vector2 Terrain3DEditor::_get_uv_position(Vector3 p_global_position, int p_regio
 	return uv_position;
 }
 
-Vector2 Terrain3DEditor::_rotate_uv(Vector2 p_uv, real_t p_angle) {
+Vector2 Terrain3DEditor::_get_rotated_uv(const Vector2 &p_uv, const real_t p_angle) const {
 	Vector2 rotation_offset = Vector2(0.5f, 0.5f);
-	p_uv = (p_uv - rotation_offset).rotated(p_angle) + rotation_offset;
-	return p_uv.clamp(Vector2(0.f, 0.f), Vector2(1.f, 1.f));
+	Vector2 uv = (p_uv - rotation_offset).rotated(p_angle) + rotation_offset;
+	return uv.clamp(Vector2(0.f, 0.f), Vector2(1.f, 1.f));
 }
 
-Dictionary Terrain3DEditor::_collect_undo_data() {
+Dictionary Terrain3DEditor::_get_undo_data() const {
 	Dictionary data;
 	if (_tool < 0 || _tool >= TOOL_MAX) {
 		return data;
@@ -527,16 +527,16 @@ void Terrain3DEditor::_store_undo() {
 	LOG(DEBUG, "Creating undo action: '", action_name, "'");
 	undo_redo->create_action(action_name);
 
-	if (_undo_set.has("edited_area")) {
-		_undo_set["edited_area"] = _terrain->get_storage()->get_edited_area();
-		LOG(DEBUG, "Updating undo snapshot edited area: ", _undo_set["edited_area"]);
+	if (_undo_data.has("edited_area")) {
+		_undo_data["edited_area"] = _terrain->get_storage()->get_edited_area();
+		LOG(DEBUG, "Updating undo snapshot edited area: ", _undo_data["edited_area"]);
 	}
 
-	LOG(DEBUG, "Storing undo snapshot: ", _undo_set);
-	undo_redo->add_undo_method(this, "apply_undo", _undo_set.duplicate());
+	LOG(DEBUG, "Storing undo snapshot: ", _undo_data);
+	undo_redo->add_undo_method(this, "apply_undo", _undo_data.duplicate());
 
 	LOG(DEBUG, "Setting up redo snapshot...");
-	Dictionary redo_set = _collect_undo_data();
+	Dictionary redo_set = _get_undo_data();
 
 	LOG(DEBUG, "Storing redo snapshot: ", redo_set);
 	undo_redo->add_do_method(this, "apply_undo", redo_set);
@@ -545,7 +545,7 @@ void Terrain3DEditor::_store_undo() {
 	undo_redo->commit_action(false);
 }
 
-void Terrain3DEditor::_apply_undo(Dictionary p_set) {
+void Terrain3DEditor::_apply_undo(const Dictionary &p_set) {
 	IS_INIT_COND_MESG(_terrain->get_plugin() == nullptr, "_terrain isn't initialized, returning", VOID);
 	LOG(INFO, "Applying Undo/Redo set. Array size: ", p_set.size());
 	LOG(DEBUG, "Apply undo received: ", p_set);
@@ -586,7 +586,7 @@ void Terrain3DEditor::_apply_undo(Dictionary p_set) {
 
 // Santize and set incoming brush data w/ defaults and clamps
 // Only santizes data needed for the editor, other parameters (eg instancer) untouched here
-void Terrain3DEditor::set_brush_data(Dictionary p_data) {
+void Terrain3DEditor::set_brush_data(const Dictionary &p_data) {
 	_brush_data = p_data;
 
 	// Setup image and textures
@@ -629,7 +629,7 @@ void Terrain3DEditor::set_brush_data(Dictionary p_data) {
 	}
 }
 
-void Terrain3DEditor::set_tool(Tool p_tool) {
+void Terrain3DEditor::set_tool(const Tool p_tool) {
 	_tool = p_tool;
 	if (_terrain) {
 		_terrain->get_material()->set_show_navigation(_tool == NAVIGATION);
@@ -637,11 +637,11 @@ void Terrain3DEditor::set_tool(Tool p_tool) {
 }
 
 // Called on mouse click
-void Terrain3DEditor::start_operation(Vector3 p_global_position) {
+void Terrain3DEditor::start_operation(const Vector3 &p_global_position) {
 	IS_STORAGE_INIT_MESG("Terrain isn't initialized", VOID);
 	LOG(INFO, "Setting up undo snapshot...");
-	_undo_set.clear();
-	_undo_set = _collect_undo_data();
+	_undo_data.clear();
+	_undo_data = _get_undo_data();
 	_pending_undo = true;
 	_modified = false;
 	// Reset counter at start to ensure first click places an instance
@@ -655,7 +655,7 @@ void Terrain3DEditor::start_operation(Vector3 p_global_position) {
 }
 
 // Called on mouse movement with left mouse button down
-void Terrain3DEditor::operate(Vector3 p_global_position, real_t p_camera_direction) {
+void Terrain3DEditor::operate(const Vector3 &p_global_position, const real_t p_camera_direction) {
 	IS_STORAGE_INIT_MESG("Terrain isn't initialized", VOID);
 	if (!_pending_undo) {
 		return;

--- a/src/terrain_3d_editor.h
+++ b/src/terrain_3d_editor.h
@@ -81,19 +81,19 @@ private:
 	bool _pending_undo = false;
 	bool _modified = false;
 	AABB _modified_area;
-	Dictionary _undo_set; // See _collect_undo_data for definition
+	Dictionary _undo_data; // See _get_undo_data for definition
 
-	real_t _get_brush_alpha(Vector2i p_position);
-	void _region_modified(Vector3 p_global_position, Vector2 p_height_range = Vector2());
-	void _operate_region(Vector3 p_global_position);
-	void _operate_map(Vector3 p_global_position, real_t p_camera_direction);
-	bool _is_in_bounds(Vector2i p_position, Vector2i p_max_position);
-	Vector2 _get_uv_position(Vector3 p_global_position, int p_region_size);
-	Vector2 _rotate_uv(Vector2 p_uv, real_t p_angle);
+	void _region_modified(const Vector3 &p_global_position, const Vector2 &p_height_range = Vector2());
+	void _operate_region(const Vector3 &p_global_position);
+	void _operate_map(const Vector3 &p_global_position, const real_t p_camera_direction);
+	bool _is_in_bounds(const Vector2i &p_position, const Vector2i &p_max_position) const;
+	real_t _get_brush_alpha(const Vector2i &p_position) const;
+	Vector2 _get_uv_position(const Vector3 &p_global_position, const int p_region_size) const;
+	Vector2 _get_rotated_uv(const Vector2 &p_uv, const real_t p_angle) const;
 
-	Dictionary _collect_undo_data();
+	Dictionary _get_undo_data() const;
 	void _store_undo();
-	void _apply_undo(Dictionary p_set);
+	void _apply_undo(const Dictionary &p_set);
 
 public:
 	Terrain3DEditor() {}
@@ -102,14 +102,14 @@ public:
 	void set_terrain(Terrain3D *p_terrain) { _terrain = p_terrain; }
 	Terrain3D *get_terrain() const { return _terrain; }
 
-	void set_brush_data(Dictionary p_data);
-	void set_tool(Tool p_tool);
+	void set_brush_data(const Dictionary &p_data);
+	void set_tool(const Tool p_tool);
 	Tool get_tool() const { return _tool; }
-	void set_operation(Operation p_operation) { _operation = p_operation; }
+	void set_operation(const Operation p_operation) { _operation = p_operation; }
 	Operation get_operation() const { return _operation; }
 
-	void start_operation(Vector3 p_global_position);
-	void operate(Vector3 p_global_position, real_t p_camera_direction);
+	void start_operation(const Vector3 &p_global_position);
+	void operate(const Vector3 &p_global_position, const real_t p_camera_direction);
 	void stop_operation();
 	bool is_operating() const { return _pending_undo; }
 

--- a/src/terrain_3d_instancer.cpp
+++ b/src/terrain_3d_instancer.cpp
@@ -89,12 +89,12 @@ void Terrain3DInstancer::_update_mmis() {
 	LOG(DEBUG, "_mmis: ", _mmis);
 }
 
-void Terrain3DInstancer::_destroy_mmi_by_region_id(int p_region_id, int p_mesh_id) {
+void Terrain3DInstancer::_destroy_mmi_by_region_id(const int p_region_id, const int p_mesh_id) {
 	Vector2i region_offset = _terrain->get_storage()->get_region_offset_from_index(p_region_id);
 	_destroy_mmi_by_offset(region_offset, p_mesh_id);
 }
 
-void Terrain3DInstancer::_destroy_mmi_by_offset(Vector2i p_region_offset, int p_mesh_id) {
+void Terrain3DInstancer::_destroy_mmi_by_offset(const Vector2i &p_region_offset, const int p_mesh_id) {
 	Vector3i mmi_key = Vector3i(p_region_offset.x, p_region_offset.y, p_mesh_id);
 	LOG(DEBUG, "Deleting MMI at: ", p_region_offset, " mesh_id: ", p_mesh_id);
 	MultiMeshInstance3D *mmi = cast_to<MultiMeshInstance3D>(_mmis[mmi_key]);
@@ -202,12 +202,12 @@ void Terrain3DInstancer::update_multimesh(const Vector2i &p_region_offset, const
 	}
 }
 
-Ref<MultiMesh> Terrain3DInstancer::get_multimesh(Vector3 p_global_position, int p_mesh_id) {
+Ref<MultiMesh> Terrain3DInstancer::get_multimesh(const Vector3 &p_global_position, const int p_mesh_id) const {
 	Vector2i region_offset = _terrain->get_storage()->get_region_offset(p_global_position);
 	return get_multimesh(region_offset, p_mesh_id);
 }
 
-Ref<MultiMesh> Terrain3DInstancer::get_multimesh(Vector2i p_region_offset, int p_mesh_id) {
+Ref<MultiMesh> Terrain3DInstancer::get_multimesh(const Vector2i &p_region_offset, const int p_mesh_id) const {
 	IS_STORAGE_INIT(Ref<MultiMesh>());
 	Dictionary mesh_dict = _terrain->get_storage()->get_multimeshes().get(p_region_offset, Dictionary());
 	Ref<MultiMesh> mm = mesh_dict.get(p_mesh_id, Ref<MultiMesh>());
@@ -215,19 +215,19 @@ Ref<MultiMesh> Terrain3DInstancer::get_multimesh(Vector2i p_region_offset, int p
 	return mm;
 }
 
-MultiMeshInstance3D *Terrain3DInstancer::get_multimesh_instance(Vector3 p_global_position, int p_mesh_id) {
+MultiMeshInstance3D *Terrain3DInstancer::get_multimesh_instance(const Vector3 &p_global_position, const int p_mesh_id) const {
 	Vector2i region_offset = _terrain->get_storage()->get_region_offset(p_global_position);
 	return get_multimesh_instance(region_offset, p_mesh_id);
 }
 
-MultiMeshInstance3D *Terrain3DInstancer::get_multimesh_instance(Vector2i p_region_offset, int p_mesh_id) {
+MultiMeshInstance3D *Terrain3DInstancer::get_multimesh_instance(const Vector2i &p_region_offset, const int p_mesh_id) const {
 	Vector3i key = Vector3i(p_region_offset.x, p_region_offset.y, p_mesh_id);
 	MultiMeshInstance3D *mmi = cast_to<MultiMeshInstance3D>(_mmis[key]);
 	LOG(DEBUG_CONT, "Retrieving MultiMeshInstance3D at region: ", p_region_offset, " mesh_id: ", p_mesh_id, " : ", mmi);
 	return mmi;
 }
 
-void Terrain3DInstancer::swap_ids(int p_src_id, int p_dst_id) {
+void Terrain3DInstancer::swap_ids(const int p_src_id, const int p_dst_id) {
 	IS_STORAGE_INIT_MESG("Instancer isn't initialized.", VOID);
 	Ref<Terrain3DAssets> assets = _terrain->get_assets();
 	int asset_count = assets->get_mesh_count();
@@ -287,7 +287,7 @@ void Terrain3DInstancer::swap_ids(int p_src_id, int p_dst_id) {
 	}
 }
 
-void Terrain3DInstancer::add_instances(Vector3 p_global_position, Dictionary p_params) {
+void Terrain3DInstancer::add_instances(const Vector3 &p_global_position, const Dictionary &p_params) {
 	IS_STORAGE_INIT_MESG("Instancer isn't initialized.", VOID);
 
 	int mesh_id = p_params.get("asset_id", 0);
@@ -307,7 +307,7 @@ void Terrain3DInstancer::add_instances(Vector3 p_global_position, Dictionary p_p
 			.001f, 1000.f);
 
 	// Density based on strength, mesh AABB and input scale determines how many to place, even fractional
-	uint32_t count = _get_count(density);
+	uint32_t count = _get_instace_count(density);
 	if (count <= 0) {
 		return;
 	}
@@ -392,7 +392,7 @@ void Terrain3DInstancer::add_instances(Vector3 p_global_position, Dictionary p_p
 	_terrain->get_storage()->set_modified();
 }
 
-void Terrain3DInstancer::remove_instances(Vector3 p_global_position, Dictionary p_params) {
+void Terrain3DInstancer::remove_instances(const Vector3 &p_global_position, const Dictionary &p_params) {
 	IS_STORAGE_INIT_MESG("Instancer isn't initialized.", VOID);
 
 	int mesh_id = p_params.get("asset_id", 0);
@@ -412,7 +412,7 @@ void Terrain3DInstancer::remove_instances(Vector3 p_global_position, Dictionary 
 			.001f, 1000.f);
 
 	// Density based on strength, mesh AABB and input scale determines how many to place, even fractional
-	uint32_t count = _get_count(density);
+	uint32_t count = _get_instace_count(density);
 	if (count <= 0) {
 		return;
 	}
@@ -450,7 +450,7 @@ void Terrain3DInstancer::remove_instances(Vector3 p_global_position, Dictionary 
 	_terrain->get_storage()->set_modified();
 }
 
-void Terrain3DInstancer::add_transforms(int p_mesh_id, TypedArray<Transform3D> p_xforms, TypedArray<Color> p_colors) {
+void Terrain3DInstancer::add_transforms(const int p_mesh_id, const TypedArray<Transform3D> &p_xforms, const TypedArray<Color> &p_colors) {
 	IS_STORAGE_INIT_MESG("Instancer isn't initialized.", VOID);
 	if (p_xforms.size() == 0) {
 		return;
@@ -513,7 +513,7 @@ void Terrain3DInstancer::add_transforms(int p_mesh_id, TypedArray<Transform3D> p
 	_terrain->get_storage()->set_modified();
 }
 
-void Terrain3DInstancer::add_multimesh(int p_mesh_id, Ref<MultiMesh> p_multimesh, Transform3D p_xform) {
+void Terrain3DInstancer::add_multimesh(const int p_mesh_id, const Ref<MultiMesh> &p_multimesh, const Transform3D &p_xform) {
 	LOG(INFO, "Extracting ", p_multimesh->get_instance_count(), " transforms from multimesh");
 	TypedArray<Transform3D> xforms;
 	TypedArray<Color> colors;
@@ -529,7 +529,7 @@ void Terrain3DInstancer::add_multimesh(int p_mesh_id, Ref<MultiMesh> p_multimesh
 	add_transforms(p_mesh_id, xforms, colors);
 }
 
-void Terrain3DInstancer::set_cast_shadows(int p_mesh_id, GeometryInstance3D::ShadowCastingSetting p_cast_shadows) {
+void Terrain3DInstancer::set_cast_shadows(const int p_mesh_id, const GeometryInstance3D::ShadowCastingSetting p_cast_shadows) {
 	LOG(INFO, "Setting shadow casting on MMIS with mesh: ", p_mesh_id, " to mode: ", p_cast_shadows);
 	Array keys = _mmis.keys();
 	for (int i = 0; i < keys.size(); i++) {
@@ -543,7 +543,7 @@ void Terrain3DInstancer::set_cast_shadows(int p_mesh_id, GeometryInstance3D::Sha
 	}
 }
 
-void Terrain3DInstancer::clear_by_mesh(int p_mesh_id) {
+void Terrain3DInstancer::clear_by_mesh(const int p_mesh_id) {
 	LOG(INFO, "Deleting Multimeshes in all regions with mesh_id: ", p_mesh_id);
 	Dictionary region_dict = _terrain->get_storage()->get_multimeshes();
 	Array offsets = region_dict.keys();
@@ -552,12 +552,12 @@ void Terrain3DInstancer::clear_by_mesh(int p_mesh_id) {
 	}
 }
 
-void Terrain3DInstancer::clear_by_region_id(int p_region_id, int p_mesh_id) {
+void Terrain3DInstancer::clear_by_region_id(const int p_region_id, const int p_mesh_id) {
 	Vector2i region_offset = _terrain->get_storage()->get_region_offset_from_index(p_region_id);
 	clear_by_offset(region_offset, p_mesh_id);
 }
 
-void Terrain3DInstancer::clear_by_offset(Vector2i p_region_offset, int p_mesh_id) {
+void Terrain3DInstancer::clear_by_offset(const Vector2i &p_region_offset, const int p_mesh_id) {
 	LOG(INFO, "Deleting Multimeshes w/ mesh_id: ", p_mesh_id, " in region: ", p_region_offset);
 	Dictionary region_dict = _terrain->get_storage()->get_multimeshes();
 	LOG(DEBUG, "Original region_dict: ", region_dict);
@@ -571,7 +571,7 @@ void Terrain3DInstancer::clear_by_offset(Vector2i p_region_offset, int p_mesh_id
 	_destroy_mmi_by_offset(p_region_offset, p_mesh_id);
 }
 
-void Terrain3DInstancer::print_multimesh_buffer(MultiMeshInstance3D *p_mmi) {
+void Terrain3DInstancer::print_multimesh_buffer(MultiMeshInstance3D *p_mmi) const {
 	if (p_mmi == nullptr) {
 		return;
 	}

--- a/src/terrain_3d_instancer.h
+++ b/src/terrain_3d_instancer.h
@@ -42,7 +42,7 @@ public:
 	void initialize(Terrain3D *p_terrain);
 	void destroy();
 
-	void update_multimesh(Vector2i p_region_offset, int p_mesh_id, TypedArray<Transform3D> p_xforms, TypedArray<Color> p_colors, bool p_clear = false);
+	void update_multimesh(const Vector2i &p_region_offset, const int p_mesh_id, const TypedArray<Transform3D> &p_xforms, const TypedArray<Color> &p_colors, const bool p_clear = false);
 	Ref<MultiMesh> get_multimesh(Vector2i p_region_offset, int p_mesh_id);
 	Ref<MultiMesh> get_multimesh(Vector3 p_global_position, int p_mesh_id);
 	MultiMeshInstance3D *get_multimesh_instance(Vector3 p_global_position, int p_mesh_id);

--- a/src/terrain_3d_instancer.h
+++ b/src/terrain_3d_instancer.h
@@ -27,13 +27,12 @@ class Terrain3DInstancer : public Object {
 	Dictionary _mmis;
 
 	uint32_t _instance_counter = 0;
+	int _get_instace_count(const real_t p_density);
 
 	void _rebuild_mmis();
 	void _update_mmis();
-	void _destroy_mmi_by_region_id(int p_region, int p_mesh_id);
-	void _destroy_mmi_by_offset(Vector2i p_region_offset, int p_mesh_id);
-
-	int _get_count(real_t p_density);
+	void _destroy_mmi_by_region_id(const int p_region, const int p_mesh_id);
+	void _destroy_mmi_by_offset(const Vector2i &p_region_offset, const int p_mesh_id);
 
 public:
 	Terrain3DInstancer() {}
@@ -43,33 +42,34 @@ public:
 	void destroy();
 
 	void update_multimesh(const Vector2i &p_region_offset, const int p_mesh_id, const TypedArray<Transform3D> &p_xforms, const TypedArray<Color> &p_colors, const bool p_clear = false);
-	Ref<MultiMesh> get_multimesh(Vector2i p_region_offset, int p_mesh_id);
-	Ref<MultiMesh> get_multimesh(Vector3 p_global_position, int p_mesh_id);
-	MultiMeshInstance3D *get_multimesh_instance(Vector3 p_global_position, int p_mesh_id);
-	MultiMeshInstance3D *get_multimesh_instance(Vector2i p_region_offset, int p_mesh_id);
-	Dictionary get_mmis() { return _mmis; }
-	void swap_ids(int p_src_id, int p_dst_id);
+	Ref<MultiMesh> get_multimesh(const Vector3 &p_global_position, const int p_mesh_id) const;
+	Ref<MultiMesh> get_multimesh(const Vector2i &p_region_offset, const int p_mesh_id) const;
+	MultiMeshInstance3D *get_multimesh_instance(const Vector3 &p_global_position, const int p_mesh_id) const;
+	MultiMeshInstance3D *get_multimesh_instance(const Vector2i &p_region_offset, const int p_mesh_id) const;
+	Dictionary get_mmis() const { return _mmis; }
+	void swap_ids(const int p_src_id, const int p_dst_id);
 
-	void add_instances(Vector3 p_global_position, Dictionary p_params);
-	void remove_instances(Vector3 p_global_position, Dictionary p_params);
+	void add_instances(const Vector3 &p_global_position, const Dictionary &p_params);
+	void remove_instances(const Vector3 &p_global_position, const Dictionary &p_params);
 	void reset_instance_counter() { _instance_counter = 0; }
-	void add_transforms(int p_mesh_id, TypedArray<Transform3D> p_xforms, TypedArray<Color> p_colors = TypedArray<Color>());
-	void add_multimesh(int p_mesh_id, Ref<MultiMesh> p_multimesh, Transform3D p_xform = Transform3D());
+	void add_transforms(const int p_mesh_id, const TypedArray<Transform3D> &p_xforms, const TypedArray<Color> &p_colors = TypedArray<Color>());
+	void add_multimesh(const int p_mesh_id, const Ref<MultiMesh> &p_multimesh, const Transform3D &p_xform = Transform3D());
 
-	void set_cast_shadows(int p_mesh_id, GeometryInstance3D::ShadowCastingSetting p_cast_shadows);
+	void set_cast_shadows(const int p_mesh_id, const GeometryInstance3D::ShadowCastingSetting p_cast_shadows);
 
-	void clear_by_mesh(int p_mesh_id);
-	void clear_by_region_id(int p_region_id, int p_mesh_id);
-	void clear_by_offset(Vector2i p_region_offset, int p_mesh_id);
+	void clear_by_mesh(const int p_mesh_id);
+	void clear_by_region_id(const int p_region_id, const int p_mesh_id);
+	void clear_by_offset(const Vector2i &p_region_offset, const int p_mesh_id);
 
-	void print_multimesh_buffer(MultiMeshInstance3D *p_mmi);
+	void print_multimesh_buffer(MultiMeshInstance3D *p_mmi) const;
 
 protected:
 	static void _bind_methods();
 };
 
-// _instance_counter allows us to instance every X function calls for sparse placement
-inline int Terrain3DInstancer::_get_count(real_t p_density) {
+// Allows us to instance every X function calls for sparse placement
+// Modifies _instance_counter, not const!
+inline int Terrain3DInstancer::_get_instace_count(const real_t p_density) {
 	uint32_t count = 0;
 	if (p_density < 1.f && _instance_counter++ % int(1.f / p_density) == 0) {
 		count = 1;

--- a/src/terrain_3d_material.cpp
+++ b/src/terrain_3d_material.cpp
@@ -53,7 +53,7 @@ void Terrain3DMaterial::_preload_shaders() {
 /**
  *	All `//INSERT: ID` blocks in p_shader are loaded into the DB _shader_code
  */
-void Terrain3DMaterial::_parse_shader(String p_shader, String p_name) {
+void Terrain3DMaterial::_parse_shader(const String &p_shader, const String &p_name) {
 	if (p_name.is_empty()) {
 		LOG(ERROR, "No dictionary key for saving shader snippets specified");
 		return;
@@ -86,7 +86,7 @@ void Terrain3DMaterial::_parse_shader(String p_shader, String p_name) {
  *	returns a shader string with inserts applied
  *  Skips `EDITOR_*` and `DEBUG_*` inserts
  */
-String Terrain3DMaterial::_apply_inserts(String p_shader, Array p_excludes) {
+String Terrain3DMaterial::_apply_inserts(const String &p_shader, const Array &p_excludes) const {
 	PackedStringArray parsed = p_shader.split("//INSERT:");
 	String shader;
 	for (int i = 0; i < parsed.size(); i++) {
@@ -116,7 +116,7 @@ String Terrain3DMaterial::_apply_inserts(String p_shader, Array p_excludes) {
 	return shader;
 }
 
-String Terrain3DMaterial::_generate_shader_code() {
+String Terrain3DMaterial::_generate_shader_code() const {
 	LOG(INFO, "Generating default shader code");
 	Array excludes;
 	if (_world_background != NOISE) {
@@ -146,7 +146,7 @@ String Terrain3DMaterial::_generate_shader_code() {
 	return shader;
 }
 
-String Terrain3DMaterial::_inject_editor_code(String p_shader) {
+String Terrain3DMaterial::_inject_editor_code(const String &p_shader) const {
 	String shader = p_shader;
 	int idx = p_shader.rfind("}");
 	if (idx < 0) {
@@ -437,31 +437,31 @@ RID Terrain3DMaterial::get_shader_rid() const {
 	}
 }
 
-void Terrain3DMaterial::set_world_background(WorldBackground p_background) {
+void Terrain3DMaterial::set_world_background(const WorldBackground p_background) {
 	LOG(INFO, "Enable world background: ", p_background);
 	_world_background = p_background;
 	_update_shader();
 }
 
-void Terrain3DMaterial::set_texture_filtering(TextureFiltering p_filtering) {
+void Terrain3DMaterial::set_texture_filtering(const TextureFiltering p_filtering) {
 	LOG(INFO, "Setting texture filtering: ", p_filtering);
 	_texture_filtering = p_filtering;
 	_update_shader();
 }
 
-void Terrain3DMaterial::set_auto_shader(bool p_enabled) {
+void Terrain3DMaterial::set_auto_shader(const bool p_enabled) {
 	LOG(INFO, "Enable auto shader: ", p_enabled);
 	_auto_shader = p_enabled;
 	_update_shader();
 }
 
-void Terrain3DMaterial::set_dual_scaling(bool p_enabled) {
+void Terrain3DMaterial::set_dual_scaling(const bool p_enabled) {
 	LOG(INFO, "Enable dual scaling: ", p_enabled);
 	_dual_scaling = p_enabled;
 	_update_shader();
 }
 
-void Terrain3DMaterial::enable_shader_override(bool p_enabled) {
+void Terrain3DMaterial::enable_shader_override(const bool p_enabled) {
 	LOG(INFO, "Enable shader override: ", p_enabled);
 	_shader_override_enabled = p_enabled;
 	if (_shader_override_enabled && _shader_override.is_null()) {
@@ -489,91 +489,91 @@ Variant Terrain3DMaterial::get_shader_param(const StringName &p_name) const {
 	return value;
 }
 
-void Terrain3DMaterial::set_show_checkered(bool p_enabled) {
+void Terrain3DMaterial::set_show_checkered(const bool p_enabled) {
 	LOG(INFO, "Enable set_show_checkered: ", p_enabled);
 	_debug_view_checkered = p_enabled;
 	_update_shader();
 }
 
-void Terrain3DMaterial::set_show_grey(bool p_enabled) {
+void Terrain3DMaterial::set_show_grey(const bool p_enabled) {
 	LOG(INFO, "Enable show_grey: ", p_enabled);
 	_debug_view_grey = p_enabled;
 	_update_shader();
 }
 
-void Terrain3DMaterial::set_show_heightmap(bool p_enabled) {
+void Terrain3DMaterial::set_show_heightmap(const bool p_enabled) {
 	LOG(INFO, "Enable show_heightmap: ", p_enabled);
 	_debug_view_heightmap = p_enabled;
 	_update_shader();
 }
 
-void Terrain3DMaterial::set_show_colormap(bool p_enabled) {
+void Terrain3DMaterial::set_show_colormap(const bool p_enabled) {
 	LOG(INFO, "Enable show_colormap: ", p_enabled);
 	_debug_view_colormap = p_enabled;
 	_update_shader();
 }
 
-void Terrain3DMaterial::set_show_roughmap(bool p_enabled) {
+void Terrain3DMaterial::set_show_roughmap(const bool p_enabled) {
 	LOG(INFO, "Enable show_roughmap: ", p_enabled);
 	_debug_view_roughmap = p_enabled;
 	_update_shader();
 }
 
-void Terrain3DMaterial::set_show_control_texture(bool p_enabled) {
+void Terrain3DMaterial::set_show_control_texture(const bool p_enabled) {
 	LOG(INFO, "Enable show_control_texture: ", p_enabled);
 	_debug_view_control_texture = p_enabled;
 	_update_shader();
 }
 
-void Terrain3DMaterial::set_show_control_angle(bool p_enabled) {
+void Terrain3DMaterial::set_show_control_angle(const bool p_enabled) {
 	LOG(INFO, "Enable show_control_angle: ", p_enabled);
 	_debug_view_control_angle = p_enabled;
 	_update_shader();
 }
 
-void Terrain3DMaterial::set_show_control_scale(bool p_enabled) {
+void Terrain3DMaterial::set_show_control_scale(const bool p_enabled) {
 	LOG(INFO, "Enable show_control_scale: ", p_enabled);
 	_debug_view_control_scale = p_enabled;
 	_update_shader();
 }
 
-void Terrain3DMaterial::set_show_control_blend(bool p_enabled) {
+void Terrain3DMaterial::set_show_control_blend(const bool p_enabled) {
 	LOG(INFO, "Enable show_control_blend: ", p_enabled);
 	_debug_view_control_blend = p_enabled;
 	_update_shader();
 }
 
-void Terrain3DMaterial::set_show_autoshader(bool p_enabled) {
+void Terrain3DMaterial::set_show_autoshader(const bool p_enabled) {
 	LOG(INFO, "Enable show_autoshader: ", p_enabled);
 	_debug_view_autoshader = p_enabled;
 	_update_shader();
 }
 
-void Terrain3DMaterial::set_show_navigation(bool p_enabled) {
+void Terrain3DMaterial::set_show_navigation(const bool p_enabled) {
 	LOG(INFO, "Enable show_navigation: ", p_enabled);
 	_show_navigation = p_enabled;
 	_update_shader();
 }
 
-void Terrain3DMaterial::set_show_texture_height(bool p_enabled) {
+void Terrain3DMaterial::set_show_texture_height(const bool p_enabled) {
 	LOG(INFO, "Enable show_texture_height: ", p_enabled);
 	_debug_view_tex_height = p_enabled;
 	_update_shader();
 }
 
-void Terrain3DMaterial::set_show_texture_normal(bool p_enabled) {
+void Terrain3DMaterial::set_show_texture_normal(const bool p_enabled) {
 	LOG(INFO, "Enable show_texture_normal: ", p_enabled);
 	_debug_view_tex_normal = p_enabled;
 	_update_shader();
 }
 
-void Terrain3DMaterial::set_show_texture_rough(bool p_enabled) {
+void Terrain3DMaterial::set_show_texture_rough(const bool p_enabled) {
 	LOG(INFO, "Enable show_texture_rough: ", p_enabled);
 	_debug_view_tex_rough = p_enabled;
 	_update_shader();
 }
 
-void Terrain3DMaterial::set_show_vertex_grid(bool p_enabled) {
+void Terrain3DMaterial::set_show_vertex_grid(const bool p_enabled) {
 	LOG(INFO, "Enable show_vertex_grid: ", p_enabled);
 	_debug_view_vertex_grid = p_enabled;
 	_update_shader();
@@ -691,7 +691,7 @@ bool Terrain3DMaterial::_property_can_revert(const StringName &p_name) const {
 	return false;
 }
 
-// Provide uniform default values
+// Provide uniform default values in r_property
 bool Terrain3DMaterial::_property_get_revert(const StringName &p_name, Variant &r_property) const {
 	IS_INIT_COND(!_active_params.has(p_name), Resource::_property_get_revert(p_name, r_property));
 	RID shader;

--- a/src/terrain_3d_material.h
+++ b/src/terrain_3d_material.h
@@ -69,10 +69,10 @@ private:
 
 	// Functions
 	void _preload_shaders();
-	void _parse_shader(String p_shader, String p_name);
-	String _apply_inserts(String p_shader, Array p_excludes = Array());
-	String _generate_shader_code();
-	String _inject_editor_code(String p_shader);
+	void _parse_shader(const String &p_shader, const String &p_name);
+	String _apply_inserts(const String &p_shader, const Array &p_excludes = Array()) const;
+	String _generate_shader_code() const;
+	String _inject_editor_code(const String &p_shader) const;
 	void _update_shader();
 	void _update_regions();
 	void _generate_region_blend_map();
@@ -87,19 +87,19 @@ public:
 
 	RID get_material_rid() const { return _material; }
 	RID get_shader_rid() const;
-	RID get_region_blend_map() { return _generated_region_blend_map.get_rid(); }
+	RID get_region_blend_map() const { return _generated_region_blend_map.get_rid(); }
 
 	// Material settings
-	void set_world_background(WorldBackground p_background);
+	void set_world_background(const WorldBackground p_background);
 	WorldBackground get_world_background() const { return _world_background; }
-	void set_texture_filtering(TextureFiltering p_filtering);
+	void set_texture_filtering(const TextureFiltering p_filtering);
 	TextureFiltering get_texture_filtering() const { return _texture_filtering; }
-	void set_auto_shader(bool p_enabled);
+	void set_auto_shader(const bool p_enabled);
 	bool get_auto_shader() const { return _auto_shader; }
-	void set_dual_scaling(bool p_enabled);
+	void set_dual_scaling(const bool p_enabled);
 	bool get_dual_scaling() const { return _dual_scaling; }
 
-	void enable_shader_override(bool p_enabled);
+	void enable_shader_override(const bool p_enabled);
 	bool is_shader_override_enabled() const { return _shader_override_enabled; }
 	void set_shader_override(const Ref<Shader> &p_shader);
 	Ref<Shader> get_shader_override() const { return _shader_override; }
@@ -108,35 +108,35 @@ public:
 	Variant get_shader_param(const StringName &p_name) const;
 
 	// Editor functions / Debug views
-	void set_show_checkered(bool p_enabled);
+	void set_show_checkered(const bool p_enabled);
 	bool get_show_checkered() const { return _debug_view_checkered; }
-	void set_show_grey(bool p_enabled);
+	void set_show_grey(const bool p_enabled);
 	bool get_show_grey() const { return _debug_view_grey; }
-	void set_show_heightmap(bool p_enabled);
+	void set_show_heightmap(const bool p_enabled);
 	bool get_show_heightmap() const { return _debug_view_heightmap; }
-	void set_show_colormap(bool p_enabled);
+	void set_show_colormap(const bool p_enabled);
 	bool get_show_colormap() const { return _debug_view_colormap; }
-	void set_show_roughmap(bool p_enabled);
+	void set_show_roughmap(const bool p_enabled);
 	bool get_show_roughmap() const { return _debug_view_roughmap; }
-	void set_show_control_texture(bool p_enabled);
+	void set_show_control_texture(const bool p_enabled);
 	bool get_show_control_texture() const { return _debug_view_control_texture; }
-	void set_show_control_angle(bool p_enabled);
+	void set_show_control_angle(const bool p_enabled);
 	bool get_show_control_angle() const { return _debug_view_control_angle; }
-	void set_show_control_scale(bool p_enabled);
+	void set_show_control_scale(const bool p_enabled);
 	bool get_show_control_scale() const { return _debug_view_control_scale; }
-	void set_show_control_blend(bool p_enabled);
+	void set_show_control_blend(const bool p_enabled);
 	bool get_show_control_blend() const { return _debug_view_control_blend; }
-	void set_show_autoshader(bool p_enabled);
+	void set_show_autoshader(const bool p_enabled);
 	bool get_show_autoshader() const { return _debug_view_autoshader; }
-	void set_show_navigation(bool p_enabled);
+	void set_show_navigation(const bool p_enabled);
 	bool get_show_navigation() const { return _show_navigation; }
-	void set_show_texture_height(bool p_enabled);
+	void set_show_texture_height(const bool p_enabled);
 	bool get_show_texture_height() const { return _debug_view_tex_height; }
-	void set_show_texture_normal(bool p_enabled);
+	void set_show_texture_normal(const bool p_enabled);
 	bool get_show_texture_normal() const { return _debug_view_tex_normal; }
-	void set_show_texture_rough(bool p_enabled);
+	void set_show_texture_rough(const bool p_enabled);
 	bool get_show_texture_rough() const { return _debug_view_tex_rough; }
-	void set_show_vertex_grid(bool p_enabled);
+	void set_show_vertex_grid(const bool p_enabled);
 	bool get_show_vertex_grid() const { return _debug_view_vertex_grid; }
 
 	void save();

--- a/src/terrain_3d_mesh_asset.cpp
+++ b/src/terrain_3d_mesh_asset.cpp
@@ -17,14 +17,14 @@
 ///////////////////////////
 
 // This version doesn't emit a signal
-void Terrain3DMeshAsset::_set_generated_type(GenType p_type) {
+void Terrain3DMeshAsset::_set_generated_type(const GenType p_type) {
 	_generated_type = p_type;
 	LOG(INFO, "Setting is_generated: ", p_type);
 	if (p_type > TYPE_NONE && p_type < TYPE_MAX) {
 		_packed_scene.unref();
 		_meshes.clear();
 		LOG(DEBUG, "Generating card mesh");
-		_meshes.push_back(_build_generated_mesh());
+		_meshes.push_back(_get_generated_mesh());
 		_set_material_override(_get_material());
 		_height_offset = 0.5f;
 		_generated_faces = 2;
@@ -34,7 +34,7 @@ void Terrain3DMeshAsset::_set_generated_type(GenType p_type) {
 }
 
 // This version doesn't emit a signal
-void Terrain3DMeshAsset::_set_material_override(const Ref<Material> p_material) {
+void Terrain3DMeshAsset::_set_material_override(const Ref<Material> &p_material) {
 	LOG(INFO, _name, ": Setting material override: ", p_material);
 	_material_override = p_material;
 	if (_material_override.is_null() && _packed_scene.is_valid()) {
@@ -54,7 +54,7 @@ void Terrain3DMeshAsset::_set_material_override(const Ref<Material> p_material) 
 	}
 }
 
-Ref<ArrayMesh> Terrain3DMeshAsset::_build_generated_mesh() {
+Ref<ArrayMesh> Terrain3DMeshAsset::_get_generated_mesh() const {
 	LOG(DEBUG_CONT, "Regeneratingn new mesh");
 	Ref<ArrayMesh> array_mesh;
 	array_mesh.instantiate();
@@ -163,26 +163,26 @@ void Terrain3DMeshAsset::clear() {
 	notify_property_list_changed();
 }
 
-void Terrain3DMeshAsset::set_name(String p_name) {
+void Terrain3DMeshAsset::set_name(const String &p_name) {
 	LOG(INFO, "Setting name: ", p_name);
 	_name = p_name;
 	emit_signal("setting_changed");
 }
 
-void Terrain3DMeshAsset::set_id(int p_new_id) {
+void Terrain3DMeshAsset::set_id(const int p_new_id) {
 	int old_id = _id;
 	_id = CLAMP(p_new_id, 0, Terrain3DAssets::MAX_MESHES);
 	LOG(INFO, "Setting mesh id: ", _id);
 	emit_signal("id_changed", Terrain3DAssets::TYPE_MESH, old_id, p_new_id);
 }
 
-void Terrain3DMeshAsset::set_height_offset(real_t p_offset) {
+void Terrain3DMeshAsset::set_height_offset(const real_t p_offset) {
 	_height_offset = CLAMP(p_offset, -50.f, 50.f);
 	LOG(INFO, "Setting height offset: ", _height_offset);
 	emit_signal("setting_changed");
 }
 
-void Terrain3DMeshAsset::set_density(real_t p_density) {
+void Terrain3DMeshAsset::set_density(const real_t p_density) {
 	LOG(INFO, "Setting mesh density: ", p_density);
 	if (p_density < 0) {
 		_relative_density = _calculated_density;
@@ -199,13 +199,13 @@ real_t Terrain3DMeshAsset::get_density() const {
 	}
 }
 
-void Terrain3DMeshAsset::set_cast_shadows(GeometryInstance3D::ShadowCastingSetting p_cast_shadows) {
+void Terrain3DMeshAsset::set_cast_shadows(const GeometryInstance3D::ShadowCastingSetting p_cast_shadows) {
 	_cast_shadows = p_cast_shadows;
 	LOG(INFO, "Setting shadow casting mode: ", _cast_shadows);
 	emit_signal("cast_shadows_changed", _id, _cast_shadows);
 }
 
-void Terrain3DMeshAsset::set_scene_file(const Ref<PackedScene> p_scene_file) {
+void Terrain3DMeshAsset::set_scene_file(const Ref<PackedScene> &p_scene_file) {
 	LOG(INFO, "Setting scene file and instantiating node: ", p_scene_file);
 	_packed_scene = p_scene_file;
 	if (_packed_scene.is_valid()) {
@@ -258,25 +258,25 @@ void Terrain3DMeshAsset::set_scene_file(const Ref<PackedScene> p_scene_file) {
 	}
 }
 
-void Terrain3DMeshAsset::set_material_override(const Ref<Material> p_material) {
+void Terrain3DMeshAsset::set_material_override(const Ref<Material> &p_material) {
 	_set_material_override(p_material);
 	LOG(DEBUG, "Emitting setting_changed");
 	emit_signal("setting_changed");
 }
 
-void Terrain3DMeshAsset::set_generated_type(GenType p_type) {
+void Terrain3DMeshAsset::set_generated_type(const GenType p_type) {
 	_set_generated_type(p_type);
 	LOG(DEBUG, "Emitting file_changed");
 	notify_property_list_changed();
 	emit_signal("file_changed");
 }
 
-void Terrain3DMeshAsset::set_generated_faces(int p_count) {
+void Terrain3DMeshAsset::set_generated_faces(const int p_count) {
 	if (_generated_faces != p_count) {
 		_generated_faces = CLAMP(p_count, 1, 3);
 		LOG(INFO, "Setting generated face count: ", _generated_faces);
 		if (_generated_type > TYPE_NONE && _generated_type < TYPE_MAX && _meshes.size() == 1) {
-			_meshes[0] = _build_generated_mesh();
+			_meshes[0] = _get_generated_mesh();
 			_set_material_override(_get_material());
 			LOG(DEBUG, "Emitting setting_changed");
 			emit_signal("setting_changed");
@@ -284,12 +284,12 @@ void Terrain3DMeshAsset::set_generated_faces(int p_count) {
 	}
 }
 
-void Terrain3DMeshAsset::set_generated_size(Vector2 p_size) {
+void Terrain3DMeshAsset::set_generated_size(const Vector2 &p_size) {
 	if (_generated_size != p_size) {
 		_generated_size = p_size;
 		LOG(INFO, "Setting generated size: ", _generated_faces);
 		if (_generated_type > TYPE_NONE && _generated_type < TYPE_MAX && _meshes.size() == 1) {
-			_meshes[0] = _build_generated_mesh();
+			_meshes[0] = _get_generated_mesh();
 			_set_material_override(_get_material());
 			LOG(DEBUG, "Emitting setting_changed");
 			emit_signal("setting_changed");
@@ -297,7 +297,7 @@ void Terrain3DMeshAsset::set_generated_size(Vector2 p_size) {
 	}
 }
 
-Ref<Mesh> Terrain3DMeshAsset::get_mesh(int p_index) {
+Ref<Mesh> Terrain3DMeshAsset::get_mesh(const int p_index) {
 	if (p_index >= 0 && p_index < _meshes.size()) {
 		return _meshes[p_index];
 	}

--- a/src/terrain_3d_mesh_asset.h
+++ b/src/terrain_3d_mesh_asset.h
@@ -43,9 +43,9 @@ private:
 	Ref<Texture2D> _thumbnail;
 
 	// No signal versions
-	void _set_generated_type(GenType p_type);
-	void _set_material_override(const Ref<Material> p_material);
-	Ref<ArrayMesh> _build_generated_mesh();
+	void _set_generated_type(const GenType p_type);
+	void _set_material_override(const Ref<Material> &p_material);
+	Ref<ArrayMesh> _get_generated_mesh() const;
 	Ref<Material> _get_material();
 
 public:
@@ -54,35 +54,35 @@ public:
 
 	void clear();
 
-	void set_name(String p_name);
+	void set_name(const String &p_name);
 	String get_name() const { return _name; }
 
-	void set_id(int p_new_id);
+	void set_id(const int p_new_id);
 	int get_id() const { return _id; }
 
-	void set_height_offset(real_t p_offset);
+	void set_height_offset(const real_t p_offset);
 	real_t get_height_offset() const { return _height_offset; }
-	void set_density(real_t p_density);
+	void set_density(const real_t p_density);
 	real_t get_density() const;
 
-	void set_cast_shadows(GeometryInstance3D::ShadowCastingSetting p_cast_shadows);
+	void set_cast_shadows(const GeometryInstance3D::ShadowCastingSetting p_cast_shadows);
 	GeometryInstance3D::ShadowCastingSetting get_cast_shadows() const { return _cast_shadows; };
 
-	void set_scene_file(const Ref<PackedScene> p_scene_file);
+	void set_scene_file(const Ref<PackedScene> &p_scene_file);
 	Ref<PackedScene> get_scene_file() const { return _packed_scene; }
 
-	void set_material_override(const Ref<Material> p_material);
+	void set_material_override(const Ref<Material> &p_material);
 	Ref<Material> get_material_override() const { return _material_override; }
 
-	void set_generated_type(GenType p_type);
+	void set_generated_type(const GenType p_type);
 	GenType get_generated_type() const { return _generated_type; }
-	void set_generated_faces(int p_count);
+	void set_generated_faces(const int p_count);
 	int get_generated_faces() const { return _generated_faces; }
-	void set_generated_size(Vector2 p_size);
+	void set_generated_size(const Vector2 &p_size);
 	Vector2 get_generated_size() const { return _generated_size; }
 
-	Ref<Mesh> get_mesh(int p_index = 0);
-	int get_mesh_count() { return _meshes.size(); }
+	Ref<Mesh> get_mesh(const int p_index = 0);
+	int get_mesh_count() const { return _meshes.size(); }
 	Ref<Texture2D> get_thumbnail() const { return _thumbnail; }
 
 protected:

--- a/src/terrain_3d_storage.cpp
+++ b/src/terrain_3d_storage.cpp
@@ -46,7 +46,7 @@ Terrain3DStorage::~Terrain3DStorage() {
 // Lots of the upgrade process requires this to run first
 // It only runs if the version is saved in the file, which only happens if it was
 // different from the in the file is different from _version
-void Terrain3DStorage::set_version(real_t p_version) {
+void Terrain3DStorage::set_version(const real_t p_version) {
 	LOG(INFO, vformat("%.3f", p_version));
 	_version = p_version;
 	if (_version < CURRENT_VERSION) {
@@ -55,17 +55,17 @@ void Terrain3DStorage::set_version(real_t p_version) {
 	}
 }
 
-void Terrain3DStorage::set_save_16_bit(bool p_enabled) {
+void Terrain3DStorage::set_save_16_bit(const bool p_enabled) {
 	LOG(INFO, p_enabled);
 	_save_16_bit = p_enabled;
 }
 
-void Terrain3DStorage::set_height_range(Vector2 p_range) {
+void Terrain3DStorage::set_height_range(const Vector2 &p_range) {
 	LOG(INFO, vformat("%.2v", p_range));
 	_height_range = p_range;
 }
 
-void Terrain3DStorage::update_heights(real_t p_height) {
+void Terrain3DStorage::update_heights(const real_t p_height) {
 	if (p_height < _height_range.x) {
 		_height_range.x = p_height;
 	} else if (p_height > _height_range.y) {
@@ -74,7 +74,7 @@ void Terrain3DStorage::update_heights(real_t p_height) {
 	_modified = true;
 }
 
-void Terrain3DStorage::update_heights(Vector2 p_heights) {
+void Terrain3DStorage::update_heights(const Vector2 &p_heights) {
 	if (p_heights.x < _height_range.x) {
 		_height_range.x = p_heights.x;
 	}
@@ -105,7 +105,7 @@ void Terrain3DStorage::add_edited_area(const AABB &p_area) {
 	emit_signal("maps_edited", _edited_area);
 }
 
-void Terrain3DStorage::set_region_size(RegionSize p_size) {
+void Terrain3DStorage::set_region_size(const RegionSize p_size) {
 	LOG(INFO, p_size);
 	//ERR_FAIL_COND(p_size < SIZE_64);
 	//ERR_FAIL_COND(p_size > SIZE_2048);
@@ -123,26 +123,26 @@ void Terrain3DStorage::set_region_offsets(const TypedArray<Vector2i> &p_offsets)
 }
 
 /** Returns a region offset given a location */
-Vector2i Terrain3DStorage::get_region_offset(const Vector3 &p_global_position) {
+Vector2i Terrain3DStorage::get_region_offset(const Vector3 &p_global_position) const {
 	IS_INIT_MESG("Storage not initialized", Vector2i());
 	Vector3 descaled_position = p_global_position / _terrain->get_mesh_vertex_spacing();
 	return Vector2i((Vector2(descaled_position.x, descaled_position.z) / real_t(_region_size)).floor());
 }
 
 // Returns Vector2i(2147483647) if out of range
-Vector2i Terrain3DStorage::get_region_offset_from_index(int p_index) {
+Vector2i Terrain3DStorage::get_region_offset_from_index(const int p_index) const {
 	if (p_index < 0 || p_index >= _region_offsets.size()) {
 		return Vector2i(INT32_MAX, INT32_MAX);
 	}
 	return _region_offsets[p_index];
 }
 
-int Terrain3DStorage::get_region_index(const Vector3 &p_global_position) {
+int Terrain3DStorage::get_region_index(const Vector3 &p_global_position) const {
 	Vector2i uv_offset = get_region_offset(p_global_position);
 	return get_region_index_from_offset(uv_offset);
 }
 
-int Terrain3DStorage::get_region_index_from_offset(Vector2i p_region_offset) {
+int Terrain3DStorage::get_region_index_from_offset(const Vector2i &p_region_offset) const {
 	Vector2i pos = Vector2i(p_region_offset + (REGION_MAP_VSIZE / 2));
 	int map_index = pos.y * REGION_MAP_SIZE + pos.x;
 	if (map_index < 0 || map_index >= REGION_MAP_SIZE * REGION_MAP_SIZE) {
@@ -164,7 +164,7 @@ int Terrain3DStorage::get_region_index_from_offset(Vector2i p_region_offset) {
  *	p_images - Optional array of [ Height, Control, Color ... ] w/ region_sized images
  *	p_update - rebuild the maps if true. Set to false if bulk adding many regions.
  */
-Error Terrain3DStorage::add_region(const Vector3 &p_global_position, const TypedArray<Image> &p_images, bool p_update) {
+Error Terrain3DStorage::add_region(const Vector3 &p_global_position, const TypedArray<Image> &p_images, const bool p_update) {
 	IS_INIT_MESG("Storage not initialized", FAILED);
 	Vector2i uv_offset = get_region_offset(p_global_position);
 	LOG(INFO, "Adding region at ", p_global_position, ", uv_offset ", uv_offset,
@@ -228,7 +228,7 @@ Error Terrain3DStorage::add_region(const Vector3 &p_global_position, const Typed
 	return OK;
 }
 
-void Terrain3DStorage::remove_region(const Vector3 &p_global_position, bool p_update) {
+void Terrain3DStorage::remove_region(const Vector3 &p_global_position, const bool p_update) {
 	LOG(INFO, "Removing region at ", p_global_position, " Updating: ", p_update ? "yes" : "no");
 	int index = get_region_index(p_global_position);
 	ERR_FAIL_COND_MSG(index == -1, "Map does not exist.");
@@ -262,7 +262,9 @@ void Terrain3DStorage::remove_region(const Vector3 &p_global_position, bool p_up
 	}
 }
 
-void Terrain3DStorage::update_regions(bool force_emit) {
+void Terrain3DStorage::update_regions(const bool p_force_emit) {
+	bool force_emit = p_force_emit;
+
 	if (_generated_height_maps.is_dirty()) {
 		LOG(DEBUG_CONT, "Regenerating height layered texture from ", _height_maps.size(), " maps");
 		_generated_height_maps.create(_height_maps);
@@ -313,7 +315,7 @@ void Terrain3DStorage::update_regions(bool force_emit) {
 	}
 }
 
-void Terrain3DStorage::set_map_region(MapType p_map_type, int p_region_index, const Ref<Image> p_image) {
+void Terrain3DStorage::set_map_region(const MapType p_map_type, const int p_region_index, const Ref<Image> &p_image) {
 	switch (p_map_type) {
 		case TYPE_HEIGHT:
 			if (p_region_index >= 0 && p_region_index < _height_maps.size()) {
@@ -345,7 +347,7 @@ void Terrain3DStorage::set_map_region(MapType p_map_type, int p_region_index, co
 	}
 }
 
-Ref<Image> Terrain3DStorage::get_map_region(MapType p_map_type, int p_region_index) const {
+Ref<Image> Terrain3DStorage::get_map_region(const MapType p_map_type, const int p_region_index) const {
 	switch (p_map_type) {
 		case TYPE_HEIGHT:
 			if (p_region_index >= 0 && p_region_index < _height_maps.size()) {
@@ -375,7 +377,7 @@ Ref<Image> Terrain3DStorage::get_map_region(MapType p_map_type, int p_region_ind
 	return Ref<Image>();
 }
 
-void Terrain3DStorage::set_maps(MapType p_map_type, const TypedArray<Image> &p_maps) {
+void Terrain3DStorage::set_maps(const MapType p_map_type, const TypedArray<Image> &p_maps) {
 	ERR_FAIL_COND_MSG(p_map_type < 0 || p_map_type >= TYPE_MAX, "Specified map type out of range");
 	LOG(INFO, "Setting ", TYPESTR[p_map_type], " maps: ", p_maps.size());
 	switch (p_map_type) {
@@ -394,7 +396,7 @@ void Terrain3DStorage::set_maps(MapType p_map_type, const TypedArray<Image> &p_m
 	force_update_maps(p_map_type);
 }
 
-TypedArray<Image> Terrain3DStorage::get_maps(MapType p_map_type) const {
+TypedArray<Image> Terrain3DStorage::get_maps(const MapType p_map_type) const {
 	if (p_map_type < 0 || p_map_type >= TYPE_MAX) {
 		LOG(ERROR, "Specified map type out of range");
 		return TypedArray<Image>();
@@ -415,7 +417,7 @@ TypedArray<Image> Terrain3DStorage::get_maps(MapType p_map_type) const {
 	return TypedArray<Image>();
 }
 
-TypedArray<Image> Terrain3DStorage::get_maps_copy(MapType p_map_type) const {
+TypedArray<Image> Terrain3DStorage::get_maps_copy(const MapType p_map_type) const {
 	if (p_map_type < 0 || p_map_type >= TYPE_MAX) {
 		LOG(ERROR, "Specified map type out of range");
 		return TypedArray<Image>();
@@ -432,7 +434,7 @@ TypedArray<Image> Terrain3DStorage::get_maps_copy(MapType p_map_type) const {
 	return newmaps;
 }
 
-void Terrain3DStorage::set_pixel(MapType p_map_type, const Vector3 &p_global_position, const Color &p_pixel) {
+void Terrain3DStorage::set_pixel(const MapType p_map_type, const Vector3 &p_global_position, const Color &p_pixel) {
 	IS_INIT_MESG("Storage not initialized", VOID);
 	if (p_map_type < 0 || p_map_type >= TYPE_MAX) {
 		LOG(ERROR, "Specified map type out of range");
@@ -452,7 +454,7 @@ void Terrain3DStorage::set_pixel(MapType p_map_type, const Vector3 &p_global_pos
 	map->set_pixelv(img_pos, p_pixel);
 }
 
-Color Terrain3DStorage::get_pixel(MapType p_map_type, const Vector3 &p_global_position) {
+Color Terrain3DStorage::get_pixel(const MapType p_map_type, const Vector3 &p_global_position) const {
 	IS_INIT_MESG("Storage not initialized", COLOR_NAN);
 	if (p_map_type < 0 || p_map_type >= TYPE_MAX) {
 		LOG(ERROR, "Specified map type out of range");
@@ -473,7 +475,7 @@ Color Terrain3DStorage::get_pixel(MapType p_map_type, const Vector3 &p_global_po
 	return map->get_pixelv(img_pos);
 }
 
-real_t Terrain3DStorage::get_height(const Vector3 &p_global_position) {
+real_t Terrain3DStorage::get_height(const Vector3 &p_global_position) const {
 	IS_INIT_MESG("Storage not initialized", NAN);
 	if (is_hole(get_control(p_global_position))) {
 		return NAN;
@@ -513,7 +515,7 @@ real_t Terrain3DStorage::get_height(const Vector3 &p_global_position) {
  * blending values look, then consider that the overlay texture is visible starting at a blend
  * value of .3-.5, otherwise it's the base texture.
  **/
-Vector3 Terrain3DStorage::get_texture_id(const Vector3 &p_global_position) {
+Vector3 Terrain3DStorage::get_texture_id(const Vector3 &p_global_position) const {
 	IS_INIT_MESG("Storage not initialized", Vector3(NAN, NAN, NAN););
 	// Not in a region.
 	int region = get_region_index(p_global_position);
@@ -549,14 +551,14 @@ Vector3 Terrain3DStorage::get_texture_id(const Vector3 &p_global_position) {
 	return Vector3(real_t(base_id), real_t(overlay_id), blend);
 }
 
-real_t Terrain3DStorage::get_angle(const Vector3 &p_global_position) {
+real_t Terrain3DStorage::get_angle(const Vector3 &p_global_position) const {
 	float src = get_pixel(TYPE_CONTROL, p_global_position).r; // Must be 32-bit float, not double/real
 	real_t angle = real_t(get_uv_rotation(src));
 	angle *= 22.5; // Return value in degrees.
 	return real_t(angle);
 }
 
-real_t Terrain3DStorage::get_scale(const Vector3 &p_global_position) {
+real_t Terrain3DStorage::get_scale(const Vector3 &p_global_position) const {
 	float src = get_pixel(TYPE_CONTROL, p_global_position).r; // Must be 32-bit float, not double/real
 	std::array<real_t, 8> scale_values = { 0.0f, 20.0f, 40.0f, 60.0f, 80.0f, -60.0f, -40.0f, -20.0f };
 	real_t scale = scale_values[get_uv_scale(src)]; //select from array UI return values
@@ -571,7 +573,7 @@ real_t Terrain3DStorage::get_scale(const Vector3 &p_global_position) {
  *	TYPE_HEIGHT, TYPE_CONTROL, TYPE_COLOR: uniform set - p_maps are all the same type, size=N
  *	TYPE_MAX = region set - p_maps is [ height, control, color ], size=3
  **/
-TypedArray<Image> Terrain3DStorage::sanitize_maps(MapType p_map_type, const TypedArray<Image> &p_maps) {
+TypedArray<Image> Terrain3DStorage::sanitize_maps(const MapType p_map_type, const TypedArray<Image> &p_maps) const {
 	LOG(INFO, "Verifying image set is valid: ", p_maps.size(), " maps of type: ", TYPESTR[TYPE_MAX]);
 
 	TypedArray<Image> images;
@@ -635,7 +637,7 @@ TypedArray<Image> Terrain3DStorage::sanitize_maps(MapType p_map_type, const Type
 	return images;
 }
 
-void Terrain3DStorage::force_update_maps(MapType p_map_type) {
+void Terrain3DStorage::force_update_maps(const MapType p_map_type) {
 	switch (p_map_type) {
 		case TYPE_HEIGHT:
 			_generated_height_maps.clear();
@@ -655,7 +657,7 @@ void Terrain3DStorage::force_update_maps(MapType p_map_type) {
 	update_regions();
 }
 
-void Terrain3DStorage::set_multimeshes(Dictionary p_multimeshes) {
+void Terrain3DStorage::set_multimeshes(const Dictionary &p_multimeshes) {
 	LOG(INFO, "Loading multimeshes: ", p_multimeshes);
 	if (_multimeshes != p_multimeshes) {
 		_multimeshes = p_multimeshes;
@@ -713,7 +715,7 @@ void Terrain3DStorage::save() {
  *	p_offset - Add this factor to all height values, can be negative
  *	p_scale - Scale all height values by this factor (applied after offset)
  */
-void Terrain3DStorage::import_images(const TypedArray<Image> &p_images, const Vector3 &p_global_position, real_t p_offset, real_t p_scale) {
+void Terrain3DStorage::import_images(const TypedArray<Image> &p_images, const Vector3 &p_global_position, const real_t p_offset, const real_t p_scale) {
 	IS_INIT_MESG("Storage not initialized", VOID);
 	if (p_images.size() != TYPE_MAX) {
 		LOG(ERROR, "p_images.size() is ", p_images.size(), ". It should be ", TYPE_MAX, " even if some Images are blank or null");
@@ -834,7 +836,7 @@ void Terrain3DStorage::import_images(const TypedArray<Image> &p_images, const Ve
  * r16 can be edited by Krita, however you must know the dimensions and min/max before reimporting
  * res/tres allow storage in any of Godot's native Image formats.
  */
-Error Terrain3DStorage::export_image(String p_file_name, MapType p_map_type) {
+Error Terrain3DStorage::export_image(const String &p_file_name, const MapType p_map_type) const {
 	if (p_map_type < 0 || p_map_type >= TYPE_MAX) {
 		LOG(ERROR, "Invalid map type specified: ", p_map_type, " max: ", TYPE_MAX - 1);
 		return FAILED;
@@ -862,25 +864,25 @@ Error Terrain3DStorage::export_image(String p_file_name, MapType p_map_type) {
 	}
 
 	// Update path delimeter
-	p_file_name = p_file_name.replace("\\", "/");
+	String file_name = p_file_name.replace("\\", "/");
 
 	// Check if p_file_name has a path and prepend "res://" if not
 	bool is_simple_filename = true;
-	for (int i = 0; i < p_file_name.length(); ++i) {
-		char32_t c = p_file_name[i];
+	for (int i = 0; i < file_name.length(); ++i) {
+		char32_t c = file_name[i];
 		if (c == '/' || c == ':') {
 			is_simple_filename = false;
 			break;
 		}
 	}
 	if (is_simple_filename) {
-		p_file_name = "res://" + p_file_name;
+		file_name = "res://" + file_name;
 	}
 
 	// Check if the file could be opened for writing
-	Ref<FileAccess> file_ref = FileAccess::open(p_file_name, FileAccess::ModeFlags::WRITE);
+	Ref<FileAccess> file_ref = FileAccess::open(file_name, FileAccess::ModeFlags::WRITE);
 	if (file_ref.is_null()) {
-		LOG(ERROR, "Could not open file '" + p_file_name + "' for writing");
+		LOG(ERROR, "Could not open file '" + file_name + "' for writing");
 		return FAILED;
 	}
 	file_ref->close();
@@ -892,12 +894,12 @@ Error Terrain3DStorage::export_image(String p_file_name, MapType p_map_type) {
 		return FAILED;
 	}
 
-	String ext = p_file_name.get_extension().to_lower();
+	String ext = file_name.get_extension().to_lower();
 	LOG(MESG, "Saving ", img->get_size(), " sized ", TYPESTR[p_map_type],
-			" map in format ", img->get_format(), " as ", ext, " to: ", p_file_name);
+			" map in format ", img->get_format(), " as ", ext, " to: ", file_name);
 	if (ext == "r16" || ext == "raw") {
 		Vector2i minmax = Util::get_min_max(img);
-		Ref<FileAccess> file = FileAccess::open(p_file_name, FileAccess::WRITE);
+		Ref<FileAccess> file = FileAccess::open(file_name, FileAccess::WRITE);
 		real_t height_min = minmax.x;
 		real_t height_max = minmax.y;
 		real_t hscale = 65535.0 / (height_max - height_min);
@@ -910,25 +912,26 @@ Error Terrain3DStorage::export_image(String p_file_name, MapType p_map_type) {
 		}
 		return file->get_error();
 	} else if (ext == "exr") {
-		return img->save_exr(p_file_name, (p_map_type == TYPE_HEIGHT) ? true : false);
+		return img->save_exr(file_name, (p_map_type == TYPE_HEIGHT) ? true : false);
 	} else if (ext == "png") {
-		return img->save_png(p_file_name);
+		return img->save_png(file_name);
 	} else if (ext == "jpg") {
-		return img->save_jpg(p_file_name);
+		return img->save_jpg(file_name);
 	} else if (ext == "webp") {
-		return img->save_webp(p_file_name);
+		return img->save_webp(file_name);
 	} else if ((ext == "res") || (ext == "tres")) {
-		return ResourceSaver::get_singleton()->save(img, p_file_name, ResourceSaver::FLAG_COMPRESS);
+		return ResourceSaver::get_singleton()->save(img, file_name, ResourceSaver::FLAG_COMPRESS);
 	}
 
 	LOG(ERROR, "No recognized file type. See docs for valid extensions");
 	return FAILED;
 }
 
-Ref<Image> Terrain3DStorage::layered_to_image(MapType p_map_type) {
+Ref<Image> Terrain3DStorage::layered_to_image(const MapType p_map_type) const {
 	LOG(INFO, "Generating a full sized image for all regions including empty regions");
-	if (p_map_type >= TYPE_MAX) {
-		p_map_type = TYPE_HEIGHT;
+	MapType map_type = p_map_type;
+	if (map_type >= TYPE_MAX) {
+		map_type = TYPE_HEIGHT;
 	}
 	Vector2i top_left = Vector2i(0, 0);
 	Vector2i bottom_right = Vector2i(0, 0);
@@ -950,14 +953,14 @@ Ref<Image> Terrain3DStorage::layered_to_image(MapType p_map_type) {
 	LOG(DEBUG, "Full range to cover all regions: ", top_left, " to ", bottom_right);
 	Vector2i img_size = Vector2i(1 + bottom_right.x - top_left.x, 1 + bottom_right.y - top_left.y) * _region_size;
 	LOG(DEBUG, "Image size: ", img_size);
-	Ref<Image> img = Util::get_filled_image(img_size, COLOR[p_map_type], false, FORMAT[p_map_type]);
+	Ref<Image> img = Util::get_filled_image(img_size, COLOR[map_type], false, FORMAT[map_type]);
 
 	for (int i = 0; i < _region_offsets.size(); i++) {
 		Vector2i region = _region_offsets[i];
 		int index = get_region_index(Vector3(region.x, 0, region.y) * _region_size);
 		Vector2i img_location = (region - top_left) * _region_size;
 		LOG(DEBUG, "Region to blit: ", region, " Export image coords: ", img_location);
-		img->blit_rect(get_map_region(p_map_type, index), Rect2i(Vector2i(0, 0), _region_sizev), img_location);
+		img->blit_rect(get_map_region(map_type, index), Rect2i(Vector2i(0, 0), _region_sizev), img_location);
 	}
 	return img;
 }
@@ -971,7 +974,7 @@ Ref<Image> Terrain3DStorage::layered_to_image(MapType p_map_type) {
  *  HEIGHT_FILTER_MINIMUM: Samples (1 << p_lod) ** 2 heights around the given coordinates and returns the lowest.
  * p_global_position: X and Z coordinates of the vertex. Heights will be sampled around these coordinates.
  */
-Vector3 Terrain3DStorage::get_mesh_vertex(int32_t p_lod, HeightFilter p_filter, const Vector3 &p_global_position) {
+Vector3 Terrain3DStorage::get_mesh_vertex(const int32_t p_lod, const HeightFilter p_filter, const Vector3 &p_global_position) const {
 	IS_INIT_MESG("Storage not initialized", Vector3());
 	LOG(INFO, "Calculating vertex location");
 	int32_t step = 1 << CLAMP(p_lod, 0, 8);
@@ -1005,7 +1008,7 @@ Vector3 Terrain3DStorage::get_mesh_vertex(int32_t p_lod, HeightFilter p_filter, 
 	return Vector3(p_global_position.x, height, p_global_position.z);
 }
 
-Vector3 Terrain3DStorage::get_normal(const Vector3 &p_global_position) {
+Vector3 Terrain3DStorage::get_normal(const Vector3 &p_global_position) const {
 	IS_INIT_MESG("Storage not initialized", Vector3());
 	int region = get_region_index(p_global_position);
 	if (region < 0 || is_hole(get_control(p_global_position))) {
@@ -1020,7 +1023,7 @@ Vector3 Terrain3DStorage::get_normal(const Vector3 &p_global_position) {
 	return normal;
 }
 
-void Terrain3DStorage::print_audit_data() {
+void Terrain3DStorage::print_audit_data() const {
 	LOG(INFO, "Dumping storage data");
 	LOG(INFO, "_modified: ", _modified);
 	LOG(INFO, "Region_offsets size: ", _region_offsets.size(), " ", _region_offsets);

--- a/src/terrain_3d_storage.h
+++ b/src/terrain_3d_storage.h
@@ -111,15 +111,15 @@ public:
 	void initialize(Terrain3D *p_terrain);
 	~Terrain3DStorage();
 
-	void set_version(real_t p_version);
+	void set_version(const real_t p_version);
 	real_t get_version() const { return _version; }
-	void set_save_16_bit(bool p_enabled);
+	void set_save_16_bit(const bool p_enabled);
 	bool get_save_16_bit() const { return _save_16_bit; }
 
-	void set_height_range(Vector2 p_range);
+	void set_height_range(const Vector2 &p_range);
 	Vector2 get_height_range() const { return _height_range; }
-	void update_heights(real_t p_height);
-	void update_heights(Vector2 p_heights);
+	void update_heights(const real_t p_height);
+	void update_heights(const Vector2 &p_heights);
 	void update_height_range();
 
 	void clear_edited_area();
@@ -127,70 +127,70 @@ public:
 	AABB get_edited_area() const { return _edited_area; }
 
 	// Regions
-	void set_region_size(RegionSize p_size);
+	void set_region_size(const RegionSize p_size);
 	RegionSize get_region_size() const { return _region_size; }
 	Vector2i get_region_sizev() const { return _region_sizev; }
 	void set_region_offsets(const TypedArray<Vector2i> &p_offsets);
 	TypedArray<Vector2i> get_region_offsets() const { return _region_offsets; }
 	PackedInt32Array get_region_map() const { return _region_map; }
 	int get_region_count() const { return _region_offsets.size(); }
-	Vector2i get_region_offset(const Vector3 &p_global_position);
-	Vector2i get_region_offset_from_index(int p_index);
-	int get_region_index(const Vector3 &p_global_position);
-	int get_region_index_from_offset(Vector2i p_region_offset);
-	bool has_region(const Vector3 &p_global_position) { return get_region_index(p_global_position) != -1; }
-	Error add_region(const Vector3 &p_global_position, const TypedArray<Image> &p_images = TypedArray<Image>(), bool p_update = true);
-	void remove_region(const Vector3 &p_global_position, bool p_update = true);
-	void update_regions(bool force_emit = false);
+	Vector2i get_region_offset(const Vector3 &p_global_position) const;
+	Vector2i get_region_offset_from_index(const int p_index) const;
+	int get_region_index(const Vector3 &p_global_position) const;
+	int get_region_index_from_offset(const Vector2i &p_region_offset) const;
+	bool has_region(const Vector3 &p_global_position) const { return get_region_index(p_global_position) != -1; }
+	Error add_region(const Vector3 &p_global_position, const TypedArray<Image> &p_images = TypedArray<Image>(), const bool p_update = true);
+	void remove_region(const Vector3 &p_global_position, const bool p_update = true);
+	void update_regions(const bool p_force_emit = false);
 
 	// Maps
-	void set_map_region(MapType p_map_type, int p_region_index, const Ref<Image> p_image);
-	Ref<Image> get_map_region(MapType p_map_type, int p_region_index) const;
-	void set_maps(MapType p_map_type, const TypedArray<Image> &p_maps);
-	TypedArray<Image> get_maps(MapType p_map_type) const;
-	TypedArray<Image> get_maps_copy(MapType p_map_type) const;
+	void set_map_region(const MapType p_map_type, const int p_region_index, const Ref<Image> &p_image);
+	Ref<Image> get_map_region(const MapType p_map_type, const int p_region_index) const;
+	void set_maps(const MapType p_map_type, const TypedArray<Image> &p_maps);
+	TypedArray<Image> get_maps(const MapType p_map_type) const;
+	TypedArray<Image> get_maps_copy(const MapType p_map_type) const;
 	void set_height_maps(const TypedArray<Image> &p_maps) { set_maps(TYPE_HEIGHT, p_maps); }
 	TypedArray<Image> get_height_maps() const { return _height_maps; }
-	RID get_height_rid() { return _generated_height_maps.get_rid(); }
+	RID get_height_rid() const { return _generated_height_maps.get_rid(); }
 	void set_control_maps(const TypedArray<Image> &p_maps) { set_maps(TYPE_CONTROL, p_maps); }
 	TypedArray<Image> get_control_maps() const { return _control_maps; }
-	RID get_control_rid() { return _generated_control_maps.get_rid(); }
+	RID get_control_rid() const { return _generated_control_maps.get_rid(); }
 	void set_color_maps(const TypedArray<Image> &p_maps) { set_maps(TYPE_COLOR, p_maps); }
 	TypedArray<Image> get_color_maps() const { return _color_maps; }
-	RID get_color_rid() { return _generated_color_maps.get_rid(); }
-	TypedArray<Image> sanitize_maps(MapType p_map_type, const TypedArray<Image> &p_maps);
-	void set_pixel(MapType p_map_type, const Vector3 &p_global_position, const Color &p_pixel);
-	Color get_pixel(MapType p_map_type, const Vector3 &p_global_position);
-	void set_height(const Vector3 &p_global_position, real_t p_height);
-	real_t get_height(const Vector3 &p_global_position);
+	RID get_color_rid() const { return _generated_color_maps.get_rid(); }
+	void set_pixel(const MapType p_map_type, const Vector3 &p_global_position, const Color &p_pixel);
+	Color get_pixel(const MapType p_map_type, const Vector3 &p_global_position) const;
+	void set_height(const Vector3 &p_global_position, const real_t p_height);
+	real_t get_height(const Vector3 &p_global_position) const;
 	void set_color(const Vector3 &p_global_position, const Color &p_color);
-	Color get_color(const Vector3 &p_global_position);
-	void set_control(const Vector3 &p_global_position, uint32_t p_control);
-	uint32_t get_control(const Vector3 &p_global_position);
-	void set_roughness(const Vector3 &p_global_position, real_t p_roughness);
-	real_t get_roughness(const Vector3 &p_global_position);
-	Vector3 get_texture_id(const Vector3 &p_global_position);
-	real_t get_angle(const Vector3 &p_global_position);
-	real_t get_scale(const Vector3 &p_global_position);
-	void force_update_maps(MapType p_map = TYPE_MAX);
+	Color get_color(const Vector3 &p_global_position) const;
+	void set_control(const Vector3 &p_global_position, const uint32_t p_control);
+	uint32_t get_control(const Vector3 &p_global_position) const;
+	void set_roughness(const Vector3 &p_global_position, const real_t p_roughness);
+	real_t get_roughness(const Vector3 &p_global_position) const;
+	Vector3 get_texture_id(const Vector3 &p_global_position) const;
+	real_t get_angle(const Vector3 &p_global_position) const;
+	real_t get_scale(const Vector3 &p_global_position) const;
+	TypedArray<Image> sanitize_maps(const MapType p_map_type, const TypedArray<Image> &p_maps) const;
+	void force_update_maps(const MapType p_map = TYPE_MAX);
 
 	// Instancer
-	void set_multimeshes(Dictionary p_multimeshes);
-	Dictionary get_multimeshes() { return _multimeshes; }
+	void set_multimeshes(const Dictionary &p_multimeshes);
+	Dictionary get_multimeshes() const { return _multimeshes; }
 
 	// File I/O
 	void save();
 	void clear_modified() { _modified = false; }
 	void set_modified() { _modified = true; }
 	void import_images(const TypedArray<Image> &p_images, const Vector3 &p_global_position = Vector3(0.f, 0.f, 0.f),
-			real_t p_offset = 0.f, real_t p_scale = 1.f);
-	Error export_image(String p_file_name, MapType p_map_type = TYPE_HEIGHT);
-	Ref<Image> layered_to_image(MapType p_map_type);
+			const real_t p_offset = 0.f, const real_t p_scale = 1.f);
+	Error export_image(const String &p_file_name, const MapType p_map_type = TYPE_HEIGHT) const;
+	Ref<Image> layered_to_image(const MapType p_map_type) const;
 
 	// Utility
-	Vector3 get_mesh_vertex(int32_t p_lod, HeightFilter p_filter, const Vector3 &p_global_position);
-	Vector3 get_normal(const Vector3 &global_position);
-	void print_audit_data();
+	Vector3 get_mesh_vertex(const int32_t p_lod, const HeightFilter p_filter, const Vector3 &p_global_position) const;
+	Vector3 get_normal(const Vector3 &global_position) const;
+	void print_audit_data() const;
 
 protected:
 	static void _bind_methods();
@@ -202,7 +202,7 @@ VARIANT_ENUM_CAST(Terrain3DStorage::HeightFilter);
 
 // Inline Functions
 
-inline void Terrain3DStorage::set_height(const Vector3 &p_global_position, real_t p_height) {
+inline void Terrain3DStorage::set_height(const Vector3 &p_global_position, const real_t p_height) {
 	set_pixel(TYPE_HEIGHT, p_global_position, Color(p_height, 0.f, 0.f, 1.f));
 }
 
@@ -212,27 +212,27 @@ inline void Terrain3DStorage::set_color(const Vector3 &p_global_position, const 
 	set_pixel(TYPE_COLOR, p_global_position, clr);
 }
 
-inline Color Terrain3DStorage::get_color(const Vector3 &p_global_position) {
+inline Color Terrain3DStorage::get_color(const Vector3 &p_global_position) const {
 	Color clr = get_pixel(TYPE_COLOR, p_global_position);
 	clr.a = 1.0f;
 	return clr;
 }
 
-inline void Terrain3DStorage::set_control(const Vector3 &p_global_position, uint32_t p_control) {
+inline void Terrain3DStorage::set_control(const Vector3 &p_global_position, const uint32_t p_control) {
 	set_pixel(TYPE_CONTROL, p_global_position, Color(as_float(p_control), 0.f, 0.f, 1.f));
 }
 
-inline uint32_t Terrain3DStorage::get_control(const Vector3 &p_global_position) {
+inline uint32_t Terrain3DStorage::get_control(const Vector3 &p_global_position) const {
 	return as_uint(get_pixel(TYPE_CONTROL, p_global_position).r);
 }
 
-inline void Terrain3DStorage::set_roughness(const Vector3 &p_global_position, real_t p_roughness) {
+inline void Terrain3DStorage::set_roughness(const Vector3 &p_global_position, const real_t p_roughness) {
 	Color clr = get_pixel(TYPE_COLOR, p_global_position);
 	clr.a = p_roughness;
 	set_pixel(TYPE_COLOR, p_global_position, clr);
 }
 
-inline real_t Terrain3DStorage::get_roughness(const Vector3 &p_global_position) {
+inline real_t Terrain3DStorage::get_roughness(const Vector3 &p_global_position) const {
 	return get_pixel(TYPE_COLOR, p_global_position).a;
 }
 

--- a/src/terrain_3d_texture_asset.cpp
+++ b/src/terrain_3d_texture_asset.cpp
@@ -50,20 +50,20 @@ void Terrain3DTextureAsset::clear() {
 	_detiling = 0.0f;
 }
 
-void Terrain3DTextureAsset::set_name(String p_name) {
+void Terrain3DTextureAsset::set_name(const String &p_name) {
 	LOG(INFO, "Setting name: ", p_name);
 	_name = p_name;
 	emit_signal("setting_changed");
 }
 
-void Terrain3DTextureAsset::set_id(int p_new_id) {
+void Terrain3DTextureAsset::set_id(const int p_new_id) {
 	int old_id = _id;
 	_id = CLAMP(p_new_id, 0, Terrain3DAssets::MAX_TEXTURES);
 	LOG(INFO, "Setting texture id: ", _id);
 	emit_signal("id_changed", Terrain3DAssets::TYPE_TEXTURE, old_id, _id);
 }
 
-void Terrain3DTextureAsset::set_albedo_color(Color p_color) {
+void Terrain3DTextureAsset::set_albedo_color(const Color &p_color) {
 	LOG(INFO, "Setting color: ", p_color);
 	_albedo_color = p_color;
 	emit_signal("setting_changed");
@@ -89,15 +89,15 @@ void Terrain3DTextureAsset::set_normal_texture(const Ref<Texture2D> &p_texture) 
 	}
 }
 
-void Terrain3DTextureAsset::set_uv_scale(real_t p_scale) {
+void Terrain3DTextureAsset::set_uv_scale(const real_t p_scale) {
 	_uv_scale = CLAMP(p_scale, .001f, 2.f);
 	LOG(INFO, "Setting uv_scale: ", _uv_scale);
 	emit_signal("setting_changed");
 }
 
-void Terrain3DTextureAsset::set_detiling(real_t p_detiling) {
+void Terrain3DTextureAsset::set_detiling(const real_t p_detiling) {
 	_detiling = CLAMP(p_detiling, 0.0f, 1.0f);
-	LOG(INFO, "Setting uv_rotation: ", _detiling);
+	LOG(INFO, "Setting detiling: ", _detiling);
 	emit_signal("setting_changed");
 }
 

--- a/src/terrain_3d_texture_asset.h
+++ b/src/terrain_3d_texture_asset.h
@@ -29,13 +29,13 @@ public:
 
 	void clear();
 
-	void set_name(String p_name);
+	void set_name(const String &p_name);
 	String get_name() const { return _name; }
 
-	void set_id(int p_new_id);
+	void set_id(const int p_new_id);
 	int get_id() const { return _id; }
 
-	void set_albedo_color(Color p_color);
+	void set_albedo_color(const Color &p_color);
 	Color get_albedo_color() const { return _albedo_color; }
 
 	void set_albedo_texture(const Ref<Texture2D> &p_texture);
@@ -44,10 +44,10 @@ public:
 	void set_normal_texture(const Ref<Texture2D> &p_texture);
 	Ref<Texture2D> get_normal_texture() const { return _normal_texture; }
 
-	void set_uv_scale(real_t p_scale);
+	void set_uv_scale(const real_t p_scale);
 	real_t get_uv_scale() const { return _uv_scale; }
 
-	void set_detiling(real_t p_detiling);
+	void set_detiling(const real_t p_detiling);
 	real_t get_detiling() const { return _detiling; }
 
 protected:

--- a/src/terrain_3d_util.cpp
+++ b/src/terrain_3d_util.cpp
@@ -10,7 +10,7 @@
 // Public Functions
 ///////////////////////////
 
-void Terrain3DUtil::print_dict(String p_name, const Dictionary &p_dict, int p_level) {
+void Terrain3DUtil::print_dict(const String &p_name, const Dictionary &p_dict, const int p_level) {
 	LOG(p_level, "Printing Dictionary: ", p_name);
 	Array keys = p_dict.keys();
 	for (int i = 0; i < keys.size(); i++) {
@@ -18,11 +18,11 @@ void Terrain3DUtil::print_dict(String p_name, const Dictionary &p_dict, int p_le
 	}
 }
 
-void Terrain3DUtil::dump_gen(GeneratedTexture p_gen, String p_name, int p_level) {
+void Terrain3DUtil::dump_gen(const GeneratedTexture p_gen, const String &p_name, const int p_level) {
 	LOG(p_level, "Generated ", p_name, " RID: ", p_gen.get_rid(), ", dirty: ", p_gen.is_dirty(), ", image: ", p_gen.get_image());
 }
 
-void Terrain3DUtil::dump_maps(const TypedArray<Image> p_maps, String p_name) {
+void Terrain3DUtil::dump_maps(const TypedArray<Image> &p_maps, const String &p_name) {
 	LOG(DEBUG, "Dumping ", p_name, " map array. Size: ", p_maps.size());
 	for (int i = 0; i < p_maps.size(); i++) {
 		Ref<Image> img = p_maps[i];
@@ -30,7 +30,7 @@ void Terrain3DUtil::dump_maps(const TypedArray<Image> p_maps, String p_name) {
 	}
 }
 
-Ref<Image> Terrain3DUtil::black_to_alpha(const Ref<Image> p_image) {
+Ref<Image> Terrain3DUtil::black_to_alpha(const Ref<Image> &p_image) {
 	if (p_image.is_null()) {
 		return Ref<Image>();
 	}
@@ -48,7 +48,7 @@ Ref<Image> Terrain3DUtil::black_to_alpha(const Ref<Image> p_image) {
 /**
  * Returns the minimum and maximum values for a heightmap (red channel only)
  */
-Vector2 Terrain3DUtil::get_min_max(const Ref<Image> p_image) {
+Vector2 Terrain3DUtil::get_min_max(const Ref<Image> &p_image) {
 	if (p_image.is_null()) {
 		LOG(ERROR, "Provided image is not valid. Nothing to analyze");
 		return Vector2(INFINITY, INFINITY);
@@ -79,7 +79,7 @@ Vector2 Terrain3DUtil::get_min_max(const Ref<Image> p_image) {
  * Returns a Image of a float heightmap normalized to RGB8 greyscale and scaled
  * Minimum of 8x8
  */
-Ref<Image> Terrain3DUtil::get_thumbnail(const Ref<Image> p_image, Vector2i p_size) {
+Ref<Image> Terrain3DUtil::get_thumbnail(const Ref<Image> &p_image, const Vector2i &p_size) {
 	if (p_image.is_null()) {
 		LOG(ERROR, "Provided image is not valid. Nothing to process.");
 		return Ref<Image>();
@@ -87,15 +87,14 @@ Ref<Image> Terrain3DUtil::get_thumbnail(const Ref<Image> p_image, Vector2i p_siz
 		LOG(ERROR, "Provided image is empty. Nothing to process.");
 		return Ref<Image>();
 	}
-	p_size.x = CLAMP(p_size.x, 8, 16384);
-	p_size.y = CLAMP(p_size.y, 8, 16384);
+	Vector2i size = Vector2i(CLAMP(p_size.x, 8, 16384), CLAMP(p_size.y, 8, 16384));
 
-	LOG(INFO, "Drawing a thumbnail sized: ", p_size);
+	LOG(INFO, "Drawing a thumbnail sized: ", size);
 	// Create a temporary work image scaled to desired width
 	Ref<Image> img;
 	img.instantiate();
 	img->copy_from(p_image);
-	img->resize(p_size.x, p_size.y, Image::INTERPOLATE_LANCZOS);
+	img->resize(size.x, size.y, Image::INTERPOLATE_LANCZOS);
 
 	// Get minimum and maximum height values on the scaled image
 	Vector2 minmax = get_min_max(img);
@@ -108,7 +107,7 @@ Ref<Image> Terrain3DUtil::get_thumbnail(const Ref<Image> p_image, Vector2i p_siz
 	hmax = (hmax == 0) ? 0.001f : hmax;
 
 	// Create a new image w / normalized values
-	Ref<Image> thumb = Image::create(p_size.x, p_size.y, false, Image::FORMAT_RGB8);
+	Ref<Image> thumb = Image::create(size.x, size.y, false, Image::FORMAT_RGB8);
 	for (int y = 0; y < thumb->get_height(); y++) {
 		for (int x = 0; x < thumb->get_width(); x++) {
 			Color col = img->get_pixel(x, y);
@@ -132,9 +131,11 @@ Ref<Image> Terrain3DUtil::get_thumbnail(const Ref<Image> p_image, Vector2i p_siz
  * unreliable, offering little control over the output format, choosing automatically and
  * often wrong. We have selected a few compressed formats it gets right.
  */
-Ref<Image> Terrain3DUtil::get_filled_image(Vector2i p_size, Color p_color, bool p_create_mipmaps, Image::Format p_format) {
-	if (p_format < 0 || p_format >= Image::FORMAT_MAX) {
-		p_format = Image::FORMAT_DXT5;
+Ref<Image> Terrain3DUtil::get_filled_image(const Vector2i &p_size, const Color &p_color,
+		const bool p_create_mipmaps, const Image::Format p_format) {
+	Image::Format format = p_format;
+	if (format < 0 || format >= Image::FORMAT_MAX) {
+		format = Image::FORMAT_DXT5;
 	}
 
 	Image::CompressMode compression_format = Image::COMPRESS_MAX;
@@ -142,22 +143,22 @@ Ref<Image> Terrain3DUtil::get_filled_image(Vector2i p_size, Color p_color, bool 
 	bool compress = false;
 	bool fill_image = true;
 
-	if (p_format >= Image::Format::FORMAT_DXT1) {
-		switch (p_format) {
+	if (format >= Image::Format::FORMAT_DXT1) {
+		switch (format) {
 			case Image::FORMAT_DXT1:
-				p_format = Image::FORMAT_RGB8;
+				format = Image::FORMAT_RGB8;
 				channels = Image::USED_CHANNELS_RGB;
 				compression_format = Image::COMPRESS_S3TC;
 				compress = true;
 				break;
 			case Image::FORMAT_DXT5:
-				p_format = Image::FORMAT_RGBA8;
+				format = Image::FORMAT_RGBA8;
 				channels = Image::USED_CHANNELS_RGBA;
 				compression_format = Image::COMPRESS_S3TC;
 				compress = true;
 				break;
 			case Image::FORMAT_BPTC_RGBA:
-				p_format = Image::FORMAT_RGBA8;
+				format = Image::FORMAT_RGBA8;
 				channels = Image::USED_CHANNELS_RGBA;
 				compression_format = Image::COMPRESS_BPTC;
 				compress = true;
@@ -169,19 +170,20 @@ Ref<Image> Terrain3DUtil::get_filled_image(Vector2i p_size, Color p_color, bool 
 		}
 	}
 
-	Ref<Image> img = Image::create(p_size.x, p_size.y, p_create_mipmaps, p_format);
+	Ref<Image> img = Image::create(p_size.x, p_size.y, p_create_mipmaps, format);
 
+	Color color = p_color;
 	if (fill_image) {
-		if (p_color.a < 0.0f) {
-			p_color.a = 1.0f;
-			Color col_a = Color(0.8f, 0.8f, 0.8f, 1.0) * p_color;
-			Color col_b = Color(0.5f, 0.5f, 0.5f, 1.0) * p_color;
+		if (color.a < 0.0f) {
+			color.a = 1.0f;
+			Color col_a = Color(0.8f, 0.8f, 0.8f, 1.0) * color;
+			Color col_b = Color(0.5f, 0.5f, 0.5f, 1.0) * color;
 			img->fill_rect(Rect2i(Vector2i(0, 0), p_size / 2), col_a);
 			img->fill_rect(Rect2i(p_size / 2, p_size / 2), col_a);
 			img->fill_rect(Rect2i(Vector2(p_size.x, 0) / 2, p_size / 2), col_b);
 			img->fill_rect(Rect2i(Vector2(0, p_size.y) / 2, p_size / 2), col_b);
 		} else {
-			img->fill(p_color);
+			img->fill(color);
 		}
 		if (p_create_mipmaps) {
 			img->generate_mipmaps();
@@ -201,7 +203,7 @@ Ref<Image> Terrain3DUtil::get_filled_image(Vector2i p_size, Color p_color, bool 
  *	p_height_range - R16 format: x=Min & y=Max value ranges. Required for R16 import
  *	p_size - R16 format: Image dimensions. Default (0,0) auto detects f/ square images. Required f/ non-square R16
  */
-Ref<Image> Terrain3DUtil::load_image(String p_file_name, int p_cache_mode, Vector2 p_r16_height_range, Vector2i p_r16_size) {
+Ref<Image> Terrain3DUtil::load_image(const String &p_file_name, const int p_cache_mode, const Vector2 &p_r16_height_range, const Vector2i &p_r16_size) {
 	if (p_file_name.is_empty()) {
 		LOG(ERROR, "No file specified. Nothing imported.");
 		return Ref<Image>();
@@ -222,17 +224,18 @@ Ref<Image> Terrain3DUtil::load_image(String p_file_name, int p_cache_mode, Vecto
 		LOG(DEBUG, "Loading file as an r16");
 		Ref<FileAccess> file = FileAccess::open(p_file_name, FileAccess::READ);
 		// If p_size is zero, assume square and try to auto detect size
-		if (p_r16_size <= Vector2i(0, 0)) {
+		Vector2i r16_size = p_r16_size;
+		if (r16_size <= Vector2i(0, 0)) {
 			file->seek_end();
 			int fsize = file->get_position();
 			int fwidth = sqrt(fsize / 2);
-			p_r16_size = Vector2i(fwidth, fwidth);
-			LOG(DEBUG, "Total file size is: ", fsize, " calculated width: ", fwidth, " dimensions: ", p_r16_size);
+			r16_size = Vector2i(fwidth, fwidth);
+			LOG(DEBUG, "Total file size is: ", fsize, " calculated width: ", fwidth, " dimensions: ", r16_size);
 			file->seek(0);
 		}
-		img = Image::create(p_r16_size.x, p_r16_size.y, false, Terrain3DStorage::FORMAT[Terrain3DStorage::TYPE_HEIGHT]);
-		for (int y = 0; y < p_r16_size.y; y++) {
-			for (int x = 0; x < p_r16_size.x; x++) {
+		img = Image::create(r16_size.x, r16_size.y, false, Terrain3DStorage::FORMAT[Terrain3DStorage::TYPE_HEIGHT]);
+		for (int y = 0; y < r16_size.y; y++) {
+			for (int x = 0; x < r16_size.x; x++) {
 				real_t h = real_t(file->get_16()) / 65535.0f;
 				h = h * (p_r16_height_range.y - p_r16_height_range.x) + p_r16_height_range.x;
 				img->set_pixel(x, y, Color(h, 0.f, 0.f));
@@ -265,7 +268,7 @@ Ref<Image> Terrain3DUtil::load_image(String p_file_name, int p_cache_mode, Vecto
 /* From source RGB and R channels, create a new RGBA image. If p_invert_green_channel is true,
  * the destination green channel will be 1.0 - input green channel.
  */
-Ref<Image> Terrain3DUtil::pack_image(const Ref<Image> p_src_rgb, const Ref<Image> p_src_r, bool p_invert_green_channel) {
+Ref<Image> Terrain3DUtil::pack_image(const Ref<Image> &p_src_rgb, const Ref<Image> &p_src_r, const bool p_invert_green_channel) {
 	if (!p_src_rgb.is_valid() || !p_src_r.is_valid()) {
 		LOG(ERROR, "Provided images are not valid. Cannot pack.");
 		return Ref<Image>();

--- a/src/terrain_3d_util.h
+++ b/src/terrain_3d_util.h
@@ -16,21 +16,21 @@ class Terrain3DUtil : public Object {
 
 public:
 	// Print info to the console
-	static void print_dict(String name, const Dictionary &p_dict, int p_level = 2); // Level 2: DEBUG
-	static void dump_gen(GeneratedTexture p_gen, String name = "", int p_level = 2);
-	static void dump_maps(const TypedArray<Image> p_maps, String p_name = "");
+	static void print_dict(const String &name, const Dictionary &p_dict, const int p_level = 2); // Level 2: DEBUG
+	static void dump_gen(const GeneratedTexture p_gen, const String &name = "", const int p_level = 2);
+	static void dump_maps(const TypedArray<Image> &p_maps, const String &p_name = "");
 
 	// Image operations
-	static Ref<Image> black_to_alpha(const Ref<Image> p_image);
-	static Vector2 get_min_max(const Ref<Image> p_image);
-	static Ref<Image> get_thumbnail(const Ref<Image> p_image, Vector2i p_size = Vector2i(256, 256));
-	static Ref<Image> get_filled_image(Vector2i p_size,
-			Color p_color = COLOR_BLACK,
-			bool p_create_mipmaps = true,
-			Image::Format p_format = Image::FORMAT_MAX);
-	static Ref<Image> load_image(String p_file_name, int p_cache_mode = ResourceLoader::CACHE_MODE_IGNORE,
-			Vector2 p_r16_height_range = Vector2(0.f, 255.f), Vector2i p_r16_size = Vector2i(0, 0));
-	static Ref<Image> pack_image(const Ref<Image> p_src_rgb, const Ref<Image> p_src_r, bool p_invert_green_channel = false);
+	static Ref<Image> black_to_alpha(const Ref<Image> &p_image);
+	static Vector2 get_min_max(const Ref<Image> &p_image);
+	static Ref<Image> get_thumbnail(const Ref<Image> &p_image, const Vector2i &p_size = Vector2i(256, 256));
+	static Ref<Image> get_filled_image(const Vector2i &p_size,
+			const Color &p_color = COLOR_BLACK,
+			const bool p_create_mipmaps = true,
+			const Image::Format p_format = Image::FORMAT_MAX);
+	static Ref<Image> load_image(const String &p_file_name, const int p_cache_mode = ResourceLoader::CACHE_MODE_IGNORE,
+			const Vector2 &p_r16_height_range = Vector2(0.f, 255.f), const Vector2i &p_r16_size = Vector2i(0, 0));
+	static Ref<Image> pack_image(const Ref<Image> &p_src_rgb, const Ref<Image> &p_src_r, const bool p_invert_green_channel = false);
 
 protected:
 	static void _bind_methods();
@@ -45,7 +45,7 @@ typedef Terrain3DUtil Util;
 ///////////////////////////
 
 template <typename T>
-T round_multiple(T p_value, T p_multiple) {
+T round_multiple(const T p_value, const T p_multiple) {
 	if (p_multiple == 0) {
 		return p_value;
 	}
@@ -56,8 +56,8 @@ T round_multiple(T p_value, T p_multiple) {
 // * 4 values to be interpolated
 // * Positioned at the 4 corners of the p_pos00 - p_pos11 rectangle
 // * Interpolated to the position p_pos, which is global, not a 0-1 percentage
-inline real_t bilerp(real_t p_v00, real_t p_v01, real_t p_v10, real_t p_v11,
-		Vector2 p_pos00, Vector2 p_pos11, Vector2 p_pos) {
+inline real_t bilerp(const real_t p_v00, const real_t p_v01, const real_t p_v10, const real_t p_v11,
+		const Vector2 &p_pos00, const Vector2 &p_pos11, const Vector2 &p_pos) {
 	real_t x2x1 = p_pos11.x - p_pos00.x;
 	real_t y2y1 = p_pos11.y - p_pos00.y;
 	real_t x2x = p_pos11.x - p_pos.x;
@@ -71,8 +71,8 @@ inline real_t bilerp(real_t p_v00, real_t p_v01, real_t p_v10, real_t p_v11,
 			(x2x1 * y2y1);
 }
 
-inline real_t bilerp(real_t p_v00, real_t p_v01, real_t p_v10, real_t p_v11,
-		Vector3 p_pos00, Vector3 p_pos11, Vector3 p_pos) {
+inline real_t bilerp(const real_t p_v00, const real_t p_v01, const real_t p_v10, const real_t p_v11,
+		const Vector3 &p_pos00, const Vector3 &p_pos11, const Vector3 &p_pos) {
 	Vector2 pos00 = Vector2(p_pos00.x, p_pos00.z);
 	Vector2 pos11 = Vector2(p_pos11.x, p_pos11.z);
 	Vector2 pos = Vector2(p_pos.x, p_pos.z);
@@ -85,55 +85,55 @@ inline real_t bilerp(real_t p_v00, real_t p_v01, real_t p_v10, real_t p_v11,
 
 // Getters read the 32-bit float as a 32-bit uint, then mask bits to retreive value
 // Encoders return a full 32-bit uint with bits in the proper place for ORing
-inline float as_float(uint32_t value) { return *(float *)&value; }
-inline uint32_t as_uint(float value) { return *(uint32_t *)&value; }
+inline float as_float(const uint32_t p_value) { return *(float *)&p_value; }
+inline uint32_t as_uint(const float p_value) { return *(uint32_t *)&p_value; }
 
-inline uint8_t get_base(uint32_t pixel) { return pixel >> 27 & 0x1F; }
-inline uint8_t get_base(float pixel) { return get_base(as_uint(pixel)); }
-inline uint32_t enc_base(uint8_t base) { return (base & 0x1F) << 27; }
+inline uint8_t get_base(const uint32_t p_pixel) { return p_pixel >> 27 & 0x1F; }
+inline uint8_t get_base(const float p_pixel) { return get_base(as_uint(p_pixel)); }
+inline uint32_t enc_base(const uint8_t p_base) { return (p_base & 0x1F) << 27; }
 
-inline uint8_t get_overlay(uint32_t pixel) { return pixel >> 22 & 0x1F; }
-inline uint8_t get_overlay(float pixel) { return get_overlay(as_uint(pixel)); }
-inline uint32_t enc_overlay(uint8_t over) { return (over & 0x1F) << 22; }
+inline uint8_t get_overlay(const uint32_t p_pixel) { return p_pixel >> 22 & 0x1F; }
+inline uint8_t get_overlay(const float p_pixel) { return get_overlay(as_uint(p_pixel)); }
+inline uint32_t enc_overlay(const uint8_t p_over) { return (p_over & 0x1F) << 22; }
 
-inline uint8_t get_blend(uint32_t pixel) { return pixel >> 14 & 0xFF; }
-inline uint8_t get_blend(float pixel) { return get_blend(as_uint(pixel)); }
-inline uint32_t enc_blend(uint8_t blend) { return (blend & 0xFF) << 14; }
+inline uint8_t get_blend(const uint32_t p_pixel) { return p_pixel >> 14 & 0xFF; }
+inline uint8_t get_blend(const float p_pixel) { return get_blend(as_uint(p_pixel)); }
+inline uint32_t enc_blend(const uint8_t p_blend) { return (p_blend & 0xFF) << 14; }
 
-inline uint8_t get_uv_rotation(uint32_t pixel) { return pixel >> 10 & 0xF; }
-inline uint8_t get_uv_rotation(float pixel) { return get_uv_rotation(as_uint(pixel)); }
-inline uint32_t enc_uv_rotation(uint8_t rotation) { return (rotation & 0xF) << 10; }
+inline uint8_t get_uv_rotation(const uint32_t p_pixel) { return p_pixel >> 10 & 0xF; }
+inline uint8_t get_uv_rotation(const float p_pixel) { return get_uv_rotation(as_uint(p_pixel)); }
+inline uint32_t enc_uv_rotation(const uint8_t p_rotation) { return (p_rotation & 0xF) << 10; }
 
-inline uint8_t get_uv_scale(uint32_t pixel) { return pixel >> 7 & 0x7; }
-inline uint8_t get_uv_scale(float pixel) { return get_uv_scale(as_uint(pixel)); }
-inline uint32_t enc_uv_scale(uint8_t scale) { return (scale & 0x7) << 7; }
+inline uint8_t get_uv_scale(const uint32_t p_pixel) { return p_pixel >> 7 & 0x7; }
+inline uint8_t get_uv_scale(const float p_pixel) { return get_uv_scale(as_uint(p_pixel)); }
+inline uint32_t enc_uv_scale(const uint8_t p_scale) { return (p_scale & 0x7) << 7; }
 
-inline bool is_hole(uint32_t pixel) { return (pixel >> 2 & 0x1) == 1; }
-inline bool is_hole(float pixel) { return is_hole(as_uint(pixel)); }
-inline uint32_t enc_hole(bool hole) { return (hole & 0x1) << 2; }
+inline bool is_hole(const uint32_t p_pixel) { return (p_pixel >> 2 & 0x1) == 1; }
+inline bool is_hole(const float p_pixel) { return is_hole(as_uint(p_pixel)); }
+inline uint32_t enc_hole(const bool p_hole) { return (p_hole & 0x1) << 2; }
 
-inline bool is_nav(uint32_t pixel) { return (pixel >> 1 & 0x1) == 1; }
-inline bool is_nav(float pixel) { return is_nav(as_uint(pixel)); }
-inline uint32_t enc_nav(bool nav) { return (nav & 0x1) << 1; }
+inline bool is_nav(const uint32_t p_pixel) { return (p_pixel >> 1 & 0x1) == 1; }
+inline bool is_nav(const float p_pixel) { return is_nav(as_uint(p_pixel)); }
+inline uint32_t enc_nav(const bool p_nav) { return (p_nav & 0x1) << 1; }
 
-inline bool is_auto(uint32_t pixel) { return (pixel & 0x1) == 1; }
-inline bool is_auto(float pixel) { return is_auto(as_uint(pixel)); }
-inline uint32_t enc_auto(bool autosh) { return autosh & 0x1; }
+inline bool is_auto(const uint32_t p_pixel) { return (p_pixel & 0x1) == 1; }
+inline bool is_auto(const float p_pixel) { return is_auto(as_uint(p_pixel)); }
+inline uint32_t enc_auto(const bool p_autosh) { return p_autosh & 0x1; }
 
 // Aliases for GDScript since it can't handle overridden functions
-inline uint32_t gd_get_base(uint32_t pixel) { return get_base(pixel); }
-inline uint32_t gd_enc_base(uint32_t base) { return enc_base(base); }
-inline uint32_t gd_get_overlay(uint32_t pixel) { return get_overlay(pixel); }
-inline uint32_t gd_enc_overlay(uint32_t over) { return enc_overlay(over); }
-inline uint32_t gd_get_blend(uint32_t pixel) { return get_overlay(pixel); }
-inline uint32_t gd_enc_blend(uint32_t blend) { return enc_blend(blend); }
-inline bool gd_is_hole(uint32_t pixel) { return is_hole(pixel); }
-inline bool gd_is_auto(uint32_t pixel) { return is_auto(pixel); }
-inline bool gd_is_nav(uint32_t pixel) { return is_nav(pixel); }
-inline uint32_t gd_get_uv_rotation(uint32_t pixel) { return get_uv_rotation(pixel); }
-inline uint32_t gd_enc_uv_rotation(uint32_t rotation) { return enc_uv_rotation(rotation); }
-inline uint32_t gd_get_uv_scale(uint32_t pixel) { return get_uv_rotation(pixel); }
-inline uint32_t gd_enc_uv_scale(uint32_t scale) { return enc_uv_rotation(scale); }
+inline uint32_t gd_get_base(const uint32_t p_pixel) { return get_base(p_pixel); }
+inline uint32_t gd_enc_base(const uint32_t p_base) { return enc_base(p_base); }
+inline uint32_t gd_get_overlay(const uint32_t p_pixel) { return get_overlay(p_pixel); }
+inline uint32_t gd_enc_overlay(const uint32_t p_over) { return enc_overlay(p_over); }
+inline uint32_t gd_get_blend(const uint32_t p_pixel) { return get_overlay(p_pixel); }
+inline uint32_t gd_enc_blend(const uint32_t p_blend) { return enc_blend(p_blend); }
+inline bool gd_is_hole(const uint32_t p_pixel) { return is_hole(p_pixel); }
+inline bool gd_is_auto(const uint32_t p_pixel) { return is_auto(p_pixel); }
+inline bool gd_is_nav(const uint32_t p_pixel) { return is_nav(p_pixel); }
+inline uint32_t gd_get_uv_rotation(const uint32_t p_pixel) { return get_uv_rotation(p_pixel); }
+inline uint32_t gd_enc_uv_rotation(const uint32_t p_rotation) { return enc_uv_rotation(p_rotation); }
+inline uint32_t gd_get_uv_scale(const uint32_t p_pixel) { return get_uv_rotation(p_pixel); }
+inline uint32_t gd_enc_uv_scale(const uint32_t p_scale) { return enc_uv_rotation(p_scale); }
 
 ///////////////////////////
 // Memory
@@ -164,7 +164,7 @@ _FORCE_INLINE_ bool remove_from_tree(Node *p_node) {
 // UtilityFunctions::is_instance_valid() is faulty and shouldn't be used.
 // Use this version instead on objects that might be freed by the user.
 // See https://github.com/godotengine/godot-cpp/issues/1390#issuecomment-1937570699
-_FORCE_INLINE_ bool is_instance_valid(uint64_t p_instance_id, Object *p_object = nullptr) {
+_FORCE_INLINE_ bool is_instance_valid(const uint64_t p_instance_id, Object *p_object = nullptr) {
 	Object *obj = ObjectDB::get_instance(p_instance_id);
 	if (p_object != nullptr) {
 		return p_instance_id > 0 && p_object == obj;


### PR DESCRIPTION
Fixes #410

Implements:
* const correctness on function declarations
* Pass everything > 4 bytes by reference: arrays, RIDs, Vector3, Transform3D, String, etc.

Reviewers, here's what to audit:
1. Functions that guarantee they won't change the class state are marked const (typically getters). Static & standalone functions like in Terrain3DUtil cannot be marked const like this.
```C++
-	RID get_albedo_array_rid() { return _generated_albedo_textures.get_rid(); }
+	RID get_albedo_array_rid() const { return _generated_albedo_textures.get_rid(); }
```

2. Every function parameter is const, unless the function intentionally modifies it (eg Terrain3D::_generate_triangles)
```C++
-void Terrain3DInstancer::_destroy_mmi_by_region_id(int p_region_id, int p_mesh_id) {
+void Terrain3DInstancer::_destroy_mmi_by_region_id(const int p_region_id, const int p_mesh_id)
```

3. All objects are now passed by reference or by pointer
```C++
-	void _operate_region(Vector3 p_global_position);
+	void _operate_region(const Vector3 &p_global_position);
```

4. Local function variables have been added where the function previously modified the parameter

```C++
Terrain3DEditor::_rotate_uv
-	p_uv = (p_uv - rotation_offset).rotated(p_angle) + rotation_offset;
+	Vector2 uv = (p_uv - rotation_offset).rotated(p_angle) + rotation_offset;
```

5. Ignore functions in `protected:` blocks, which derive from the engine definitions.

Also I jumped the gun on committing, so 24008a6137c38cd00156f3efbda9626413eae5a9 should be reviewed as well. Alternatively you can look at [this link](https://github.com/TokisanGames/Terrain3D/compare/c23683f577ac68db3177733c3aea7f9183491942...7bedc57a3875888074e23e71de15e9ae8fd495b9) to join that commit with the ones in this PR.

Todo: 
* update_multimesh changes can be more optimal