### PR TITLE
Improve brush defaults and settings, Add SHIFT f/ smooth

### DIFF
--- a/project/addons/terrain_3d/editor.gd
+++ b/project/addons/terrain_3d/editor.gd
@@ -130,7 +130,8 @@ func _forward_3d_gui_input(p_viewport_camera: Camera3D, p_event: InputEvent) -> 
 	if not is_terrain_valid():
 		return AFTER_GUI_INPUT_PASS
 	
-	ui.update_modifiers()
+	if p_event is InputEventKey:
+		ui.update_modifiers()
 	
 	## Handle mouse movement
 	if p_event is InputEventMouseMotion:

--- a/project/addons/terrain_3d/src/tool_settings.gd
+++ b/project/addons/terrain_3d/src/tool_settings.gd
@@ -57,10 +57,10 @@ func _ready() -> void:
 	add_setting({ "name":"instructions", "label":"Click the terrain to add a region. CTRL+Click to remove. Or select another tool on the left.",
 		"type":SettingType.LABEL, "list":main_list, "flags":NO_LABEL })
 
-	add_setting({ "name":"size", "type":SettingType.SLIDER, "list":main_list, "default":50, "unit":"m",
+	add_setting({ "name":"size", "type":SettingType.SLIDER, "list":main_list, "default":20, "unit":"m",
 								"range":Vector3(2, 200, 1), "flags":ALLOW_LARGER|ADD_SPACER })
 		
-	add_setting({ "name":"strength", "type":SettingType.SLIDER, "list":main_list, "default":10, 
+	add_setting({ "name":"strength", "type":SettingType.SLIDER, "list":main_list, "default":33, 
 								"unit":"%", "range":Vector3(1, 100, 1), "flags":ALLOW_LARGER })
 
 	add_setting({ "name":"lift_floor", "type":SettingType.CHECKBOX, "list":main_list,
@@ -68,7 +68,7 @@ func _ready() -> void:
 	add_setting({ "name":"flatten_peaks", "type":SettingType.CHECKBOX, "list":main_list,
 								"default":false })
 
-	add_setting({ "name":"height", "type":SettingType.SLIDER, "list":main_list, "default":50, 
+	add_setting({ "name":"height", "type":SettingType.SLIDER, "list":main_list, "default":20, 
 								"unit":"m", "range":Vector3(-500, 500, 0.1), "flags":ALLOW_OUT_OF_BOUNDS })
 	add_setting({ "name":"height_picker", "type":SettingType.PICKER, "list":main_list, 
 								"default":Terrain3DEditor.HEIGHT, "flags":NO_LABEL })
@@ -78,7 +78,7 @@ func _ready() -> void:
 	add_setting({ "name":"color_picker", "type":SettingType.PICKER, "list":main_list, 
 								"default":Terrain3DEditor.COLOR, "flags":NO_LABEL })
 
-	add_setting({ "name":"roughness", "type":SettingType.SLIDER, "list":main_list, "default":0,
+	add_setting({ "name":"roughness", "type":SettingType.SLIDER, "list":main_list, "default":-65,
 								"unit":"%", "range":Vector3(-100, 100, 1), "flags":ADD_SEPARATOR })
 	add_setting({ "name":"roughness_picker", "type":SettingType.PICKER, "list":main_list, 
 								"default":Terrain3DEditor.ROUGHNESS, "flags":NO_LABEL })

--- a/project/addons/terrain_3d/src/toolbar.gd
+++ b/project/addons/terrain_3d/src/toolbar.gd
@@ -7,8 +7,6 @@ const ICON_REGION_ADD: String = "res://addons/terrain_3d/icons/region_add.svg"
 const ICON_REGION_REMOVE: String = "res://addons/terrain_3d/icons/region_remove.svg"
 const ICON_HEIGHT_ADD: String = "res://addons/terrain_3d/icons/height_add.svg"
 const ICON_HEIGHT_SUB: String = "res://addons/terrain_3d/icons/height_sub.svg"
-const ICON_HEIGHT_MUL: String = "res://addons/terrain_3d/icons/height_mul.svg"
-const ICON_HEIGHT_DIV: String = "res://addons/terrain_3d/icons/height_div.svg"
 const ICON_HEIGHT_FLAT: String = "res://addons/terrain_3d/icons/height_flat.svg"
 const ICON_HEIGHT_SLOPE: String = "res://addons/terrain_3d/icons/height_slope.svg"
 const ICON_HEIGHT_SMOOTH: String = "res://addons/terrain_3d/icons/height_smooth.svg"
@@ -41,10 +39,6 @@ func _ready() -> void:
 	add_tool_button({ "tool":Terrain3DEditor.HEIGHT, 
 		"add_text":"Raise", "add_op":Terrain3DEditor.ADD, "add_icon":ICON_HEIGHT_ADD,
 		"sub_text":"Lower", "sub_op":Terrain3DEditor.SUBTRACT, "sub_icon":ICON_HEIGHT_SUB })
-
-	add_tool_button({ "tool":Terrain3DEditor.HEIGHT,
-		"add_text":"Expand", "add_op":Terrain3DEditor.MULTIPLY, "add_icon":ICON_HEIGHT_MUL,
-		"sub_text":"Reduce", "sub_op":Terrain3DEditor.DIVIDE, "sub_icon":ICON_HEIGHT_DIV })
 
 	add_tool_button({ "tool":Terrain3DEditor.HEIGHT, 
 		"add_text":"Smooth", "add_op":Terrain3DEditor.AVERAGE, "add_icon":ICON_HEIGHT_SMOOTH })

--- a/project/addons/terrain_3d/src/toolbar.gd
+++ b/project/addons/terrain_3d/src/toolbar.gd
@@ -43,17 +43,17 @@ func _ready() -> void:
 		"sub_text":"Lower", "sub_op":Terrain3DEditor.SUBTRACT, "sub_icon":ICON_HEIGHT_SUB })
 
 	add_tool_button({ "tool":Terrain3DEditor.HEIGHT,
-		"add_text":"Expand (Away from 0)", "add_op":Terrain3DEditor.MULTIPLY, "add_icon":ICON_HEIGHT_MUL,
-		"sub_text":"Reduce (Towards 0)", "sub_op":Terrain3DEditor.DIVIDE, "sub_icon":ICON_HEIGHT_DIV })
-
-	add_tool_button({ "tool":Terrain3DEditor.HEIGHT, 
-		"add_text":"Flatten", "add_op":Terrain3DEditor.REPLACE, "add_icon":ICON_HEIGHT_FLAT })
-
-	add_tool_button({ "tool":Terrain3DEditor.HEIGHT, 
-		"add_text":"Slope", "add_op":Terrain3DEditor.GRADIENT, "add_icon":ICON_HEIGHT_SLOPE })
+		"add_text":"Expand", "add_op":Terrain3DEditor.MULTIPLY, "add_icon":ICON_HEIGHT_MUL,
+		"sub_text":"Reduce", "sub_op":Terrain3DEditor.DIVIDE, "sub_icon":ICON_HEIGHT_DIV })
 
 	add_tool_button({ "tool":Terrain3DEditor.HEIGHT, 
 		"add_text":"Smooth", "add_op":Terrain3DEditor.AVERAGE, "add_icon":ICON_HEIGHT_SMOOTH })
+
+	add_tool_button({ "tool":Terrain3DEditor.HEIGHT, 
+		"add_text":"Height", "add_op":Terrain3DEditor.REPLACE, "add_icon":ICON_HEIGHT_FLAT })
+
+	add_tool_button({ "tool":Terrain3DEditor.HEIGHT, 
+		"add_text":"Slope", "add_op":Terrain3DEditor.GRADIENT, "add_icon":ICON_HEIGHT_SLOPE })
 
 	add_child(HSeparator.new())
 

--- a/project/addons/terrain_3d/src/ui.gd
+++ b/project/addons/terrain_3d/src/ui.gd
@@ -13,7 +13,7 @@ const COLOR_LOWER := Color.BLACK
 const COLOR_SMOOTH := Color(0.5, 0, .1)
 const COLOR_EXPAND := Color.ORANGE
 const COLOR_REDUCE := Color.BLUE_VIOLET
-const COLOR_FLATTEN := Color(0., 0.32, .4)
+const COLOR_HEIGHT := Color(0., 0.32, .4)
 const COLOR_SLOPE := Color.YELLOW
 const COLOR_PAINT := Color.FOREST_GREEN
 const COLOR_SPRAY := Color.SEA_GREEN
@@ -297,7 +297,7 @@ func update_decal() -> void:
 					Terrain3DEditor.DIVIDE:
 						decal.modulate = COLOR_REDUCE
 					Terrain3DEditor.REPLACE:
-						decal.modulate = COLOR_FLATTEN
+						decal.modulate = COLOR_HEIGHT
 					Terrain3DEditor.AVERAGE:
 						decal.modulate = COLOR_SMOOTH
 					Terrain3DEditor.GRADIENT:

--- a/project/addons/terrain_3d/src/ui.gd
+++ b/project/addons/terrain_3d/src/ui.gd
@@ -49,6 +49,7 @@ var brush_data: Dictionary
 var operation_builder: OperationBuilder
 var modifier_ctrl: bool
 var modifier_alt: bool
+var modifier_shift: bool
 var last_tool: Terrain3DEditor.Tool
 var last_operation: Terrain3DEditor.Operation
 
@@ -421,20 +422,30 @@ func pick(p_global_position: Vector3) -> void:
 
 
 func set_modifier(p_modifier: int, p_pressed: bool) -> void:
+	# Ctrl (invert) key. Swap enable/disable holes, swap raise/lower terrain, etc.
 	if p_modifier == KEY_CTRL && modifier_ctrl != p_pressed:
-		# Ctrl (invert) key. Swap enable/disable holes, swap raise/lower terrain, etc.
 		modifier_ctrl = p_pressed
 		toolbar.show_add_buttons(!p_pressed)
 		if plugin.editor:
 			plugin.editor.set_operation(_modify_operation(plugin.editor.get_operation()))
 
+	# Alt (modify) key. Change the raise/lower operation to lift floors / flatten peaks.
 	if p_modifier == KEY_ALT && modifier_alt != p_pressed:
-		# Alt key. Change the raise/lower operation to lift floors / flatten peaks.
 		modifier_alt = p_pressed
 		
 		tool_settings.set_setting("lift_floor", p_pressed)
 		tool_settings.set_setting("flatten_peaks", p_pressed)
 
+	# Shift (smooth) key
+	if p_modifier == KEY_SHIFT && modifier_shift != p_pressed:
+		modifier_shift = p_pressed
+		if modifier_shift:
+			plugin.editor.set_tool(Terrain3DEditor.HEIGHT)
+			plugin.editor.set_operation(Terrain3DEditor.AVERAGE)
+		else:
+			plugin.editor.set_tool(last_tool)
+			plugin.editor.set_operation(last_operation)
+	
 
 func _modify_operation(p_operation: Terrain3DEditor.Operation) -> Terrain3DEditor.Operation:
 	var remove_checked: bool = false

--- a/project/addons/terrain_3d/src/ui.gd
+++ b/project/addons/terrain_3d/src/ui.gd
@@ -144,8 +144,7 @@ func _on_tool_changed(p_tool: Terrain3DEditor.Tool, p_operation: Terrain3DEditor
 			to_show.push_back("brush")
 			to_show.push_back("size")
 			to_show.push_back("strength")
-			if p_operation in [Terrain3DEditor.ADD, Terrain3DEditor.SUBTRACT, \
-				Terrain3DEditor.MULTIPLY, Terrain3DEditor.DIVIDE]:
+			if p_operation in [Terrain3DEditor.ADD, Terrain3DEditor.SUBTRACT]:
 					to_show.push_back("remove")
 			elif p_operation == Terrain3DEditor.REPLACE:
 				to_show.push_back("height")
@@ -303,12 +302,6 @@ func update_decal() -> void:
 						else:
 							decal.modulate = COLOR_LOWER
 							decal.modulate.a = clamp(brush_data["strength"], .2, .5) + .5
-					Terrain3DEditor.MULTIPLY:
-						decal.modulate = COLOR_EXPAND
-						decal.modulate.a = clamp(brush_data["strength"], .2, .5)
-					Terrain3DEditor.DIVIDE:
-						decal.modulate = COLOR_REDUCE
-						decal.modulate.a = clamp(brush_data["strength"], .2, .5)
 					Terrain3DEditor.REPLACE:
 						decal.modulate = COLOR_HEIGHT
 						decal.modulate.a = clamp(brush_data["strength"], .2, .5)
@@ -474,10 +467,6 @@ func _invert_operation(p_operation: Terrain3DEditor.Operation, flags: int = OP_N
 		return Terrain3DEditor.SUBTRACT
 	elif p_operation == Terrain3DEditor.SUBTRACT and ! (flags & OP_NEGATIVE_ONLY):
 		return Terrain3DEditor.ADD
-	elif p_operation == Terrain3DEditor.MULTIPLY and ! (flags & OP_POSITIVE_ONLY):
-		return Terrain3DEditor.DIVIDE
-	elif p_operation == Terrain3DEditor.DIVIDE and ! (flags & OP_NEGATIVE_ONLY):
-		return Terrain3DEditor.MULTIPLY
 	return p_operation
 
 

--- a/src/terrain_3d_editor.cpp
+++ b/src/terrain_3d_editor.cpp
@@ -216,24 +216,6 @@ void Terrain3DEditor::_operate_map(const Vector3 &p_global_position, const real_
 							}
 							break;
 						}
-						case MULTIPLY: {
-							brush_alpha *= (srcf > 0) ? 1 : -1;
-							destf = srcf * (brush_alpha * strength * .01f + 1.0f);
-							if (lift_floor && !std::isnan(p_global_position.y)) {
-								real_t brush_center_y = p_global_position.y * (brush_alpha * strength * .01f + 1.0f);
-								destf = Math::clamp(brush_center_y, srcf, destf);
-							}
-							break;
-						}
-						case DIVIDE: {
-							brush_alpha *= (srcf < 0) ? 1 : -1;
-							destf = srcf * (brush_alpha * strength * .01f + 1.0f);
-							if (flatten_peaks && !std::isnan(p_global_position.y)) {
-								real_t brush_center_y = p_global_position.y * (brush_alpha * strength * .01f + 1.0f);
-								destf = Math::clamp(brush_center_y, destf, srcf);
-							}
-							break;
-						}
 						case REPLACE: {
 							destf = Math::lerp(srcf, height, brush_alpha * strength * .5f);
 							break;
@@ -720,8 +702,6 @@ void Terrain3DEditor::stop_operation() {
 void Terrain3DEditor::_bind_methods() {
 	BIND_ENUM_CONSTANT(ADD);
 	BIND_ENUM_CONSTANT(SUBTRACT);
-	BIND_ENUM_CONSTANT(MULTIPLY);
-	BIND_ENUM_CONSTANT(DIVIDE);
 	BIND_ENUM_CONSTANT(REPLACE);
 	BIND_ENUM_CONSTANT(AVERAGE);
 	BIND_ENUM_CONSTANT(GRADIENT);

--- a/src/terrain_3d_editor.cpp
+++ b/src/terrain_3d_editor.cpp
@@ -243,28 +243,24 @@ void Terrain3DEditor::_operate_map(const Vector3 &p_global_position, const real_
 							Vector3 right_position = brush_global_position + Vector3(vertex_spacing, 0.f, 0.f);
 							Vector3 down_position = brush_global_position - Vector3(0.f, 0.f, vertex_spacing);
 							Vector3 up_position = brush_global_position + Vector3(0.f, 0.f, vertex_spacing);
-
-							real_t left = srcf, right = srcf, up = srcf, down = srcf;
-
-							left = storage->get_pixel(map_type, left_position).r;
+							real_t left = storage->get_pixel(map_type, left_position).r;
 							if (std::isnan(left)) {
 								left = 0.f;
 							}
-							right = storage->get_pixel(map_type, right_position).r;
+							real_t right = storage->get_pixel(map_type, right_position).r;
 							if (std::isnan(right)) {
 								right = 0.f;
 							}
-							up = storage->get_pixel(map_type, up_position).r;
+							real_t up = storage->get_pixel(map_type, up_position).r;
 							if (std::isnan(up)) {
 								up = 0.f;
 							}
-							down = storage->get_pixel(map_type, down_position).r;
+							real_t down = storage->get_pixel(map_type, down_position).r;
 							if (std::isnan(down)) {
 								down = 0.f;
 							}
-
 							real_t avg = (srcf + left + right + up + down) * 0.2f;
-							destf = Math::lerp(srcf, avg, brush_alpha * strength);
+							destf = Math::lerp(srcf, avg, CLAMP(brush_alpha * strength * 2.f, .02f, 1.f));
 							break;
 						}
 						case GRADIENT: {

--- a/src/terrain_3d_editor.h
+++ b/src/terrain_3d_editor.h
@@ -18,8 +18,6 @@ public: // Constants
 	enum Operation {
 		ADD,
 		SUBTRACT,
-		MULTIPLY,
-		DIVIDE,
 		REPLACE,
 		AVERAGE,
 		GRADIENT,
@@ -29,8 +27,6 @@ public: // Constants
 	static inline const char *OPNAME[] = {
 		"Add",
 		"Subtract",
-		"Multiply",
-		"Divide",
 		"Replace",
 		"Average",
 		"Gradient",

--- a/src/terrain_3d_instancer.cpp
+++ b/src/terrain_3d_instancer.cpp
@@ -193,7 +193,7 @@ void Terrain3DInstancer::add_instances(const Vector3 &p_global_position, const D
 	}
 	Ref<Terrain3DMeshAsset> mesh_asset = _terrain->get_assets()->get_mesh_asset(mesh_id);
 
-	real_t brush_size = CLAMP(real_t(p_params.get("size", 10.f)), 2.f, 4096); // Meters
+	real_t brush_size = CLAMP(real_t(p_params.get("size", 10.f)), 2.f, 4096.f); // Meters
 	real_t radius = brush_size * .4f; // Ring1's inner radius
 	real_t strength = CLAMP(real_t(p_params.get("strength", .1f)), .01f, 100.f); // (premul) 1-10k%
 	real_t fixed_scale = CLAMP(real_t(p_params.get("fixed_scale", 100.f)) * .01f, .01f, 100.f); // 1-10k%
@@ -299,7 +299,7 @@ void Terrain3DInstancer::remove_instances(const Vector3 &p_global_position, cons
 	}
 	Ref<Terrain3DMeshAsset> mesh_asset = _terrain->get_assets()->get_mesh_asset(mesh_id);
 
-	real_t brush_size = CLAMP(real_t(p_params.get("size", 10.f)), 2.f, 4096); // Meters
+	real_t brush_size = CLAMP(real_t(p_params.get("size", 10.f)), 2.f, 4096.f); // Meters
 	real_t radius = brush_size * .4f; // Ring1's inner radius
 	real_t strength = CLAMP(real_t(p_params.get("strength", .1f)), .01f, 100.f); // (premul) 1-10k%
 	real_t fixed_scale = CLAMP(real_t(p_params.get("fixed_scale", 100.f)) * .01f, .01f, 100.f); // 1-10k%


### PR DESCRIPTION
Makes the following changes:

**General**
* Brush size default 50m to 20m
* Brush strength default 10% to 33%

**Raise/Lower**
* Raise/Lower brush reduced to 1/10th strength
* ~~Expand only goes up (instead of down below zero), Reduce only goes down (instead of up below zero)~~
* Expand/reduce removed. They are multiplicative, so at 0 do nothing, at large heights are super strong. Raise/lower is additive and the same regardless of heights. There's now little difference from Raise/lower, and it's an inconsistent brush.
* Lift/flatten mode via ALT now has colored decals

**Smooth**
* Ordered Smooth above Slope/Height buttons
* Smooth enabled on SHIFT
* Smooth brush 2x stronger, lower cap added (maximum is not stronger)

**Height**
* Flatten brush renamed to Height brush
* Height brush default height 50m to 20m
* Height / Slope strength 1/2th

**Texture/Rough**
* Spray brush strength 2x, upper clamp 10x
* Wetness defaults to -65%

Fixes #122 