### PR TITLE
API change first pass - Breaks loading region_offsets!

### DIFF
--- a/project/addons/terrain_3d/editor.gd
+++ b/project/addons/terrain_3d/editor.gd
@@ -103,13 +103,13 @@ func _edit(p_object: Object) -> void:
 		ui.set_visible(true)
 		terrain.set_meta("_edit_lock_", true)
 		
-		# Connect to new Assets resource
+        # Get alerted when a new asset list is loaded
 		if not terrain.assets_changed.is_connected(asset_dock.update_assets):
 			terrain.assets_changed.connect(asset_dock.update_assets)
 		asset_dock.update_assets()
-		# Connect to new Storage resource
-		if not terrain.storage_changed.is_connected(update_region_grid):
-			terrain.storage_changed.connect(update_region_grid)
+        # Get alerted when the region map changes
+		if not terrain.get_storage().region_map_changed.is_connected(update_region_grid):
+			terrain.get_storage().region_map_changed.connect(update_region_grid)
 		update_region_grid()
 	else:
 		_clear()
@@ -124,7 +124,7 @@ func _edit(p_object: Object) -> void:
 	
 func _clear() -> void:
 	if is_terrain_valid():
-		terrain.storage_changed.disconnect(update_region_grid)
+		terrain.get_storage().region_map_changed.disconnect(update_region_grid)
 		
 		terrain.clear_gizmos()
 		terrain = null

--- a/project/addons/terrain_3d/editor.gd
+++ b/project/addons/terrain_3d/editor.gd
@@ -247,7 +247,7 @@ func update_region_grid() -> void:
 		region_gizmo.use_secondary_color = editor.get_operation() == Terrain3DEditor.SUBTRACT
 		region_gizmo.region_position = current_region_position
 		region_gizmo.region_size = terrain.get_storage().get_region_size() * terrain.get_mesh_vertex_spacing()
-		region_gizmo.grid = terrain.get_storage().get_region_offsets()
+		region_gizmo.grid = terrain.get_storage().get_region_locations()
 		
 		terrain.update_gizmos()
 		return

--- a/project/addons/terrain_3d/extras/minimum.gdshader
+++ b/project/addons/terrain_3d/extras/minimum.gdshader
@@ -10,7 +10,7 @@ uniform float _mesh_vertex_spacing = 1.0;
 uniform float _mesh_vertex_density = 1.0; // = 1/_mesh_vertex_spacing
 uniform int _region_map_size = 16;
 uniform int _region_map[256];
-uniform vec2 _region_offsets[256];
+uniform vec2 _region_locations[256];
 uniform sampler2DArray _height_maps : repeat_disable;
 uniform usampler2DArray _control_maps : repeat_disable;
 uniform sampler2DArray _color_maps : source_color, filter_linear_mipmap_anisotropic, repeat_disable;
@@ -38,7 +38,7 @@ ivec3 get_region_uv(vec2 uv) {
 	ivec2 pos = ivec2(floor(uv)) + (_region_map_size / 2);
 	int bounds = int(pos.x>=0 && pos.x<_region_map_size && pos.y>=0 && pos.y<_region_map_size);
 	int layer_index = _region_map[ pos.y * _region_map_size + pos.x ] * bounds - 1;
-	return ivec3(ivec2((uv - _region_offsets[layer_index]) * _region_size), layer_index);
+	return ivec3(ivec2((uv - _region_locations[layer_index]) * _region_size), layer_index);
 }
 
 // Takes in UV2 region space coordinates, returns vec3 with:
@@ -52,7 +52,7 @@ vec3 get_region_uv2(vec2 uv) {
 	int bounds = int(pos.x>=0 && pos.x<_region_map_size && pos.y>=0 && pos.y<_region_map_size);
 	int layer_index = _region_map[ pos.y * _region_map_size + pos.x ] * bounds - 1;
 	// The return value is still texel-centered.
-	return vec3(uv - _region_offsets[layer_index], float(layer_index));
+	return vec3(uv - _region_locations[layer_index], float(layer_index));
 }
 
 // 1 lookup

--- a/src/shaders/main.glsl
+++ b/src/shaders/main.glsl
@@ -31,7 +31,7 @@ uniform float _mesh_vertex_spacing = 1.0;
 uniform float _mesh_vertex_density = 1.0; // = 1/_mesh_vertex_spacing
 uniform int _region_map_size = 16;
 uniform int _region_map[256];
-uniform vec2 _region_offsets[256];
+uniform vec2 _region_locations[256];
 uniform sampler2DArray _height_maps : repeat_disable;
 uniform usampler2DArray _control_maps : repeat_disable;
 //INSERT: TEXTURE_SAMPLERS_NEAREST
@@ -101,7 +101,7 @@ vec3 get_region_uv2(const vec2 uv2) {
 	ivec2 pos = ivec2(floor(uv2 - vec2(_region_texel_size * 0.5))) + (_region_map_size / 2);
 	int bounds = int(uint(pos.x | pos.y) < uint(_region_map_size));
 	int layer_index = _region_map[ pos.y * _region_map_size + pos.x ] * bounds - 1;
-	return vec3(uv2 - _region_offsets[layer_index], float(layer_index));
+	return vec3(uv2 - _region_locations[layer_index], float(layer_index));
 }
 
 //INSERT: WORLD_NOISE1
@@ -261,7 +261,7 @@ void get_material(vec2 base_uv, uint control, ivec3 iuv_center, vec3 normal, out
 //INSERT: TEXTURE_ID	
 	// Control map scale & rotation, apply to both base and 
 	// uv_center. Translate uv center to the current region.
-	uv_center += _region_offsets[region] * _region_size;
+	uv_center += _region_locations[region] * _region_size;
 	// Define base scale from control map value as array index. 0.5 as baseline.
 	float[8] scale_array = { 0.5, 0.4, 0.3, 0.2, 0.1, 0.8, 0.7, 0.6};
 	float control_scale = scale_array[(control >>7u & 0x7u)];

--- a/src/terrain_3d.cpp
+++ b/src/terrain_3d.cpp
@@ -61,7 +61,7 @@ void Terrain3D::_initialize() {
 		LOG(DEBUG, "Connecting region_size_changed signal to _material->_update_regions()");
 		_storage->connect("region_size_changed", callable_mp(_material.ptr(), &Terrain3DMaterial::_update_regions));
 	}
-	// Any map was regenerated or region offsets changed, update material
+	// Any map was regenerated or region locations changed, update material
 	if (!_storage->is_connected("regions_changed", callable_mp(_material.ptr(), &Terrain3DMaterial::_update_regions))) {
 		LOG(DEBUG, "Connecting _storage::regions_changed signal to _material->_update_regions()");
 		_storage->connect("regions_changed", callable_mp(_material.ptr(), &Terrain3DMaterial::_update_regions));
@@ -409,27 +409,27 @@ void Terrain3D::_update_collision() {
 		PackedRealArray map_data = PackedRealArray();
 		map_data.resize(shape_size * shape_size);
 
-		Vector2i global_offset = Vector2i(_storage->get_region_offsets()[i]) * region_size;
-		Vector3 global_pos = Vector3(global_offset.x, 0.f, global_offset.y);
+		Vector2i global_loc = Vector2i(_storage->get_region_locations()[i]) * region_size;
+		Vector3 global_pos = Vector3(global_loc.x, 0.f, global_loc.y);
 
 		Ref<Image> map, map_x, map_z, map_xz;
 		Ref<Image> cmap, cmap_x, cmap_z, cmap_xz;
 		map = _storage->get_map_region(Terrain3DStorage::TYPE_HEIGHT, i);
 		cmap = _storage->get_map_region(Terrain3DStorage::TYPE_CONTROL, i);
-		int region = _storage->get_region_index(Vector3(global_pos.x + region_size, 0.f, global_pos.z) * _mesh_vertex_spacing);
-		if (region >= 0) {
-			map_x = _storage->get_map_region(Terrain3DStorage::TYPE_HEIGHT, region);
-			cmap_x = _storage->get_map_region(Terrain3DStorage::TYPE_CONTROL, region);
+		int region_id = _storage->get_region_id(Vector3(global_pos.x + region_size, 0.f, global_pos.z) * _mesh_vertex_spacing);
+		if (region_id >= 0) {
+			map_x = _storage->get_map_region(Terrain3DStorage::TYPE_HEIGHT, region_id);
+			cmap_x = _storage->get_map_region(Terrain3DStorage::TYPE_CONTROL, region_id);
 		}
-		region = _storage->get_region_index(Vector3(global_pos.x, 0.f, global_pos.z + region_size) * _mesh_vertex_spacing);
-		if (region >= 0) {
-			map_z = _storage->get_map_region(Terrain3DStorage::TYPE_HEIGHT, region);
-			cmap_z = _storage->get_map_region(Terrain3DStorage::TYPE_CONTROL, region);
+		region_id = _storage->get_region_id(Vector3(global_pos.x, 0.f, global_pos.z + region_size) * _mesh_vertex_spacing);
+		if (region_id >= 0) {
+			map_z = _storage->get_map_region(Terrain3DStorage::TYPE_HEIGHT, region_id);
+			cmap_z = _storage->get_map_region(Terrain3DStorage::TYPE_CONTROL, region_id);
 		}
-		region = _storage->get_region_index(Vector3(global_pos.x + region_size, 0.f, global_pos.z + region_size) * _mesh_vertex_spacing);
-		if (region >= 0) {
-			map_xz = _storage->get_map_region(Terrain3DStorage::TYPE_HEIGHT, region);
-			cmap_xz = _storage->get_map_region(Terrain3DStorage::TYPE_CONTROL, region);
+		region_id = _storage->get_region_id(Vector3(global_pos.x + region_size, 0.f, global_pos.z + region_size) * _mesh_vertex_spacing);
+		if (region_id >= 0) {
+			map_xz = _storage->get_map_region(Terrain3DStorage::TYPE_HEIGHT, region_id);
+			cmap_xz = _storage->get_map_region(Terrain3DStorage::TYPE_CONTROL, region_id);
 		}
 
 		for (int z = 0; z < shape_size; z++) {
@@ -547,12 +547,12 @@ void Terrain3D::_generate_triangles(PackedVector3Array &p_vertices, PackedVector
 	if (!p_global_aabb.has_volume()) {
 		int32_t region_size = (int)_storage->get_region_size();
 
-		TypedArray<Vector2i> region_offsets = _storage->get_region_offsets();
-		for (int r = 0; r < region_offsets.size(); ++r) {
-			Vector2i region_offset = (Vector2i)region_offsets[r] * region_size;
+		TypedArray<Vector2i> region_locations = _storage->get_region_locations();
+		for (int r = 0; r < region_locations.size(); ++r) {
+			Vector2i region_loc = (Vector2i)region_locations[r] * region_size;
 
-			for (int32_t z = region_offset.y; z < region_offset.y + region_size; z += step) {
-				for (int32_t x = region_offset.x; x < region_offset.x + region_size; x += step) {
+			for (int32_t z = region_loc.y; z < region_loc.y + region_size; z += step) {
+				for (int32_t x = region_loc.x; x < region_loc.x + region_size; x += step) {
 					_generate_triangle_pair(p_vertices, p_uvs, p_lod, p_filter, p_require_nav, x, z);
 				}
 			}

--- a/src/terrain_3d.cpp
+++ b/src/terrain_3d.cpp
@@ -414,22 +414,22 @@ void Terrain3D::_update_collision() {
 
 		Ref<Image> map, map_x, map_z, map_xz;
 		Ref<Image> cmap, cmap_x, cmap_z, cmap_xz;
-		map = _storage->get_map_region(Terrain3DStorage::TYPE_HEIGHT, i);
-		cmap = _storage->get_map_region(Terrain3DStorage::TYPE_CONTROL, i);
+		map = _storage->get_map_region(TYPE_HEIGHT, i);
+		cmap = _storage->get_map_region(TYPE_CONTROL, i);
 		int region_id = _storage->get_region_id(Vector3(global_pos.x + region_size, 0.f, global_pos.z) * _mesh_vertex_spacing);
 		if (region_id >= 0) {
-			map_x = _storage->get_map_region(Terrain3DStorage::TYPE_HEIGHT, region_id);
-			cmap_x = _storage->get_map_region(Terrain3DStorage::TYPE_CONTROL, region_id);
+			map_x = _storage->get_map_region(TYPE_HEIGHT, region_id);
+			cmap_x = _storage->get_map_region(TYPE_CONTROL, region_id);
 		}
 		region_id = _storage->get_region_id(Vector3(global_pos.x, 0.f, global_pos.z + region_size) * _mesh_vertex_spacing);
 		if (region_id >= 0) {
-			map_z = _storage->get_map_region(Terrain3DStorage::TYPE_HEIGHT, region_id);
-			cmap_z = _storage->get_map_region(Terrain3DStorage::TYPE_CONTROL, region_id);
+			map_z = _storage->get_map_region(TYPE_HEIGHT, region_id);
+			cmap_z = _storage->get_map_region(TYPE_CONTROL, region_id);
 		}
 		region_id = _storage->get_region_id(Vector3(global_pos.x + region_size, 0.f, global_pos.z + region_size) * _mesh_vertex_spacing);
 		if (region_id >= 0) {
-			map_xz = _storage->get_map_region(Terrain3DStorage::TYPE_HEIGHT, region_id);
-			cmap_xz = _storage->get_map_region(Terrain3DStorage::TYPE_CONTROL, region_id);
+			map_xz = _storage->get_map_region(TYPE_HEIGHT, region_id);
+			cmap_xz = _storage->get_map_region(TYPE_CONTROL, region_id);
 		}
 
 		for (int z = 0; z < shape_size; z++) {

--- a/src/terrain_3d.cpp
+++ b/src/terrain_3d.cpp
@@ -51,25 +51,25 @@ void Terrain3D::_initialize() {
 	}
 
 	// Connect signals
-	// Texture assets changed, update material
-	if (!_assets->is_connected("textures_changed", callable_mp(_material.ptr(), &Terrain3DMaterial::_update_texture_arrays))) {
-		LOG(DEBUG, "Connecting _assets.textures_changed to _material->_update_texture_arrays()");
-		_assets->connect("textures_changed", callable_mp(_material.ptr(), &Terrain3DMaterial::_update_texture_arrays));
-	}
 	// Region size changed, update material
-	if (!_storage->is_connected("region_size_changed", callable_mp(_material.ptr(), &Terrain3DMaterial::_update_regions))) {
+	if (!_storage->is_connected("region_size_changed", callable_mp(_material.ptr(), &Terrain3DMaterial::_update_maps))) {
 		LOG(DEBUG, "Connecting region_size_changed signal to _material->_update_regions()");
-		_storage->connect("region_size_changed", callable_mp(_material.ptr(), &Terrain3DMaterial::_update_regions));
+		_storage->connect("region_size_changed", callable_mp(_material.ptr(), &Terrain3DMaterial::_update_maps));
 	}
-	// Any map was regenerated or region locations changed, update material
-	if (!_storage->is_connected("regions_changed", callable_mp(_material.ptr(), &Terrain3DMaterial::_update_regions))) {
-		LOG(DEBUG, "Connecting _storage::regions_changed signal to _material->_update_regions()");
-		_storage->connect("regions_changed", callable_mp(_material.ptr(), &Terrain3DMaterial::_update_regions));
+	// Any map was regenerated or regions changed, update material
+	if (!_storage->is_connected("maps_changed", callable_mp(_material.ptr(), &Terrain3DMaterial::_update_maps))) {
+		LOG(DEBUG, "Connecting _storage::maps_changed signal to _material->_update_maps()");
+		_storage->connect("maps_changed", callable_mp(_material.ptr(), &Terrain3DMaterial::_update_maps));
 	}
 	// Height map was regenerated - update aabbs - Probably remove and just use maps_edited
 	if (!_storage->is_connected("height_maps_changed", callable_mp(this, &Terrain3D::update_aabbs))) {
 		LOG(DEBUG, "Connecting _storage::height_maps_changed signal to update_aabbs()");
 		_storage->connect("height_maps_changed", callable_mp(this, &Terrain3D::update_aabbs));
+	}
+	// Texture assets changed, update material
+	if (!_assets->is_connected("textures_changed", callable_mp(_material.ptr(), &Terrain3DMaterial::_update_texture_arrays))) {
+		LOG(DEBUG, "Connecting _assets.textures_changed to _material->_update_texture_arrays()");
+		_assets->connect("textures_changed", callable_mp(_material.ptr(), &Terrain3DMaterial::_update_texture_arrays));
 	}
 	// MeshAssets changed, update instancer
 	if (!_assets->is_connected("meshes_changed", callable_mp(_instancer, &Terrain3DInstancer::_update_mmis).bind(Vector2i(INT32_MAX, INT32_MAX), -1))) {

--- a/src/terrain_3d_editor.cpp
+++ b/src/terrain_3d_editor.cpp
@@ -13,11 +13,11 @@
 ///////////////////////////
 
 void Terrain3DEditor::_region_modified(const Vector3 &p_global_position, const Vector2 &p_height_range) {
-	Vector2i region_offset = _terrain->get_storage()->get_region_offset(p_global_position);
+	Vector2i region_loc = _terrain->get_storage()->get_region_location(p_global_position);
 	Terrain3DStorage::RegionSize region_size = _terrain->get_storage()->get_region_size();
 
 	AABB edited_area;
-	edited_area.position = Vector3(region_offset.x * region_size, p_height_range.x, region_offset.y * region_size);
+	edited_area.position = Vector3(region_loc.x * region_size, p_height_range.x, region_loc.y * region_size);
 	edited_area.size = Vector3(region_size, p_height_range.y - p_height_range.x, region_size);
 	edited_area.position *= _terrain->get_mesh_vertex_spacing();
 	edited_area.size *= _terrain->get_mesh_vertex_spacing();
@@ -38,8 +38,8 @@ void Terrain3DEditor::_operate_region(const Vector3 &p_global_position) {
 		}
 	} else {
 		if (has_region) {
-			int region_index = _terrain->get_storage()->get_region_index(p_global_position);
-			Ref<Image> height_map = _terrain->get_storage()->get_map_region(Terrain3DStorage::TYPE_HEIGHT, region_index);
+			int region_id = _terrain->get_storage()->get_region_id(p_global_position);
+			Ref<Image> height_map = _terrain->get_storage()->get_map_region(Terrain3DStorage::TYPE_HEIGHT, region_id);
 			height_range = Util::get_min_max(height_map);
 
 			_terrain->get_storage()->remove_region(p_global_position);
@@ -57,16 +57,16 @@ void Terrain3DEditor::_operate_map(const Vector3 &p_global_position, const real_
 	Ref<Terrain3DStorage> storage = _terrain->get_storage();
 	int region_size = storage->get_region_size();
 	Vector2i region_vsize = Vector2i(region_size, region_size);
-	int region_index = storage->get_region_index(p_global_position);
-	if (region_index == -1) {
+	int region_id = storage->get_region_id(p_global_position);
+	if (region_id == -1) {
 		if (!_brush_data["auto_regions"] || _tool != HEIGHT) {
 			return;
 		} else {
 			LOG(DEBUG, "No region to operate on, attempting to add");
 			storage->add_region(p_global_position);
 			region_size = storage->get_region_size();
-			region_index = storage->get_region_index(p_global_position);
-			if (region_index == -1) {
+			region_id = storage->get_region_id(p_global_position);
+			if (region_id == -1) {
 				LOG(ERROR, "Failed to add region, no region to operate on");
 				return;
 			}
@@ -163,7 +163,7 @@ void Terrain3DEditor::_operate_map(const Vector3 &p_global_position, const real_
 	}
 
 	// MAP Operations
-	Ref<Image> map = storage->get_map_region(map_type, region_index);
+	Ref<Image> map = storage->get_map_region(map_type, region_id);
 	real_t vertex_spacing = _terrain->get_mesh_vertex_spacing();
 	for (real_t x = 0.f; x < brush_size; x += vertex_spacing) {
 		for (real_t y = 0.f; y < brush_size; y += vertex_spacing) {
@@ -173,8 +173,8 @@ void Terrain3DEditor::_operate_map(const Vector3 &p_global_position, const real_
 							p_global_position.z + brush_offset.y + .5f);
 
 			// If we're brushing across a region boundary, possibly add a region, and get the other map
-			int new_region_index = storage->get_region_index(brush_global_position);
-			if (new_region_index == -1) {
+			int new_region_id = storage->get_region_id(brush_global_position);
+			if (new_region_id == -1) {
 				if (!_brush_data["auto_regions"] || _tool != HEIGHT) {
 					continue;
 				}
@@ -182,13 +182,13 @@ void Terrain3DEditor::_operate_map(const Vector3 &p_global_position, const real_
 				if (err) {
 					continue;
 				}
-				new_region_index = storage->get_region_index(brush_global_position);
+				new_region_id = storage->get_region_id(brush_global_position);
 				_region_modified(brush_global_position);
 			}
 
-			if (new_region_index != region_index) {
-				region_index = new_region_index;
-				map = storage->get_map_region(map_type, region_index);
+			if (new_region_id != region_id) {
+				region_id = new_region_id;
+				map = storage->get_map_region(map_type, region_id);
 			}
 
 			// Identify position on map image
@@ -463,8 +463,8 @@ Dictionary Terrain3DEditor::_get_undo_data() const {
 	}
 	switch (_tool) {
 		case REGION:
-			LOG(DEBUG, "Storing region offsets");
-			data["region_offsets"] = _terrain->get_storage()->get_region_offsets().duplicate();
+			LOG(DEBUG, "Storing region locations");
+			data["region_locations"] = _terrain->get_storage()->get_region_locations().duplicate();
 			if (_operation == SUBTRACT) {
 				data["height_map"] = _terrain->get_storage()->get_maps_copy(Terrain3DStorage::TYPE_HEIGHT);
 				data["control_map"] = _terrain->get_storage()->get_maps_copy(Terrain3DStorage::TYPE_CONTROL);
@@ -476,7 +476,7 @@ Dictionary Terrain3DEditor::_get_undo_data() const {
 
 		case HEIGHT:
 			LOG(DEBUG, "Storing height maps and range");
-			data["region_offsets"] = _terrain->get_storage()->get_region_offsets().duplicate();
+			data["region_locations"] = _terrain->get_storage()->get_region_locations().duplicate();
 			data["height_map"] = _terrain->get_storage()->get_maps_copy(Terrain3DStorage::TYPE_HEIGHT);
 			data["height_range"] = _terrain->get_storage()->get_height_range();
 			data["edited_area"] = _terrain->get_storage()->get_edited_area();
@@ -549,7 +549,7 @@ void Terrain3DEditor::_apply_undo(const Dictionary &p_set) {
 	for (int i = 0; i < keys.size(); i++) {
 		String key = keys[i];
 		if (key == "region_offsets") {
-			_terrain->get_storage()->set_region_offsets(p_set[key]);
+			_terrain->get_storage()->set_region_locations(p_set[key]);
 		} else if (key == "height_map") {
 			_terrain->get_storage()->set_maps(Terrain3DStorage::TYPE_HEIGHT, p_set[key]);
 		} else if (key == "control_map") {

--- a/src/terrain_3d_editor.cpp
+++ b/src/terrain_3d_editor.cpp
@@ -39,7 +39,7 @@ void Terrain3DEditor::_operate_region(const Vector3 &p_global_position) {
 	} else {
 		if (has_region) {
 			int region_id = _terrain->get_storage()->get_region_id(p_global_position);
-			Ref<Image> height_map = _terrain->get_storage()->get_map_region(Terrain3DStorage::TYPE_HEIGHT, region_id);
+			Ref<Image> height_map = _terrain->get_storage()->get_map_region(TYPE_HEIGHT, region_id);
 			height_range = Util::get_min_max(height_map);
 
 			_terrain->get_storage()->remove_region(p_global_position);
@@ -74,11 +74,11 @@ void Terrain3DEditor::_operate_map(const Vector3 &p_global_position, const real_
 		}
 	}
 
-	Terrain3DStorage::MapType map_type;
+	MapType map_type;
 	switch (_tool) {
 		case HEIGHT:
 		case INSTANCER:
-			map_type = Terrain3DStorage::TYPE_HEIGHT;
+			map_type = TYPE_HEIGHT;
 			break;
 		case TEXTURE:
 		case AUTOSHADER:
@@ -86,11 +86,11 @@ void Terrain3DEditor::_operate_map(const Vector3 &p_global_position, const real_
 		case NAVIGATION:
 		case ANGLE:
 		case SCALE:
-			map_type = Terrain3DStorage::TYPE_CONTROL;
+			map_type = TYPE_CONTROL;
 			break;
 		case COLOR:
 		case ROUGHNESS:
-			map_type = Terrain3DStorage::TYPE_COLOR;
+			map_type = TYPE_COLOR;
 			break;
 		default:
 			LOG(ERROR, "Invalid tool selected");
@@ -213,7 +213,7 @@ void Terrain3DEditor::_operate_map(const Vector3 &p_global_position, const real_
 				Color src = map->get_pixelv(map_pixel_position);
 				Color dest = src;
 
-				if (map_type == Terrain3DStorage::TYPE_HEIGHT) {
+				if (map_type == TYPE_HEIGHT) {
 					real_t srcf = src.r;
 					real_t destf = dest.r;
 
@@ -300,7 +300,7 @@ void Terrain3DEditor::_operate_map(const Vector3 &p_global_position, const real_
 					edited_position.y = destf;
 					edited_area = edited_area.expand(edited_position);
 
-				} else if (map_type == Terrain3DStorage::TYPE_CONTROL) {
+				} else if (map_type == TYPE_CONTROL) {
 					// Get bit field from pixel
 					uint32_t base_id = get_base(src.r);
 					uint32_t overlay_id = get_overlay(src.r);
@@ -424,7 +424,7 @@ void Terrain3DEditor::_operate_map(const Vector3 &p_global_position, const real_
 					// Write back to pixel in FORMAT_RF. Must be a 32-bit float
 					dest = Color(as_float(bits), 0.f, 0.f, 1.f);
 
-				} else if (map_type == Terrain3DStorage::TYPE_COLOR) {
+				} else if (map_type == TYPE_COLOR) {
 					switch (_tool) {
 						case COLOR:
 							dest = src.lerp((_operation == ADD) ? color : COLOR_WHITE, brush_alpha * strength);
@@ -466,9 +466,9 @@ Dictionary Terrain3DEditor::_get_undo_data() const {
 			LOG(DEBUG, "Storing region locations");
 			data["region_locations"] = _terrain->get_storage()->get_region_locations().duplicate();
 			if (_operation == SUBTRACT) {
-				data["height_map"] = _terrain->get_storage()->get_maps_copy(Terrain3DStorage::TYPE_HEIGHT);
-				data["control_map"] = _terrain->get_storage()->get_maps_copy(Terrain3DStorage::TYPE_CONTROL);
-				data["color_map"] = _terrain->get_storage()->get_maps_copy(Terrain3DStorage::TYPE_COLOR);
+				data["height_map"] = _terrain->get_storage()->get_maps_copy(TYPE_HEIGHT);
+				data["control_map"] = _terrain->get_storage()->get_maps_copy(TYPE_CONTROL);
+				data["color_map"] = _terrain->get_storage()->get_maps_copy(TYPE_COLOR);
 				data["height_range"] = _terrain->get_storage()->get_height_range();
 				data["edited_area"] = _terrain->get_storage()->get_edited_area();
 			}
@@ -477,7 +477,7 @@ Dictionary Terrain3DEditor::_get_undo_data() const {
 		case HEIGHT:
 			LOG(DEBUG, "Storing height maps and range");
 			data["region_locations"] = _terrain->get_storage()->get_region_locations().duplicate();
-			data["height_map"] = _terrain->get_storage()->get_maps_copy(Terrain3DStorage::TYPE_HEIGHT);
+			data["height_map"] = _terrain->get_storage()->get_maps_copy(TYPE_HEIGHT);
 			data["height_range"] = _terrain->get_storage()->get_height_range();
 			data["edited_area"] = _terrain->get_storage()->get_edited_area();
 			break;
@@ -490,13 +490,13 @@ Dictionary Terrain3DEditor::_get_undo_data() const {
 		case AUTOSHADER:
 		case NAVIGATION:
 			LOG(DEBUG, "Storing control maps");
-			data["control_map"] = _terrain->get_storage()->get_maps_copy(Terrain3DStorage::TYPE_CONTROL);
+			data["control_map"] = _terrain->get_storage()->get_maps_copy(TYPE_CONTROL);
 			break;
 
 		case COLOR:
 		case ROUGHNESS:
 			LOG(DEBUG, "Storing color maps");
-			data["color_map"] = _terrain->get_storage()->get_maps_copy(Terrain3DStorage::TYPE_COLOR);
+			data["color_map"] = _terrain->get_storage()->get_maps_copy(TYPE_COLOR);
 			break;
 
 		case INSTANCER:
@@ -551,11 +551,11 @@ void Terrain3DEditor::_apply_undo(const Dictionary &p_set) {
 		if (key == "region_offsets") {
 			_terrain->get_storage()->set_region_locations(p_set[key]);
 		} else if (key == "height_map") {
-			_terrain->get_storage()->set_maps(Terrain3DStorage::TYPE_HEIGHT, p_set[key]);
+			_terrain->get_storage()->set_maps(TYPE_HEIGHT, p_set[key]);
 		} else if (key == "control_map") {
-			_terrain->get_storage()->set_maps(Terrain3DStorage::TYPE_CONTROL, p_set[key]);
+			_terrain->get_storage()->set_maps(TYPE_CONTROL, p_set[key]);
 		} else if (key == "color_map") {
-			_terrain->get_storage()->set_maps(Terrain3DStorage::TYPE_COLOR, p_set[key]);
+			_terrain->get_storage()->set_maps(TYPE_COLOR, p_set[key]);
 		} else if (key == "height_range") {
 			_terrain->get_storage()->set_height_range(p_set[key]);
 		} else if (key == "edited_area") {

--- a/src/terrain_3d_instancer.h
+++ b/src/terrain_3d_instancer.h
@@ -21,18 +21,18 @@ class Terrain3DInstancer : public Object {
 	Terrain3D *_terrain = nullptr;
 
 	// MM Resources stored in Terrain3DStorage::_multimeshes as
-	// Dictionary[region_offset:Vector2i] -> Dictionary[mesh_id:int] -> MultiMesh
+	// Dictionary[region_location:Vector2i] -> Dictionary[mesh_id:int] -> MultiMesh
 	// MMI Objects attached to tree, freed in destructor, stored as
-	// Dictionary[Vector3i(region_offset.x, region_offset.y, mesh_id)] -> MultiMeshInstance3D
+	// Dictionary[Vector3i(region_location.x, region_location.y, mesh_id)] -> MultiMeshInstance3D
 	Dictionary _mmis;
 
 	uint32_t _instance_counter = 0;
 	int _get_instace_count(const real_t p_density);
 
 	void _rebuild_mmis();
-	void _update_mmis(const Vector2i &p_region_offset = Vector2i(INT32_MAX, INT32_MAX), const int p_mesh_id = -1);
+	void _update_mmis(const Vector2i &p_region_loc = Vector2i(INT32_MAX, INT32_MAX), const int p_mesh_id = -1);
 	void _destroy_mmi_by_region_id(const int p_region, const int p_mesh_id);
-	void _destroy_mmi_by_offset(const Vector2i &p_region_offset, const int p_mesh_id);
+	void _destroy_mmi_by_location(const Vector2i &p_region_loc, const int p_mesh_id);
 
 public:
 	Terrain3DInstancer() {}
@@ -42,20 +42,20 @@ public:
 	void destroy();
 	void clear_by_mesh(const int p_mesh_id);
 	void clear_by_region_id(const int p_region_id, const int p_mesh_id);
-	void clear_by_offset(const Vector2i &p_region_offset, const int p_mesh_id);
+	void clear_by_location(const Vector2i &p_region_loc, const int p_mesh_id);
 
 	void add_instances(const Vector3 &p_global_position, const Dictionary &p_params);
 	void remove_instances(const Vector3 &p_global_position, const Dictionary &p_params);
 	void add_multimesh(const int p_mesh_id, const Ref<MultiMesh> &p_multimesh, const Transform3D &p_xform = Transform3D());
 	void add_transforms(const int p_mesh_id, const TypedArray<Transform3D> &p_xforms, const TypedArray<Color> &p_colors = TypedArray<Color>());
-	void append_multimesh(const Vector2i &p_region_offset, const int p_mesh_id, const TypedArray<Transform3D> &p_xforms, const TypedArray<Color> &p_colors, const bool p_clear = false);
+	void append_multimesh(const Vector2i &p_region_loc, const int p_mesh_id, const TypedArray<Transform3D> &p_xforms, const TypedArray<Color> &p_colors, const bool p_clear = false);
 	void update_transforms(const AABB &p_aabb);
 
 	void swap_ids(const int p_src_id, const int p_dst_id);
 	Ref<MultiMesh> get_multimesh(const Vector3 &p_global_position, const int p_mesh_id) const;
-	Ref<MultiMesh> get_multimesh(const Vector2i &p_region_offset, const int p_mesh_id) const;
+	Ref<MultiMesh> get_multimesh(const Vector2i &p_region_loc, const int p_mesh_id) const;
 	MultiMeshInstance3D *get_multimesh_instance(const Vector3 &p_global_position, const int p_mesh_id) const;
-	MultiMeshInstance3D *get_multimesh_instance(const Vector2i &p_region_offset, const int p_mesh_id) const;
+	MultiMeshInstance3D *get_multimesh_instance(const Vector2i &p_region_loc, const int p_mesh_id) const;
 	Dictionary get_mmis() const { return _mmis; }
 	void set_cast_shadows(const int p_mesh_id, const GeometryInstance3D::ShadowCastingSetting p_cast_shadows);
 	void reset_instance_counter() { _instance_counter = 0; }

--- a/src/terrain_3d_material.cpp
+++ b/src/terrain_3d_material.cpp
@@ -294,9 +294,9 @@ void Terrain3DMaterial::_update_shader() {
 	notify_property_list_changed();
 }
 
-void Terrain3DMaterial::_update_regions() {
+void Terrain3DMaterial::_update_maps() {
 	IS_STORAGE_INIT(VOID);
-	LOG(DEBUG_CONT, "Updating region maps in shader");
+	LOG(DEBUG_CONT, "Updating maps in shader");
 
 	Ref<Terrain3DStorage> storage = _terrain->get_storage();
 	RS->material_set_param(_material, "_height_maps", storage->get_height_maps_rid());
@@ -389,7 +389,7 @@ void Terrain3DMaterial::initialize(Terrain3D *p_terrain) {
 	_material = RS->material_create();
 	_shader.instantiate();
 	_update_shader();
-	_update_regions();
+	_update_maps();
 }
 
 Terrain3DMaterial::~Terrain3DMaterial() {
@@ -400,7 +400,7 @@ Terrain3DMaterial::~Terrain3DMaterial() {
 
 void Terrain3DMaterial::update() {
 	_update_shader();
-	_update_regions();
+	_update_maps();
 }
 
 void Terrain3DMaterial::set_world_background(const WorldBackground p_background) {

--- a/src/terrain_3d_material.cpp
+++ b/src/terrain_3d_material.cpp
@@ -322,9 +322,9 @@ void Terrain3DMaterial::_update_regions() {
 		}
 	}
 
-	TypedArray<Vector2i> region_offsets = storage->get_region_offsets();
-	LOG(DEBUG_CONT, "Region_offsets size: ", region_offsets.size(), " ", region_offsets);
-	RS->material_set_param(_material, "_region_offsets", region_offsets);
+	TypedArray<Vector2i> region_locations = storage->get_region_locations();
+	LOG(DEBUG_CONT, "Region_locations size: ", region_locations.size(), " ", region_locations);
+	RS->material_set_param(_material, "_region_locations", region_locations);
 
 	real_t region_size = real_t(storage->get_region_size());
 	LOG(DEBUG_CONT, "Setting region size in material: ", region_size);

--- a/src/terrain_3d_material.h
+++ b/src/terrain_3d_material.h
@@ -72,7 +72,7 @@ private:
 	String _generate_shader_code() const;
 	String _inject_editor_code(const String &p_shader) const;
 	void _update_shader();
-	void _update_regions();
+	void _update_maps();
 	void _update_texture_arrays();
 	void _set_shader_parameters(const Dictionary &p_dict);
 	Dictionary _get_shader_parameters() const { return _shader_params; }

--- a/src/terrain_3d_storage.cpp
+++ b/src/terrain_3d_storage.cpp
@@ -690,7 +690,7 @@ void Terrain3DStorage::save() {
 		if (_save_16_bit) {
 			LOG(DEBUG, "16-bit save requested, converting heightmaps");
 			TypedArray<Image> original_maps;
-			original_maps = get_maps_copy(Terrain3DStorage::MapType::TYPE_HEIGHT);
+			original_maps = get_maps_copy(TYPE_HEIGHT);
 			for (int i = 0; i < _height_maps.size(); i++) {
 				Ref<Image> img = _height_maps[i];
 				img->convert(Image::FORMAT_RH);

--- a/src/terrain_3d_storage.h
+++ b/src/terrain_3d_storage.h
@@ -197,7 +197,12 @@ protected:
 	static void _bind_methods();
 };
 
+typedef Terrain3DStorage::MapType MapType;
 VARIANT_ENUM_CAST(Terrain3DStorage::MapType);
+constexpr Terrain3DStorage::MapType TYPE_HEIGHT = Terrain3DStorage::MapType::TYPE_HEIGHT;
+constexpr Terrain3DStorage::MapType TYPE_CONTROL = Terrain3DStorage::MapType::TYPE_CONTROL;
+constexpr Terrain3DStorage::MapType TYPE_COLOR = Terrain3DStorage::MapType::TYPE_COLOR;
+constexpr Terrain3DStorage::MapType TYPE_MAX = Terrain3DStorage::MapType::TYPE_MAX;
 VARIANT_ENUM_CAST(Terrain3DStorage::RegionSize);
 VARIANT_ENUM_CAST(Terrain3DStorage::HeightFilter);
 

--- a/src/terrain_3d_storage.h
+++ b/src/terrain_3d_storage.h
@@ -142,7 +142,7 @@ public:
 	bool has_region(const Vector3 &p_global_position) const { return get_region_id(p_global_position) != -1; }
 	Error add_region(const Vector3 &p_global_position, const TypedArray<Image> &p_images = TypedArray<Image>(), const bool p_update = true);
 	void remove_region(const Vector3 &p_global_position, const bool p_update = true);
-	void update_regions(const bool p_force_emit = false);
+	void update_maps();
 
 	// Maps
 	void set_map_region(const MapType p_map_type, const int p_region_id, const Ref<Image> &p_image);

--- a/src/terrain_3d_util.cpp
+++ b/src/terrain_3d_util.cpp
@@ -233,7 +233,7 @@ Ref<Image> Terrain3DUtil::load_image(const String &p_file_name, const int p_cach
 			LOG(DEBUG, "Total file size is: ", fsize, " calculated width: ", fwidth, " dimensions: ", r16_size);
 			file->seek(0);
 		}
-		img = Image::create(r16_size.x, r16_size.y, false, Terrain3DStorage::FORMAT[Terrain3DStorage::TYPE_HEIGHT]);
+		img = Image::create(r16_size.x, r16_size.y, false, Terrain3DStorage::FORMAT[TYPE_HEIGHT]);
 		for (int y = 0; y < r16_size.y; y++) {
 			for (int x = 0; x < r16_size.x; x++) {
 				real_t h = real_t(file->get_16()) / 65535.0f;


### PR DESCRIPTION
API Changes to existing functions (from main):

**Breaking change:** This PR currently breaks user scenes as region_offsets aren't converted to region_locations. It is a precursor to #374 which will have upgrade code.

### Functions
|Old Name| New Name|
|--|--|
|**Terrain3DStorage**
|`set/get_region_offsets` | `set/get_region_locations`
|`get_region_offset` | `get_region_location`
|`get_region_offset_from_index` | `get_region_location_from_id`
|`get_region_index` | `get_region_id`
|`get_region_index_from_offset` | `get_region_id_from_location`
|**Terrain3DInstancer**
|`clear_by_offset` | `clear_by_location`

### Signals
|Old Name| New Name | When emitted
|--|--|--|
|**Terrain3D**|
|`storage_changed`| - | Will be dropped in #374
|**Terrain3DStorage**
|`regions_changed` | `maps_changed` | When any map/region regenerated
| - | `region_map_changed` | When region map regenerated (new)
|`height_maps_changed` |`height_maps_changed` | when height maps are regenerated (no change)
| - | `control_maps_changed` | when control maps are regenerated (new)
| - | `color_maps_changed` | when color maps are regenerated (new)
| `maps_edited(AABB)` |`maps_edited(AABB)`| when a heightmap is modified with the AABB (no change)


