### PR TITLE
Hide the navigation layer in the editor when another node is selected

### DIFF
--- a/project/addons/terrain_3d/editor.gd
+++ b/project/addons/terrain_3d/editor.gd
@@ -91,6 +91,7 @@ func _edit(p_object: Object) -> void:
 		region_gizmo.set_node_3d(terrain)
 		terrain.add_gizmo(region_gizmo)
 		terrain.set_plugin(self)
+		terrain.set_editor(editor)
 		ui.set_visible(true)
 		
 		# Connect to new Assets resource

--- a/project/addons/terrain_3d/src/ui.gd
+++ b/project/addons/terrain_3d/src/ui.gd
@@ -49,6 +49,8 @@ var brush_data: Dictionary
 var operation_builder: OperationBuilder
 var modifier_ctrl: bool
 var modifier_alt: bool
+var stored_tool: Terrain3DEditor.Tool
+var stored_operation: Terrain3DEditor.Operation
 
 
 func _enter_tree() -> void:
@@ -96,6 +98,13 @@ func _exit_tree() -> void:
 
 
 func set_visible(p_visible: bool, p_menu_only: bool = false) -> void:
+	if(plugin.editor):
+		if(p_visible):
+			await get_tree().create_timer(.01).timeout # Won't work, otherwise.
+			_on_tool_changed(stored_tool, stored_operation)
+		else:
+			plugin.editor.set_tool(Terrain3DEditor.TOOL_MAX)
+	
 	terrain_menu.set_visible(p_visible)
 
 	if p_menu_only:
@@ -218,6 +227,8 @@ func _on_tool_changed(p_tool: Terrain3DEditor.Tool, p_operation: Terrain3DEditor
 	if plugin.editor:
 		plugin.editor.set_tool(p_tool)
 		plugin.editor.set_operation(_modify_operation(p_operation))
+		stored_tool = p_tool
+		stored_operation = p_operation
 
 	_on_setting_changed()
 	plugin.update_region_grid()

--- a/project/addons/terrain_3d/src/ui.gd
+++ b/project/addons/terrain_3d/src/ui.gd
@@ -49,8 +49,8 @@ var brush_data: Dictionary
 var operation_builder: OperationBuilder
 var modifier_ctrl: bool
 var modifier_alt: bool
-var stored_tool: Terrain3DEditor.Tool
-var stored_operation: Terrain3DEditor.Operation
+var last_tool: Terrain3DEditor.Tool
+var last_operation: Terrain3DEditor.Operation
 
 
 func _enter_tree() -> void:
@@ -101,9 +101,10 @@ func set_visible(p_visible: bool, p_menu_only: bool = false) -> void:
 	if(plugin.editor):
 		if(p_visible):
 			await get_tree().create_timer(.01).timeout # Won't work, otherwise.
-			_on_tool_changed(stored_tool, stored_operation)
+			_on_tool_changed(last_tool, last_operation)
 		else:
 			plugin.editor.set_tool(Terrain3DEditor.TOOL_MAX)
+			plugin.editor.set_operation(Terrain3DEditor.OP_MAX)
 	
 	terrain_menu.set_visible(p_visible)
 
@@ -227,8 +228,8 @@ func _on_tool_changed(p_tool: Terrain3DEditor.Tool, p_operation: Terrain3DEditor
 	if plugin.editor:
 		plugin.editor.set_tool(p_tool)
 		plugin.editor.set_operation(_modify_operation(p_operation))
-		stored_tool = p_tool
-		stored_operation = p_operation
+		last_tool = p_tool
+		last_operation = p_operation
 
 	_on_setting_changed()
 	plugin.update_region_grid()

--- a/src/constants.h
+++ b/src/constants.h
@@ -8,6 +8,7 @@ using namespace godot;
 // Constants
 
 #define RS RenderingServer::get_singleton()
+#define IS_EDITOR Engine::get_singleton()->is_editor_hint()
 
 #define COLOR_NAN Color(NAN, NAN, NAN, NAN)
 #define COLOR_BLACK Color(0.0f, 0.0f, 0.0f, 1.0f)

--- a/src/terrain_3d.cpp
+++ b/src/terrain_3d.cpp
@@ -194,7 +194,7 @@ void Terrain3D::_destroy_mouse_picking() {
  * The edited_scene_root is excluded in case the user already has a Camera3D in their scene.
  */
 void Terrain3D::_grab_camera() {
-	if (Engine::get_singleton()->is_editor_hint()) {
+	if (IS_EDITOR) {
 		_camera = EditorInterface::get_singleton()->get_editor_viewport_3d(0)->get_camera_3d();
 		LOG(DEBUG, "Grabbing the first editor viewport camera: ", _camera);
 	} else {
@@ -354,7 +354,7 @@ void Terrain3D::_build_collision() {
 		return;
 	}
 	// Create collision only in game, unless showing debug
-	if (Engine::get_singleton()->is_editor_hint() && !_show_debug_collision) {
+	if (IS_EDITOR && !_show_debug_collision) {
 		return;
 	}
 	if (_storage.is_null()) {
@@ -388,7 +388,7 @@ void Terrain3D::_update_collision() {
 		return;
 	}
 	// Create collision only in game, unless showing debug
-	if (Engine::get_singleton()->is_editor_hint() && !_show_debug_collision) {
+	if (IS_EDITOR && !_show_debug_collision) {
 		return;
 	}
 	if ((!_show_debug_collision && !_static_body.is_valid()) ||
@@ -684,7 +684,7 @@ void Terrain3D::set_mesh_vertex_spacing(const real_t p_spacing) {
 		_destroy_instancer();
 		_initialize();
 	}
-	if (Engine::get_singleton()->is_editor_hint() && _plugin != nullptr) {
+	if (IS_EDITOR && _plugin != nullptr) {
 		_plugin->call("update_region_grid");
 	}
 }
@@ -1270,6 +1270,8 @@ void Terrain3D::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("get_assets"), &Terrain3D::get_assets);
 	ClassDB::bind_method(D_METHOD("get_instancer"), &Terrain3D::get_instancer);
 
+	ClassDB::bind_method(D_METHOD("set_editor", "editor"), &Terrain3D::set_editor);
+	ClassDB::bind_method(D_METHOD("get_editor"), &Terrain3D::get_editor);
 	ClassDB::bind_method(D_METHOD("set_plugin", "plugin"), &Terrain3D::set_plugin);
 	ClassDB::bind_method(D_METHOD("get_plugin"), &Terrain3D::get_plugin);
 	ClassDB::bind_method(D_METHOD("set_camera", "camera"), &Terrain3D::set_camera);

--- a/src/terrain_3d.cpp
+++ b/src/terrain_3d.cpp
@@ -722,6 +722,11 @@ void Terrain3D::set_assets(const Ref<Terrain3DAssets> &p_assets) {
 	}
 }
 
+void Terrain3D::set_editor(Terrain3DEditor *p_editor) {
+	_editor = p_editor;
+	LOG(DEBUG, "Received Terrain3DEditor: ", p_editor);
+}
+
 void Terrain3D::set_plugin(EditorPlugin *p_plugin) {
 	_plugin = p_plugin;
 	LOG(DEBUG, "Received editor plugin: ", p_plugin);

--- a/src/terrain_3d.h
+++ b/src/terrain_3d.h
@@ -13,6 +13,7 @@
 
 #include "constants.h"
 #include "terrain_3d_assets.h"
+#include "terrain_3d_editor.h"
 #include "terrain_3d_instancer.h"
 #include "terrain_3d_material.h"
 #include "terrain_3d_storage.h"
@@ -37,6 +38,7 @@ class Terrain3D : public Node3D {
 	Ref<Terrain3DStorage> _storage;
 	Ref<Terrain3DAssets> _assets;
 	Terrain3DInstancer *_instancer = nullptr;
+	Terrain3DEditor *_editor = nullptr;
 
 	// Editor components
 	EditorPlugin *_plugin = nullptr;
@@ -127,6 +129,8 @@ public:
 	Terrain3DInstancer *get_instancer() const { return _instancer; }
 
 	// Editor components
+	void set_editor(Terrain3DEditor *p_editor);
+	Terrain3DEditor *get_editor() const { return _editor; }
 	void set_plugin(EditorPlugin *p_plugin);
 	EditorPlugin *get_plugin() const { return _plugin; }
 	void set_camera(Camera3D *p_camera);

--- a/src/terrain_3d.h
+++ b/src/terrain_3d.h
@@ -129,7 +129,7 @@ public:
 	// Editor components
 	void set_plugin(EditorPlugin *p_plugin);
 	EditorPlugin *get_plugin() const { return _plugin; }
-	void set_camera(Camera3D *p_plugin);
+	void set_camera(Camera3D *p_camera);
 	Camera3D *get_camera() const { return _camera; }
 
 	// Renderer settings

--- a/src/terrain_3d_editor.cpp
+++ b/src/terrain_3d_editor.cpp
@@ -126,6 +126,7 @@ void Terrain3DEditor::_operate_map(const Vector3 &p_global_position, const real_
 	if (_brush_data["align_to_view"]) {
 		rot += p_camera_direction;
 	}
+	// Rotate the decal to align with the brush
 	cast_to<Node>(_terrain->get_plugin()->get("ui"))->call("set_decal_rotation", rot);
 
 	AABB edited_area;

--- a/src/terrain_3d_editor.cpp
+++ b/src/terrain_3d_editor.cpp
@@ -643,7 +643,7 @@ void Terrain3DEditor::set_brush_data(const Dictionary &p_data) {
 void Terrain3DEditor::set_tool(const Tool p_tool) {
 	_tool = CLAMP(p_tool, Tool(0), TOOL_MAX);
 	if (_terrain) {
-		_terrain->get_material()->set_show_navigation(_tool == NAVIGATION);
+		_terrain->get_material()->update();
 	}
 }
 

--- a/src/terrain_3d_material.cpp
+++ b/src/terrain_3d_material.cpp
@@ -1,5 +1,6 @@
 // Copyright © 2024 Cory Petkovsek, Roope Palmroos, and Contributors.
 
+#include <godot_cpp/classes/engine.hpp>
 #include <godot_cpp/classes/fast_noise_lite.hpp>
 #include <godot_cpp/classes/gradient.hpp>
 #include <godot_cpp/classes/image_texture.hpp>
@@ -195,7 +196,7 @@ String Terrain3DMaterial::_inject_editor_code(const String &p_shader) const {
 	if (_debug_view_vertex_grid) {
 		insert_names.push_back("DEBUG_VERTEX_GRID");
 	}
-	if (_show_navigation) {
+	if (_show_navigation || (IS_EDITOR && _terrain && _terrain->get_editor() && _terrain->get_editor()->get_tool() == Terrain3DEditor::NAVIGATION)) {
 		insert_names.push_back("EDITOR_NAVIGATION");
 	}
 	for (int i = 0; i < insert_names.size(); i++) {
@@ -427,6 +428,11 @@ Terrain3DMaterial::~Terrain3DMaterial() {
 	RS->free_rid(_material);
 	RS->free_rid(_shader);
 	_generated_region_blend_map.clear();
+}
+
+void Terrain3DMaterial::update() {
+	_update_shader();
+	_update_regions();
 }
 
 RID Terrain3DMaterial::get_shader_rid() const {
@@ -759,6 +765,7 @@ void Terrain3DMaterial::_bind_methods() {
 	ADD_PROPERTY(PropertyInfo(Variant::DICTIONARY, "_shader_parameters", PROPERTY_HINT_NONE, "", PROPERTY_USAGE_STORAGE), "_set_shader_parameters", "_get_shader_parameters");
 
 	// Public
+	ClassDB::bind_method(D_METHOD("update"), &Terrain3DMaterial::update);
 	ClassDB::bind_method(D_METHOD("get_material_rid"), &Terrain3DMaterial::get_material_rid);
 	ClassDB::bind_method(D_METHOD("get_shader_rid"), &Terrain3DMaterial::get_shader_rid);
 	ClassDB::bind_method(D_METHOD("get_region_blend_map"), &Terrain3DMaterial::get_region_blend_map);

--- a/src/terrain_3d_material.h
+++ b/src/terrain_3d_material.h
@@ -85,6 +85,7 @@ public:
 	void initialize(Terrain3D *p_terrain);
 	~Terrain3DMaterial();
 
+	void update();
 	RID get_material_rid() const { return _material; }
 	RID get_shader_rid() const;
 	RID get_region_blend_map() const { return _generated_region_blend_map.get_rid(); }

--- a/src/terrain_3d_util.cpp
+++ b/src/terrain_3d_util.cpp
@@ -189,7 +189,7 @@ Ref<Image> Terrain3DUtil::get_filled_image(const Vector2i &p_size, const Color &
 			img->generate_mipmaps();
 		}
 	}
-	if (compress && Engine::get_singleton()->is_editor_hint()) {
+	if (compress && IS_EDITOR) {
 		img->compress_from_channels(compression_format, channels);
 	}
 	return img;


### PR DESCRIPTION
In the editor, the terrain would keep its purple overlay even when deselected (and all the other UI elements for the terrain were hidden). This felt unintuitive to me, because if I don't have the terrain selected, I can't draw on the navigation layer anyway, and I'm probably not trying to do so either. So after a quick discussion on Discord, I wrote up a fix for this.

The currently selected tool and operation are stored whenever they're changed, and when the UI is hidden, the tool is set to TOOL_MAX. It is restored to its previous selection when the UI is shown again.