### PR TITLE
Fix crash when selecting after pressing Escape

### DIFF
--- a/project/addons/terrain_3d/src/ui.gd
+++ b/project/addons/terrain_3d/src/ui.gd
@@ -264,6 +264,10 @@ func update_decal() -> void:
 		await get_tree().create_timer(.05).timeout 
 		decal.visible = true
 
+	if not plugin.terrain:
+		_on_tool_changed(last_tool, last_operation)
+		return
+
 	decal.size = Vector3.ONE * brush_data["size"]
 	if brush_data["align_to_view"]:
 		var cam: Camera3D = plugin.terrain.get_camera();


### PR DESCRIPTION
A proper fix would be to find what part of `_on_tool_changed` undoes the state that makes the crash happen, but for now this fixes the crash and those post await errors.
