### PR TITLE
Allow region size changes

### DIFF
--- a/project/addons/terrain_3d/src/directory_setup.gd
+++ b/project/addons/terrain_3d/src/directory_setup.gd
@@ -79,24 +79,33 @@ func _on_file_selected(path: String) -> void:
 
 func _on_ok_pressed() -> void:
 	if not plugin.terrain:
-		push_error("No connected terrain. Click the Terrain3D node first")
+		push_error("Not connected terrain. Click the Terrain3D node first")
 		return
-
 	if selected_dir_le.text.is_empty():
-		push_error("No storage directory specified")
+		push_error("No data directory specified")
 		return
 	if not DirAccess.dir_exists_absolute(selected_dir_le.text):
 		push_error("Directory doesn't exist: ", selected_dir_le.text)
 		return
-	else:
-		print("Setting terrain directory: ", selected_dir_le.text)
-		plugin.terrain.data_directory = selected_dir_le.text
-		
+	# Check if directory empty of terrain files		
+	var data_found: bool = false
+	var files: Array = DirAccess.get_files_at(selected_dir_le.text)
+	for file in files:
+		if file.begins_with("terrain3d") || file.ends_with(".res"):
+			data_found = true
+			break
+
+	print("Setting terrain directory: ", selected_dir_le.text)
+	plugin.terrain.data_directory = selected_dir_le.text
 
 	if not upgrade_file_le.text.is_empty():	
+		if data_found:
+			push_warning("Target directory already has terrain data. Specify an empty directory to upgrade")
+			return
 		if not FileAccess.file_exists(upgrade_file_le.text):
 			push_error("File doesn't exist: ", upgrade_file_le.text)
 			return	
+
 		if not plugin.terrain.storage or \
 			( plugin.terrain.storage and plugin.terrain.storage.get_path() != upgrade_file_le.text):
 				print("Loading storage file: ", upgrade_file_le.text)

--- a/src/shaders/world_noise.glsl
+++ b/src/shaders/world_noise.glsl
@@ -92,7 +92,8 @@ float get_noise_height(const vec2 uv) {
 	if (weight <= 1.0 - world_noise_region_blend) {
 		return 0.0;
 	}
-	float noise = world_noise((uv + world_noise_offset.xz) * world_noise_scale * .1) *
+	//TODO: Offset/scale UVs are semi-dependent upon region size 1024. Base on v_vertex.xz instead
+	float noise = world_noise((uv + world_noise_offset.xz * 1024. / _region_size) * world_noise_scale * _region_size / 1024. * .1) *
             world_noise_height * 10. + world_noise_offset.y * 100.;
 	weight = smoothstep(1.0 - world_noise_region_blend, 1.0, weight);
 	return mix(0.0, noise, weight);

--- a/src/terrain_3d.cpp
+++ b/src/terrain_3d.cpp
@@ -1565,7 +1565,6 @@ void Terrain3D::_bind_methods() {
 	ADD_PROPERTY(PropertyInfo(Variant::INT, "debug_level", PROPERTY_HINT_ENUM, "Errors,Info,Debug,Extreme"), "set_debug_level", "get_debug_level");
 	ADD_PROPERTY(PropertyInfo(Variant::STRING, "data_directory", PROPERTY_HINT_DIR), "set_data_directory", "get_data_directory");
 	ADD_PROPERTY(PropertyInfo(Variant::INT, "region_size", PROPERTY_HINT_ENUM, "64:64, 128:128, 256:256, 512:512, 1024:1024, 2048:2048"), "set_region_size", "get_region_size");
-	//ADD_PROPERTY(PropertyInfo(Variant::INT, "region_size", PROPERTY_HINT_ENUM, "1024:1024"), "set_region_size", "get_region_size");
 	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "save_16_bit", PROPERTY_HINT_NONE), "set_save_16_bit", "get_save_16_bit");
 	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "show_region_labels"), "set_show_region_labels", "get_show_region_labels");
 	ADD_PROPERTY(PropertyInfo(Variant::OBJECT, "material", PROPERTY_HINT_RESOURCE_TYPE, "Terrain3DMaterial"), "set_material", "get_material");

--- a/src/terrain_3d.cpp
+++ b/src/terrain_3d.cpp
@@ -781,6 +781,13 @@ void Terrain3D::set_region_size(const RegionSize p_size) {
 	}
 }
 
+void Terrain3D::change_region_size(const RegionSize p_size) {
+	if (_data == nullptr) {
+		return;
+	}
+	_data->change_region_size(p_size);
+}
+
 void Terrain3D::set_save_16_bit(const bool p_enabled) {
 	LOG(INFO, p_enabled);
 	_save_16_bit = p_enabled;
@@ -1499,7 +1506,7 @@ void Terrain3D::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("get_version"), &Terrain3D::get_version);
 	ClassDB::bind_method(D_METHOD("set_debug_level", "level"), &Terrain3D::set_debug_level);
 	ClassDB::bind_method(D_METHOD("get_debug_level"), &Terrain3D::get_debug_level);
-	ClassDB::bind_method(D_METHOD("set_region_size", "size"), &Terrain3D::set_region_size);
+	ClassDB::bind_method(D_METHOD("change_region_size", "size"), &Terrain3D::change_region_size);
 	ClassDB::bind_method(D_METHOD("get_region_size"), &Terrain3D::get_region_size);
 	ClassDB::bind_method(D_METHOD("set_mesh_lods", "count"), &Terrain3D::set_mesh_lods);
 	ClassDB::bind_method(D_METHOD("get_mesh_lods"), &Terrain3D::get_mesh_lods);
@@ -1559,13 +1566,11 @@ void Terrain3D::_bind_methods() {
 	ADD_PROPERTY(PropertyInfo(Variant::OBJECT, "data", PROPERTY_HINT_NONE, "Terrain3DData", PROPERTY_USAGE_NONE), "", "get_data");
 	ADD_PROPERTY(PropertyInfo(Variant::OBJECT, "instancer", PROPERTY_HINT_NONE, "Terrain3DInstancer", PROPERTY_USAGE_NONE), "", "get_instancer");
 
-	int ro_flags = PROPERTY_USAGE_STORAGE | PROPERTY_USAGE_EDITOR | PROPERTY_USAGE_READ_ONLY;
-
 	ADD_PROPERTY(PropertyInfo(Variant::STRING, "version", PROPERTY_HINT_NONE, "", PROPERTY_USAGE_EDITOR | PROPERTY_USAGE_READ_ONLY), "", "get_version");
 	ADD_PROPERTY(PropertyInfo(Variant::INT, "debug_level", PROPERTY_HINT_ENUM, "Errors,Info,Debug,Extreme"), "set_debug_level", "get_debug_level");
 	ADD_PROPERTY(PropertyInfo(Variant::STRING, "data_directory", PROPERTY_HINT_DIR), "set_data_directory", "get_data_directory");
-	ADD_PROPERTY(PropertyInfo(Variant::INT, "region_size", PROPERTY_HINT_ENUM, "64:64, 128:128, 256:256, 512:512, 1024:1024, 2048:2048", PROPERTY_USAGE_EDITOR | PROPERTY_USAGE_READ_ONLY), "set_region_size", "get_region_size");
 	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "save_16_bit", PROPERTY_HINT_NONE), "set_save_16_bit", "get_save_16_bit");
+	ADD_PROPERTY(PropertyInfo(Variant::INT, "region_size", PROPERTY_HINT_ENUM, "64:64,128:128,256:256,512:512,1024:1024,2048:2048", PROPERTY_USAGE_EDITOR), "change_region_size", "get_region_size");
 	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "show_region_labels"), "set_show_region_labels", "get_show_region_labels");
 	ADD_PROPERTY(PropertyInfo(Variant::OBJECT, "material", PROPERTY_HINT_RESOURCE_TYPE, "Terrain3DMaterial"), "set_material", "get_material");
 	ADD_PROPERTY(PropertyInfo(Variant::OBJECT, "assets", PROPERTY_HINT_RESOURCE_TYPE, "Terrain3DAssets"), "set_assets", "get_assets");

--- a/src/terrain_3d.cpp
+++ b/src/terrain_3d.cpp
@@ -768,13 +768,13 @@ String Terrain3D::get_data_directory() const {
 }
 
 void Terrain3D::set_region_size(const RegionSize p_size) {
-	LOG(INFO, p_size);
+	LOG(INFO, "Setting region size: ", p_size);
 	ERR_FAIL_COND(p_size < SIZE_64);
 	ERR_FAIL_COND(p_size > SIZE_2048);
 	_region_size = p_size;
-	// Region size changed, update downstream
 	if (_data) {
-		_data->set_region_size(_region_size);
+		_data->_region_size = _region_size;
+		_data->_region_sizev = Vector2i(_region_size, _region_size);
 	}
 	if (_material.is_valid()) {
 		_material->_update_maps();
@@ -1564,7 +1564,7 @@ void Terrain3D::_bind_methods() {
 	ADD_PROPERTY(PropertyInfo(Variant::STRING, "version", PROPERTY_HINT_NONE, "", PROPERTY_USAGE_EDITOR | PROPERTY_USAGE_READ_ONLY), "", "get_version");
 	ADD_PROPERTY(PropertyInfo(Variant::INT, "debug_level", PROPERTY_HINT_ENUM, "Errors,Info,Debug,Extreme"), "set_debug_level", "get_debug_level");
 	ADD_PROPERTY(PropertyInfo(Variant::STRING, "data_directory", PROPERTY_HINT_DIR), "set_data_directory", "get_data_directory");
-	ADD_PROPERTY(PropertyInfo(Variant::INT, "region_size", PROPERTY_HINT_ENUM, "64:64, 128:128, 256:256, 512:512, 1024:1024, 2048:2048"), "set_region_size", "get_region_size");
+	ADD_PROPERTY(PropertyInfo(Variant::INT, "region_size", PROPERTY_HINT_ENUM, "64:64, 128:128, 256:256, 512:512, 1024:1024, 2048:2048", PROPERTY_USAGE_EDITOR | PROPERTY_USAGE_READ_ONLY), "set_region_size", "get_region_size");
 	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "save_16_bit", PROPERTY_HINT_NONE), "set_save_16_bit", "get_save_16_bit");
 	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "show_region_labels"), "set_show_region_labels", "get_show_region_labels");
 	ADD_PROPERTY(PropertyInfo(Variant::OBJECT, "material", PROPERTY_HINT_RESOURCE_TYPE, "Terrain3DMaterial"), "set_material", "get_material");

--- a/src/terrain_3d.cpp
+++ b/src/terrain_3d.cpp
@@ -769,14 +769,12 @@ String Terrain3D::get_data_directory() const {
 
 void Terrain3D::set_region_size(const RegionSize p_size) {
 	LOG(INFO, p_size);
-	//ERR_FAIL_COND(p_size < SIZE_64);
-	//ERR_FAIL_COND(p_size > SIZE_2048);
-	ERR_FAIL_COND(p_size != SIZE_1024);
+	ERR_FAIL_COND(p_size < SIZE_64);
+	ERR_FAIL_COND(p_size > SIZE_2048);
 	_region_size = p_size;
 	// Region size changed, update downstream
 	if (_data) {
-		_data->_region_size = _region_size;
-		_data->_region_sizev = Vector2i(_region_size, _region_size);
+		_data->set_region_size(_region_size);
 	}
 	if (_material.is_valid()) {
 		_material->_update_maps();
@@ -1488,12 +1486,12 @@ void Terrain3D::_notification(const int p_what) {
 }
 
 void Terrain3D::_bind_methods() {
-	//BIND_ENUM_CONSTANT(SIZE_64);
-	//BIND_ENUM_CONSTANT(SIZE_128);
-	//BIND_ENUM_CONSTANT(SIZE_256);
-	//BIND_ENUM_CONSTANT(SIZE_512);
+	BIND_ENUM_CONSTANT(SIZE_64);
+	BIND_ENUM_CONSTANT(SIZE_128);
+	BIND_ENUM_CONSTANT(SIZE_256);
+	BIND_ENUM_CONSTANT(SIZE_512);
 	BIND_ENUM_CONSTANT(SIZE_1024);
-	//BIND_ENUM_CONSTANT(SIZE_2048);
+	BIND_ENUM_CONSTANT(SIZE_2048);
 
 	BIND_ENUM_CONSTANT(FULL_GAME);
 	BIND_ENUM_CONSTANT(FULL_EDITOR);
@@ -1566,8 +1564,8 @@ void Terrain3D::_bind_methods() {
 	ADD_PROPERTY(PropertyInfo(Variant::STRING, "version", PROPERTY_HINT_NONE, "", PROPERTY_USAGE_EDITOR | PROPERTY_USAGE_READ_ONLY), "", "get_version");
 	ADD_PROPERTY(PropertyInfo(Variant::INT, "debug_level", PROPERTY_HINT_ENUM, "Errors,Info,Debug,Extreme"), "set_debug_level", "get_debug_level");
 	ADD_PROPERTY(PropertyInfo(Variant::STRING, "data_directory", PROPERTY_HINT_DIR), "set_data_directory", "get_data_directory");
-	//ADD_PROPERTY(PropertyInfo(Variant::INT, "region_size", PROPERTY_HINT_ENUM, "64:64, 128:128, 256:256, 512:512, 1024:1024, 2048:2048"), "set_region_size", "get_region_size");
-	ADD_PROPERTY(PropertyInfo(Variant::INT, "region_size", PROPERTY_HINT_ENUM, "1024:1024"), "set_region_size", "get_region_size");
+	ADD_PROPERTY(PropertyInfo(Variant::INT, "region_size", PROPERTY_HINT_ENUM, "64:64, 128:128, 256:256, 512:512, 1024:1024, 2048:2048"), "set_region_size", "get_region_size");
+	//ADD_PROPERTY(PropertyInfo(Variant::INT, "region_size", PROPERTY_HINT_ENUM, "1024:1024"), "set_region_size", "get_region_size");
 	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "save_16_bit", PROPERTY_HINT_NONE), "set_save_16_bit", "get_save_16_bit");
 	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "show_region_labels"), "set_show_region_labels", "get_show_region_labels");
 	ADD_PROPERTY(PropertyInfo(Variant::OBJECT, "material", PROPERTY_HINT_RESOURCE_TYPE, "Terrain3DMaterial"), "set_material", "get_material");

--- a/src/terrain_3d.cpp
+++ b/src/terrain_3d.cpp
@@ -752,6 +752,7 @@ void Terrain3D::set_data_directory(String p_dir) {
 	LOG(INFO, "Setting data directory to ", p_dir);
 	if (_data_directory != p_dir) {
 		_clear_meshes();
+		_destroy_labels();
 		_destroy_collision();
 		_destroy_instancer();
 		memdelete_safely(_data);
@@ -1307,6 +1308,7 @@ void Terrain3D::set_storage(const Ref<Terrain3DStorage> &p_storage) {
 	_storage = p_storage;
 	if (p_storage.is_valid()) {
 		LOG(WARN, "Loaded Terrain3DStorage v", vformat("%.3f", p_storage->get_version()), ". Use Terrain3D Tools / Directory Setup to upgrade");
+		set_region_size(SIZE_1024);
 	}
 }
 
@@ -1324,6 +1326,7 @@ void Terrain3D::split_storage() {
 		return;
 	}
 
+	set_region_size(SIZE_1024);
 	TypedArray<Vector2i> locations = _storage->get_region_offsets();
 	TypedArray<Image> hmaps = _storage->get_maps(Terrain3DStorage::TYPE_HEIGHT);
 	TypedArray<Image> ctlmaps = _storage->get_maps(Terrain3DStorage::TYPE_CONTROL);
@@ -1339,7 +1342,7 @@ void Terrain3D::split_storage() {
 		region->set_color_map(clrmaps[i]);
 		region->set_multimeshes(mms[locations[i]]);
 		_data->add_region(region, false);
-		LOG(MESG, "Splicing region ", locations[i]);
+		LOG(INFO, "Splicing region ", locations[i]);
 	}
 	_storage.unref();
 	_data->force_update_maps();

--- a/src/terrain_3d.h
+++ b/src/terrain_3d.h
@@ -50,13 +50,15 @@ private:
 	bool _initialized = false;
 
 	// Terrain settings
+	String _data_directory;
 	RegionSize _region_size = SIZE_256;
+	bool _save_16_bit = false;
+	real_t _label_distance = 0.f;
+	int _label_size = 48;
+
 	int _mesh_size = 48;
 	int _mesh_lods = 7;
 	real_t _vertex_spacing = 1.0f;
-	String _data_directory;
-	bool _save_16_bit = false;
-	bool _show_region_labels = false;
 
 	Terrain3DData *_data = nullptr;
 	Ref<Terrain3DMaterial> _material;
@@ -148,14 +150,20 @@ public:
 	Terrain3DData *get_data() const { return _data; }
 	void set_data_directory(String p_dir);
 	String get_data_directory() const;
+
+	// Regions
 	void set_region_size(const RegionSize p_size);
 	RegionSize get_region_size() const { return _region_size; }
 	void change_region_size(const RegionSize p_size);
 	void set_save_16_bit(const bool p_enabled);
 	bool get_save_16_bit() const { return _save_16_bit; }
-	void set_show_region_labels(const bool p_enabled);
-	bool get_show_region_labels() const { return _show_region_labels; }
+	void set_label_distance(const real_t p_distance);
+	real_t get_label_distance() const { return _label_distance; }
+	void set_label_size(const int p_size);
+	int get_label_size() const { return _label_size; }
 	void update_region_labels();
+	void set_show_grid(const bool p_enabled) { (_material != nullptr) ? _material->set_show_region_grid(p_enabled) : void(); }
+	bool get_show_grid() { return (_material != nullptr) ? _material->get_show_region_grid() : false; }
 
 	void set_mesh_lods(const int p_count);
 	int get_mesh_lods() const { return _mesh_lods; }

--- a/src/terrain_3d.h
+++ b/src/terrain_3d.h
@@ -28,12 +28,12 @@ class Terrain3D : public Node3D {
 
 public: // Constants
 	enum RegionSize {
-		//SIZE_64 = 64,
-		//SIZE_128 = 128,
-		//SIZE_256 = 256,
-		//SIZE_512 = 512,
+		SIZE_64 = 64,
+		SIZE_128 = 128,
+		SIZE_256 = 256,
+		SIZE_512 = 512,
 		SIZE_1024 = 1024,
-		//SIZE_2048 = 2048,
+		SIZE_2048 = 2048,
 	};
 
 	enum CollisionMode {

--- a/src/terrain_3d.h
+++ b/src/terrain_3d.h
@@ -50,7 +50,7 @@ private:
 	bool _initialized = false;
 
 	// Terrain settings
-	RegionSize _region_size = SIZE_1024;
+	RegionSize _region_size = SIZE_256;
 	int _mesh_size = 48;
 	int _mesh_lods = 7;
 	real_t _vertex_spacing = 1.0f;
@@ -150,6 +150,7 @@ public:
 	String get_data_directory() const;
 	void set_region_size(const RegionSize p_size);
 	RegionSize get_region_size() const { return _region_size; }
+	void change_region_size(const RegionSize p_size);
 	void set_save_16_bit(const bool p_enabled);
 	bool get_save_16_bit() const { return _save_16_bit; }
 	void set_show_region_labels(const bool p_enabled);

--- a/src/terrain_3d_data.cpp
+++ b/src/terrain_3d_data.cpp
@@ -73,10 +73,8 @@ TypedArray<Terrain3DRegion> Terrain3DData::get_regions_active(const bool p_copy,
 // The callable receives: source Terrain3DRegion, source Rect2i, dest Rect2i, (bindings)
 // Used with change_region_size, dest Terrain3DRegion is bound as the 4th parameter
 void Terrain3DData::do_for_regions(const Rect2i &p_area, const Callable &p_callback) {
-	Rect2i location_bounds;
-	location_bounds.position = Point2i((Point2(p_area.position) / real_t(_region_size)).floor()); // rounded down
-	location_bounds.set_end(Point2i((Point2(p_area.get_end()) / real_t(_region_size)).ceil())); // rounded up in a dumb way
-	LOG(INFO, "Processing area: ", p_area, " -> ", location_bounds);
+	Rect2i location_bounds(V2I_DIVIDE_FLOOR(p_area.position, _region_size), V2I_DIVIDE_CEIL(p_area.size, _region_size));
+	LOG(DEBUG, "Processing global area: ", p_area, " -> ", location_bounds);
 	Point2i current_region_loc;
 	for (int y = location_bounds.position.y; y < location_bounds.get_end().y; y++) {
 		current_region_loc.y = y;
@@ -111,14 +109,11 @@ void Terrain3DData::change_region_size(int p_new_size) {
 	// Get current region corners expressed in new region_size coordinates
 	Dictionary new_region_points;
 	Array locs = _regions.keys();
-	int region_id = 0;
 	for (int i = 0; i < locs.size(); i++) {
 		Ref<Terrain3DRegion> region = get_region(locs[i]);
 		if (region.is_valid() && !region->is_deleted()) {
 			Point2i region_position = region->get_location() * _region_size;
-			Rect2i location_bounds;
-			location_bounds.position = region_position / p_new_size;
-			location_bounds.set_end(Point2i((Point2(region_position + _region_sizev) / p_new_size).ceil()));
+			Rect2i location_bounds(V2I_DIVIDE_FLOOR(region_position, p_new_size), V2I_DIVIDE_CEIL(_region_sizev, p_new_size));
 			for (int y = location_bounds.position.y; y < location_bounds.get_end().y; y++) {
 				for (int x = location_bounds.position.x; x < location_bounds.get_end().x; x++) {
 					new_region_points[Point2i(x, y)] = 1;

--- a/src/terrain_3d_data.cpp
+++ b/src/terrain_3d_data.cpp
@@ -61,7 +61,7 @@ TypedArray<Terrain3DRegion> Terrain3DData::get_regions_active(const bool p_copy,
 	TypedArray<Terrain3DRegion> region_arr;
 	for (int i = 0; i < _region_locations.size(); i++) {
 		Vector2i region_loc = _region_locations[i];
-		Ref<Terrain3DRegion> region = _regions[region_loc];
+		Ref<Terrain3DRegion> region = get_region(region_loc);
 		if (region.is_valid()) {
 			region_arr.push_back((p_copy) ? region->duplicate(p_deep) : region);
 		}
@@ -110,7 +110,7 @@ void Terrain3DData::change_region_size(int p_new_region_size) {
 	Array locs = _regions.keys();
 	int region_id = 0;
 	for (int i = 0; i < locs.size(); i++) {
-		Ref<Terrain3DRegion> region = _regions[locs[i]];
+		Ref<Terrain3DRegion> region = get_region(locs[i]);
 		if (region.is_valid() && !region->is_deleted()) {
 			Rect2i index_bounds;
 			Point2i region_position = region->get_location() * _region_size;
@@ -159,7 +159,7 @@ void Terrain3DData::change_region_size(int p_new_region_size) {
 }
 
 void Terrain3DData::set_region_modified(const Vector2i &p_region_loc, const bool p_modified) {
-	Ref<Terrain3DRegion> region = _regions[p_region_loc];
+	Ref<Terrain3DRegion> region = get_region(p_region_loc);
 	if (region.is_null()) {
 		LOG(ERROR, "Region not found at: ", p_region_loc);
 		return;
@@ -168,7 +168,7 @@ void Terrain3DData::set_region_modified(const Vector2i &p_region_loc, const bool
 }
 
 bool Terrain3DData::is_region_modified(const Vector2i &p_region_loc) const {
-	Ref<Terrain3DRegion> region = _regions[p_region_loc];
+	Ref<Terrain3DRegion> region = get_region(p_region_loc);
 	if (region.is_null()) {
 		LOG(ERROR, "Region not found at: ", p_region_loc);
 		return false;
@@ -177,7 +177,7 @@ bool Terrain3DData::is_region_modified(const Vector2i &p_region_loc) const {
 }
 
 void Terrain3DData::set_region_deleted(const Vector2i &p_region_loc, const bool p_deleted) {
-	Ref<Terrain3DRegion> region = _regions[p_region_loc];
+	Ref<Terrain3DRegion> region = get_region(p_region_loc);
 	if (region.is_null()) {
 		LOG(ERROR, "Region not found at: ", p_region_loc);
 		return;
@@ -186,7 +186,7 @@ void Terrain3DData::set_region_deleted(const Vector2i &p_region_loc, const bool 
 }
 
 bool Terrain3DData::is_region_deleted(const Vector2i &p_region_loc) const {
-	Ref<Terrain3DRegion> region = _regions[p_region_loc];
+	Ref<Terrain3DRegion> region = get_region(p_region_loc);
 	if (region.is_null()) {
 		LOG(ERROR, "Region not found at: ", p_region_loc);
 		return true;
@@ -292,7 +292,7 @@ void Terrain3DData::save_directory(const String &p_dir) {
 }
 
 void Terrain3DData::save_region(const Vector2i &p_region_loc, const String &p_dir, const bool p_16_bit) {
-	Ref<Terrain3DRegion> region = _regions[p_region_loc];
+	Ref<Terrain3DRegion> region = get_region(p_region_loc);
 	if (region.is_null()) {
 		LOG(ERROR, "No region found at: ", p_region_loc);
 		return;
@@ -435,7 +435,7 @@ void Terrain3DData::force_update_maps(const MapType p_map_type, const bool p_gen
 		LOG(EXTREME, "Regenerating color mipmaps");
 		for (int i = 0; i < _region_locations.size(); i++) {
 			Vector2i region_loc = _region_locations[i];
-			Ref<Terrain3DRegion> region = _regions[region_loc];
+			Ref<Terrain3DRegion> region = get_region(region_loc);
 			region->get_color_map()->generate_mipmaps();
 		}
 	}
@@ -454,7 +454,7 @@ void Terrain3DData::update_maps() {
 		Array locs = _regions.keys();
 		int region_id = 0;
 		for (int i = 0; i < locs.size(); i++) {
-			Ref<Terrain3DRegion> region = _regions[locs[i]];
+			Ref<Terrain3DRegion> region = get_region(locs[i]);
 			if (region.is_valid() && !region->is_deleted()) {
 				region_id += 1; // Begin at 1 since 0 = no region
 				int map_index = get_region_map_index(region->get_location());
@@ -473,7 +473,7 @@ void Terrain3DData::update_maps() {
 		_height_maps.clear();
 		for (int i = 0; i < _region_locations.size(); i++) {
 			Vector2i region_loc = _region_locations[i];
-			Ref<Terrain3DRegion> region = _regions[region_loc];
+			Ref<Terrain3DRegion> region = get_region(region_loc);
 			if (region.is_valid()) {
 				_height_maps.push_back(region->get_height_map());
 			} else {
@@ -493,7 +493,7 @@ void Terrain3DData::update_maps() {
 		_control_maps.clear();
 		for (int i = 0; i < _region_locations.size(); i++) {
 			Vector2i region_loc = _region_locations[i];
-			Ref<Terrain3DRegion> region = _regions[region_loc];
+			Ref<Terrain3DRegion> region = get_region(region_loc);
 			_control_maps.push_back(region->get_control_map());
 		}
 		_generated_control_maps.create(_control_maps);
@@ -506,7 +506,7 @@ void Terrain3DData::update_maps() {
 		_color_maps.clear();
 		for (int i = 0; i < _region_locations.size(); i++) {
 			Vector2i region_loc = _region_locations[i];
-			Ref<Terrain3DRegion> region = _regions[region_loc];
+			Ref<Terrain3DRegion> region = get_region(region_loc);
 			_color_maps.push_back(region->get_color_map());
 		}
 		_generated_color_maps.create(_color_maps);
@@ -525,7 +525,7 @@ void Terrain3DData::set_pixel(const MapType p_map_type, const Vector3 &p_global_
 		return;
 	}
 	Vector2i region_loc = get_region_location(p_global_position);
-	Ref<Terrain3DRegion> region = _regions[region_loc];
+	Ref<Terrain3DRegion> region = get_region(region_loc);
 	if (region.is_null()) {
 		LOG(ERROR, "No region found at: ", p_global_position);
 		return;
@@ -545,7 +545,7 @@ Color Terrain3DData::get_pixel(const MapType p_map_type, const Vector3 &p_global
 		return COLOR_NAN;
 	}
 	Vector2i region_loc = get_region_location(p_global_position);
-	Ref<Terrain3DRegion> region = _regions[region_loc];
+	Ref<Terrain3DRegion> region = get_region(region_loc);
 	if (region.is_null()) {
 		return COLOR_NAN;
 	}
@@ -723,7 +723,7 @@ void Terrain3DData::calc_height_range(const bool p_recursive) {
 	_master_height_range = V2_ZERO;
 	for (int i = 0; i < _region_locations.size(); i++) {
 		Vector2i region_loc = _region_locations[i];
-		Ref<Terrain3DRegion> region = _regions[region_loc];
+		Ref<Terrain3DRegion> region = get_region(region_loc);
 		if (region.is_null()) {
 			LOG(ERROR, "Region not found at: ", region_loc);
 			return;
@@ -987,7 +987,7 @@ Ref<Image> Terrain3DData::layered_to_image(const MapType p_map_type) const {
 		Vector2i region_loc = _region_locations[i];
 		Vector2i img_location = (region_loc - top_left) * _region_size;
 		LOG(DEBUG, "Region to blit: ", region_loc, " Export image coords: ", img_location);
-		Ref<Terrain3DRegion> region = _regions[region_loc];
+		Ref<Terrain3DRegion> region = get_region(region_loc);
 		img->blit_rect(region->get_map(map_type), Rect2i(V2I_ZERO, _region_sizev), img_location);
 	}
 	return img;

--- a/src/terrain_3d_data.h
+++ b/src/terrain_3d_data.h
@@ -6,6 +6,7 @@
 #include "constants.h"
 #include "generated_texture.h"
 #include "terrain_3d_region.h"
+#include <functional>
 
 class Terrain3D;
 
@@ -92,6 +93,8 @@ public:
 	Dictionary get_regions_all() const { return _regions; }
 	PackedInt32Array get_region_map() const { return _region_map; }
 	static int get_region_map_index(const Vector2i &p_region_loc);
+	void do_for_regions(Rect2i bounds, std::function<void(Terrain3DRegion *, Rect2i, Rect2i, Rect2i)> callback, bool do_empty_regions);
+	void set_region_size(int region_size);
 
 	Vector2i get_region_location(const Vector3 &p_global_position) const;
 	int get_region_id(const Vector2i &p_region_loc) const;

--- a/src/terrain_3d_data.h
+++ b/src/terrain_3d_data.h
@@ -77,7 +77,7 @@ private:
 
 	// Functions
 	void _clear();
-	void _copy_paste(const Terrain3DRegion *p_src_region, const Rect2i &p_src_rect, const Rect2i &p_dst_rect, const Terrain3DRegion *p_dst_region);
+	void _copy_paste_dfr(const Terrain3DRegion *p_src_region, const Rect2i &p_src_rect, const Rect2i &p_dst_rect, const Terrain3DRegion *p_dst_region);
 
 public:
 	Terrain3DData() {}

--- a/src/terrain_3d_data.h
+++ b/src/terrain_3d_data.h
@@ -6,7 +6,6 @@
 #include "constants.h"
 #include "generated_texture.h"
 #include "terrain_3d_region.h"
-#include <functional>
 
 class Terrain3D;
 
@@ -78,6 +77,7 @@ private:
 
 	// Functions
 	void _clear();
+	void _copy_paste(const Terrain3DRegion *p_src_region, const Rect2i &p_src_rect, const Rect2i &p_dst_rect, const Terrain3DRegion *p_dst_region);
 
 public:
 	Terrain3DData() {}
@@ -93,7 +93,7 @@ public:
 	Dictionary get_regions_all() const { return _regions; }
 	PackedInt32Array get_region_map() const { return _region_map; }
 	static int get_region_map_index(const Vector2i &p_region_loc);
-	void do_for_regions(Rect2i bounds, std::function<void(Terrain3DRegion *, Rect2i, Rect2i, Rect2i)> callback, bool do_empty_regions);
+	void do_for_regions(const Rect2i &p_area, const Callable &p_callback);
 	void set_region_size(int region_size);
 
 	Vector2i get_region_location(const Vector3 &p_global_position) const;
@@ -175,6 +175,18 @@ protected:
 VARIANT_ENUM_CAST(Terrain3DData::HeightFilter);
 
 // Inline Region Functions
+
+inline void Terrain3DData::_copy_paste(const Terrain3DRegion *p_src_region, const Rect2i &p_src_rect, const Rect2i &p_dst_rect, const Terrain3DRegion *p_dst_region) {
+	if (p_src_region == nullptr || p_dst_region == nullptr) {
+		return;
+	}
+	TypedArray<Image> dst_maps = p_dst_region->get_maps();
+	TypedArray<Image> src_maps = p_src_region->get_maps();
+	for (int i = 0; i < dst_maps.size(); i++) {
+		Ref<Image> img = dst_maps[i];
+		img->blit_rect(src_maps[i], p_src_rect, p_dst_rect.position);
+	}
+}
 
 // Verifies the location is within the bounds of the _region_map array and
 // the world, returning the _region_map index, which contains the region_id.

--- a/src/terrain_3d_data.h
+++ b/src/terrain_3d_data.h
@@ -103,8 +103,8 @@ public:
 
 	bool has_region(const Vector2i &p_region_loc) const { return get_region_id(p_region_loc) != -1; }
 	bool has_regionp(const Vector3 &p_global_position) const { return get_region_idp(p_global_position) != -1; }
-	Ref<Terrain3DRegion> get_region(const Vector2i &p_region_loc) const { return _regions[p_region_loc]; }
-	Ref<Terrain3DRegion> get_regionp(const Vector3 &p_global_position) const { return _regions[get_region_location(p_global_position)]; }
+	Ref<Terrain3DRegion> get_region(const Vector2i &p_region_loc) const;
+	Ref<Terrain3DRegion> get_regionp(const Vector3 &p_global_position) const;
 
 	void set_region_modified(const Vector2i &p_region_loc, const bool p_modified = true);
 	bool is_region_modified(const Vector2i &p_region_loc) const;
@@ -225,6 +225,14 @@ inline int Terrain3DData::get_region_id(const Vector2i &p_region_loc) const {
 
 inline int Terrain3DData::get_region_idp(const Vector3 &p_global_position) const {
 	return get_region_id(get_region_location(p_global_position));
+}
+
+inline Ref<Terrain3DRegion> Terrain3DData::get_region(const Vector2i &p_region_loc) const {
+	return _regions.get(p_region_loc, Ref<Terrain3DRegion>());
+}
+
+inline Ref<Terrain3DRegion> Terrain3DData::get_regionp(const Vector3 &p_global_position) const {
+	return _regions.get(get_region_location(p_global_position), Ref<Terrain3DRegion>());
 }
 
 // Inline Map Functions

--- a/src/terrain_3d_data.h
+++ b/src/terrain_3d_data.h
@@ -178,19 +178,6 @@ VARIANT_ENUM_CAST(Terrain3DData::HeightFilter);
 
 // Inline Region Functions
 
-// Structured to work with do_for_regions. Should be renamed when copy_paste is expanded
-inline void Terrain3DData::_copy_paste(const Terrain3DRegion *p_src_region, const Rect2i &p_src_rect, const Rect2i &p_dst_rect, const Terrain3DRegion *p_dst_region) {
-	if (p_src_region == nullptr || p_dst_region == nullptr) {
-		return;
-	}
-	TypedArray<Image> dst_maps = p_dst_region->get_maps();
-	TypedArray<Image> src_maps = p_src_region->get_maps();
-	for (int i = 0; i < dst_maps.size(); i++) {
-		Ref<Image> img = dst_maps[i];
-		img->blit_rect(src_maps[i], p_src_rect, p_dst_rect.position);
-	}
-}
-
 // Verifies the location is within the bounds of the _region_map array and
 // the world, returning the _region_map index, which contains the region_id.
 // Valid region locations are -8, -8 to 7, 7, or when offset: 0, 0 to 15, 15

--- a/src/terrain_3d_data.h
+++ b/src/terrain_3d_data.h
@@ -93,8 +93,9 @@ public:
 	Dictionary get_regions_all() const { return _regions; }
 	PackedInt32Array get_region_map() const { return _region_map; }
 	static int get_region_map_index(const Vector2i &p_region_loc);
+
 	void do_for_regions(const Rect2i &p_area, const Callable &p_callback);
-	void set_region_size(int region_size);
+	void change_region_size(int region_size);
 
 	Vector2i get_region_location(const Vector3 &p_global_position) const;
 	int get_region_id(const Vector2i &p_region_loc) const;
@@ -128,6 +129,7 @@ public:
 	TypedArray<Image> get_control_maps() const { return _control_maps; }
 	TypedArray<Image> get_color_maps() const { return _color_maps; }
 	TypedArray<Image> get_maps(const MapType p_map_type) const;
+
 	void force_update_maps(const MapType p_map = TYPE_MAX, const bool p_generate_mipmaps = false);
 	void update_maps();
 	RID get_height_maps_rid() const { return _generated_height_maps.get_rid(); }
@@ -176,6 +178,7 @@ VARIANT_ENUM_CAST(Terrain3DData::HeightFilter);
 
 // Inline Region Functions
 
+// Structured to work with do_for_regions. Should be renamed when copy_paste is expanded
 inline void Terrain3DData::_copy_paste(const Terrain3DRegion *p_src_region, const Rect2i &p_src_rect, const Rect2i &p_dst_rect, const Terrain3DRegion *p_dst_region) {
 	if (p_src_region == nullptr || p_dst_region == nullptr) {
 		return;

--- a/src/terrain_3d_instancer.h
+++ b/src/terrain_3d_instancer.h
@@ -33,6 +33,7 @@ class Terrain3DInstancer : public Object {
 	void _destroy_mmi_by_location(const Vector2i &p_region_loc, const int p_mesh_id);
 	void _backup_regionl(const Vector2i &p_region_loc);
 	void _backup_region(const Ref<Terrain3DRegion> &p_region);
+	Ref<MultiMesh> _create_multimesh(const int p_mesh_id, const TypedArray<Transform3D> &p_xforms = TypedArray<Transform3D>(), const TypedArray<Color> &p_colors = TypedArray<Color>()) const;
 
 public:
 	Terrain3DInstancer() {}
@@ -43,13 +44,18 @@ public:
 
 	void clear_by_mesh(const int p_mesh_id);
 	void clear_by_location(const Vector2i &p_region_loc, const int p_mesh_id);
+	void clear_by_region(const Ref<Terrain3DRegion> &p_region, const int p_mesh_id);
 
 	void add_instances(const Vector3 &p_global_position, const Dictionary &p_params);
 	void remove_instances(const Vector3 &p_global_position, const Dictionary &p_params);
 	void add_multimesh(const int p_mesh_id, const Ref<MultiMesh> &p_multimesh, const Transform3D &p_xform = Transform3D());
 	void add_transforms(const int p_mesh_id, const TypedArray<Transform3D> &p_xforms, const TypedArray<Color> &p_colors = TypedArray<Color>());
-	void append_multimesh(const Vector2i &p_region_loc, const int p_mesh_id, const TypedArray<Transform3D> &p_xforms, const TypedArray<Color> &p_colors, const bool p_clear = false);
+	void append_location(const Vector2i &p_region_loc, const int p_mesh_id, const TypedArray<Transform3D> &p_xforms,
+			const TypedArray<Color> &p_colors, const bool p_clear = false, const bool p_update = true);
+	void append_region(const Ref<Terrain3DRegion> &p_region, const int p_mesh_id, const TypedArray<Transform3D> &p_xforms,
+			const TypedArray<Color> &p_colors, const bool p_clear = false, const bool p_update = true);
 	void update_transforms(const AABB &p_aabb);
+	void copy_paste_dfr(const Terrain3DRegion *p_src_region, const Rect2 &p_src_rect, const Terrain3DRegion *p_dst_region);
 
 	void swap_ids(const int p_src_id, const int p_dst_id);
 	Ref<MultiMesh> get_multimeshp(const Vector3 &p_global_position, const int p_mesh_id) const;

--- a/src/terrain_3d_region.h
+++ b/src/terrain_3d_region.h
@@ -65,7 +65,7 @@ public:
 
 	void set_version(const real_t p_version);
 	real_t get_version() const { return _version; }
-	void set_region_size(const int p_region_size) { _region_size = CLAMP(p_region_size, 1024, 1024); }
+	void set_region_size(const int p_region_size) { _region_size = CLAMP(p_region_size, 64, 2048); }
 	int get_region_size() const { return _region_size; }
 
 	// Maps

--- a/src/terrain_3d_util.h
+++ b/src/terrain_3d_util.h
@@ -40,14 +40,13 @@ public:
 			const bool p_create_mipmaps = true,
 			const Image::Format p_format = Image::FORMAT_MAX);
 	static Ref<Image> load_image(const String &p_file_name, const int p_cache_mode = ResourceLoader::CACHE_MODE_IGNORE,
-	const Vector2 &p_r16_height_range = Vector2(0.f, 255.f), const Vector2i &p_r16_size = V2I_ZERO);
+			const Vector2 &p_r16_height_range = Vector2(0.f, 255.f), const Vector2i &p_r16_size = V2I_ZERO);
 	static Ref<Image> pack_image(const Ref<Image> &p_src_rgb,
 			const Ref<Image> &p_src_a,
 			const bool p_invert_green = false,
 			const bool p_invert_alpha = false,
 			const int p_alpha_channel = 0);
 	static Ref<Image> luminance_to_height(const Ref<Image> &p_src_rgb);
-
 
 protected:
 	static void _bind_methods();
@@ -72,6 +71,35 @@ T round_multiple(const T p_value, const T p_multiple) {
 
 inline bool is_power_of_2(const int p_n) {
 	return p_n && !(p_n & (p_n - 1));
+}
+
+// Integer division with rounding up, down, nearest
+// https : //stackoverflow.com/questions/2422712/rounding-integer-division-instead-of-truncating/58568736#58568736
+#define V2I_DIVIDE_CEIL(v, f) Vector2i(int_divide_ceil(v.x, f), int_divide_ceil(v.y, f))
+#define V2I_DIVIDE_FLOOR(v, f) Vector2i(int_divide_floor(v.x, f), int_divide_floor(v.y, f))
+
+// Integer division rounding up
+template <typename T>
+T int_divide_ceil(T numer, T denom) {
+	static_assert(std::numeric_limits<T>::is_integer, "Only integer types are allowed");
+	T result = ((numer) < 0) != ((denom) < 0) ? (numer) / (denom) : ((numer) + ((denom) < 0 ? (denom) + 1 : (denom)-1)) / (denom);
+	return result;
+}
+
+// Integer division rounding down
+template <typename T>
+T int_divide_floor(T numer, T denom) {
+	static_assert(std::numeric_limits<T>::is_integer, "Only integer types are allowed");
+	T result = ((numer) < 0) != ((denom) < 0) ? ((numer) - ((denom) < 0 ? (denom) + 1 : (denom)-1)) / (denom) : (numer) / (denom);
+	return result;
+}
+
+// Integer division rounding to nearest int
+template <typename T>
+T int_divide_round(T numer, T denom) {
+	static_assert(std::numeric_limits<T>::is_integer, "Only integer types are allowed");
+	T result = ((numer) < 0) != ((denom) < 0) ? ((numer) - ((denom) / 2)) / (denom) : ((numer) + ((denom) / 2)) / (denom);
+	return result;
 }
 
 // Returns the bilinearly interpolated value derived from parameters:


### PR DESCRIPTION
# Update by TokisanGames

Fixes #77
Fixes #487 

- [x] Enable changing region sizes, reslicing data (by Dekker3D)
- [x] Change do_for_regions to work with Callables for all language support
- [x] Region size is set automatically from the first loaded file
- [x] Add a UI for changing region size
- [x] Bug: occasionally reports regions are missing upon saving. They are null. See https://github.com/TokisanGames/Terrain3D/pull/447#issuecomment-2353416445
- [x] Bug: Some sequences produce regions that are not blank but have data copied from other regions See https://github.com/TokisanGames/Terrain3D/pull/447#issuecomment-2350957671
- [x] Bug: Heights and AABBs are messed up after slicing.
- [x] Bug: Occasionally prints a get_dependencies error See https://github.com/TokisanGames/Terrain3D/pull/447#issuecomment-2350957671
- [x] Bug: Cannot go from 2 adjacent squares to the next size higher or that square disappears. Must have kitty-corner squares to fill in the blanks.
- [x] Foliage needs to be sliced and moved as well. Currently it is deleted.
- [x] Bug: Cannot import upgrade files then change region size or terrain disappears. Must save first, then reload the scene before region size can be changed. 

----
# Original PR

This should fix #77, and I haven't been able to spot any remaining issues regarding different region sizes. Regions are resized when you change the size, so if you have smaller regions that don't fully fill up a larger region when you change to a larger size, the other parts of that region will get default values.

The code for resizing is a little ugly (much uglier when sizing up, rather than down) and probably not very well optimized, but it works, and people are unlikely to change region sizes so often that it's a show-stopper.