### PR TITLE
Optimizations

### DIFF
--- a/project/addons/terrain_3d/src/ui.gd
+++ b/project/addons/terrain_3d/src/ui.gd
@@ -309,7 +309,7 @@ func _invert_operation(p_operation: Terrain3DEditor.Operation, flags: int = OP_N
 
 
 func update_decal() -> void:
-	if not plugin.terrain or brush_data.is_empty():
+	if not plugin.terrain or brush_data.size() <= 3:
 		return
 	mat_rid = plugin.terrain.material.get_material_rid()
 	editor_decal_timer.start()

--- a/src/constants.h
+++ b/src/constants.h
@@ -61,48 +61,48 @@ using namespace godot;
 
 #define VOID // a return value for void, to avoid compiler warnings
 
-#define IS_INIT(ret)           \
-	if (_terrain == nullptr) { \
-		return ret;            \
+#define IS_INIT(ret) \
+	if (!_terrain) { \
+		return ret;  \
 	}
 
 #define IS_INIT_MESG(mesg, ret) \
-	if (_terrain == nullptr) {  \
+	if (!_terrain) {            \
 		LOG(ERROR, mesg);       \
 		return ret;             \
 	}
 
-#define IS_INIT_COND(cond, ret)        \
-	if (_terrain == nullptr || cond) { \
-		return ret;                    \
+#define IS_INIT_COND(cond, ret) \
+	if (!_terrain || cond) {    \
+		return ret;             \
 	}
 
 #define IS_INIT_COND_MESG(cond, mesg, ret) \
-	if (_terrain == nullptr || cond) {     \
+	if (!_terrain || cond) {               \
 		LOG(ERROR, mesg);                  \
 		return ret;                        \
 	}
 
-#define IS_INSTANCER_INIT(ret)                                         \
-	if (_terrain == nullptr || _terrain->get_instancer() == nullptr) { \
-		return ret;                                                    \
+#define IS_INSTANCER_INIT(ret)                     \
+	if (!_terrain || !_terrain->get_instancer()) { \
+		return ret;                                \
 	}
 
-#define IS_INSTANCER_INIT_MESG(mesg, ret)                              \
-	if (_terrain == nullptr || _terrain->get_instancer() == nullptr) { \
-		LOG(ERROR, mesg);                                              \
-		return ret;                                                    \
+#define IS_INSTANCER_INIT_MESG(mesg, ret)          \
+	if (!_terrain || !_terrain->get_instancer()) { \
+		LOG(ERROR, mesg);                          \
+		return ret;                                \
 	}
 
-#define IS_DATA_INIT(ret)                                         \
-	if (_terrain == nullptr || _terrain->get_data() == nullptr) { \
-		return ret;                                               \
+#define IS_DATA_INIT(ret)                     \
+	if (!_terrain || !_terrain->get_data()) { \
+		return ret;                           \
 	}
 
-#define IS_DATA_INIT_MESG(mesg, ret)                              \
-	if (_terrain == nullptr || _terrain->get_data() == nullptr) { \
-		LOG(ERROR, mesg);                                         \
-		return ret;                                               \
+#define IS_DATA_INIT_MESG(mesg, ret)          \
+	if (!_terrain || !_terrain->get_data()) { \
+		LOG(ERROR, mesg);                     \
+		return ret;                           \
 	}
 
 // Global Types

--- a/src/terrain_3d.h
+++ b/src/terrain_3d.h
@@ -129,7 +129,7 @@ public:
 	void set_debug_level(const int p_level);
 	int get_debug_level() const { return debug_level; }
 	void set_data_directory(String p_dir);
-	String get_data_directory() const { return (_data == nullptr) ? "" : _data_directory; }
+	String get_data_directory() const { return _data ? _data_directory : ""; }
 
 	// Object references
 	Terrain3DData *get_data() const { return _data; }
@@ -150,7 +150,7 @@ public:
 	// Regions
 	void set_region_size(const RegionSize p_size);
 	RegionSize get_region_size() const { return _region_size; }
-	void change_region_size(const RegionSize p_size) { (_data != nullptr) ? _data->change_region_size(p_size) : void(); }
+	void change_region_size(const RegionSize p_size) { _data ? _data->change_region_size(p_size) : void(); }
 	void set_save_16_bit(const bool p_enabled);
 	bool get_save_16_bit() const { return _save_16_bit; }
 	void set_label_distance(const real_t p_distance);
@@ -198,56 +198,56 @@ public:
 	PackedStringArray _get_configuration_warnings() const override;
 
 	// Collision Aliases
-	void set_collision_mode(const CollisionMode p_mode) { (_collision != nullptr) ? _collision->set_mode(p_mode) : void(); }
-	CollisionMode get_collision_mode() const { return (_collision != nullptr) ? _collision->get_mode() : CollisionMode::DYNAMIC_GAME; }
-	void set_collision_shape_size(const uint16_t p_size) { (_collision != nullptr) ? _collision->set_shape_size(p_size) : void(); }
-	uint16_t get_collision_shape_size() const { return (_collision != nullptr) ? _collision->get_shape_size() : 16; }
-	void set_collision_radius(const uint16_t p_radius) { (_collision != nullptr) ? _collision->set_radius(p_radius) : void(); }
-	uint16_t get_collision_radius() const { return (_collision != nullptr) ? _collision->get_radius() : 64; }
-	void set_collision_layer(const uint32_t p_layers) { (_collision != nullptr) ? _collision->set_layer(p_layers) : void(); }
-	uint32_t get_collision_layer() const { return (_collision != nullptr) ? _collision->get_layer() : 1; }
-	void set_collision_mask(const uint32_t p_mask) { (_collision != nullptr) ? _collision->set_mask(p_mask) : void(); }
-	uint32_t get_collision_mask() const { return (_collision != nullptr) ? _collision->get_mask() : 1; }
-	void set_collision_priority(const real_t p_priority) { (_collision != nullptr) ? _collision->set_priority(p_priority) : void(); }
-	real_t get_collision_priority() const { return (_collision != nullptr) ? _collision->get_priority() : 1.f; }
-	void set_physics_material(const Ref<PhysicsMaterial> &p_mat) { (_collision != nullptr) ? _collision->set_physics_material(p_mat) : void(); }
-	Ref<PhysicsMaterial> get_physics_material() const { return (_collision != nullptr) ? _collision->get_physics_material() : Ref<PhysicsMaterial>(); }
+	void set_collision_mode(const CollisionMode p_mode) { _collision ? _collision->set_mode(p_mode) : void(); }
+	CollisionMode get_collision_mode() const { return _collision ? _collision->get_mode() : CollisionMode::DYNAMIC_GAME; }
+	void set_collision_shape_size(const uint16_t p_size) { _collision ? _collision->set_shape_size(p_size) : void(); }
+	uint16_t get_collision_shape_size() const { return _collision ? _collision->get_shape_size() : 16; }
+	void set_collision_radius(const uint16_t p_radius) { _collision ? _collision->set_radius(p_radius) : void(); }
+	uint16_t get_collision_radius() const { return _collision ? _collision->get_radius() : 64; }
+	void set_collision_layer(const uint32_t p_layers) { _collision ? _collision->set_layer(p_layers) : void(); }
+	uint32_t get_collision_layer() const { return _collision ? _collision->get_layer() : 1; }
+	void set_collision_mask(const uint32_t p_mask) { _collision ? _collision->set_mask(p_mask) : void(); }
+	uint32_t get_collision_mask() const { return _collision ? _collision->get_mask() : 1; }
+	void set_collision_priority(const real_t p_priority) { _collision ? _collision->set_priority(p_priority) : void(); }
+	real_t get_collision_priority() const { return _collision ? _collision->get_priority() : 1.f; }
+	void set_physics_material(const Ref<PhysicsMaterial> &p_mat) { _collision ? _collision->set_physics_material(p_mat) : void(); }
+	Ref<PhysicsMaterial> get_physics_material() const { return _collision ? _collision->get_physics_material() : Ref<PhysicsMaterial>(); }
 
 	// Debug View Aliases
-	void set_show_checkered(const bool p_enabled) { (_material != nullptr) ? _material->set_show_checkered(p_enabled) : void(); }
-	bool get_show_checkered() const { return (_material != nullptr) ? _material->get_show_checkered() : false; }
-	void set_show_grey(const bool p_enabled) { (_material != nullptr) ? _material->set_show_grey(p_enabled) : void(); }
-	bool get_show_grey() const { return (_material != nullptr) ? _material->get_show_grey() : false; }
-	void set_show_heightmap(const bool p_enabled) { (_material != nullptr) ? _material->set_show_heightmap(p_enabled) : void(); }
-	bool get_show_heightmap() const { return (_material != nullptr) ? _material->get_show_heightmap() : false; }
-	void set_show_colormap(const bool p_enabled) { (_material != nullptr) ? _material->set_show_colormap(p_enabled) : void(); }
-	bool get_show_colormap() const { return (_material != nullptr) ? _material->get_show_colormap() : false; }
-	void set_show_roughmap(const bool p_enabled) { (_material != nullptr) ? _material->set_show_roughmap(p_enabled) : void(); }
-	bool get_show_roughmap() const { return (_material != nullptr) ? _material->get_show_roughmap() : false; }
-	void set_show_control_texture(const bool p_enabled) { (_material != nullptr) ? _material->set_show_control_texture(p_enabled) : void(); }
-	bool get_show_control_texture() const { return (_material != nullptr) ? _material->get_show_control_texture() : false; }
-	void set_show_control_angle(const bool p_enabled) { (_material != nullptr) ? _material->set_show_control_angle(p_enabled) : void(); }
-	bool get_show_control_angle() const { return (_material != nullptr) ? _material->get_show_control_angle() : false; }
-	void set_show_control_scale(const bool p_enabled) { (_material != nullptr) ? _material->set_show_control_scale(p_enabled) : void(); }
-	bool get_show_control_scale() const { return (_material != nullptr) ? _material->get_show_control_scale() : false; }
-	void set_show_control_blend(const bool p_enabled) { (_material != nullptr) ? _material->set_show_control_blend(p_enabled) : void(); }
-	bool get_show_control_blend() const { return (_material != nullptr) ? _material->get_show_control_blend() : false; }
-	void set_show_autoshader(const bool p_enabled) { (_material != nullptr) ? _material->set_show_autoshader(p_enabled) : void(); }
-	bool get_show_autoshader() const { return (_material != nullptr) ? _material->get_show_autoshader() : false; }
-	void set_show_navigation(const bool p_enabled) { (_material != nullptr) ? _material->set_show_navigation(p_enabled) : void(); }
-	bool get_show_navigation() const { return (_material != nullptr) ? _material->get_show_navigation() : false; }
-	void set_show_texture_height(const bool p_enabled) { (_material != nullptr) ? _material->set_show_texture_height(p_enabled) : void(); }
-	bool get_show_texture_height() const { return (_material != nullptr) ? _material->get_show_texture_height() : false; }
-	void set_show_texture_normal(const bool p_enabled) { (_material != nullptr) ? _material->set_show_texture_normal(p_enabled) : void(); }
-	bool get_show_texture_normal() const { return (_material != nullptr) ? _material->get_show_texture_normal() : false; }
-	void set_show_texture_rough(const bool p_enabled) { (_material != nullptr) ? _material->set_show_texture_rough(p_enabled) : void(); }
-	bool get_show_texture_rough() const { return (_material != nullptr) ? _material->get_show_texture_rough() : false; }
-	void set_show_region_grid(const bool p_enabled) { (_material != nullptr) ? _material->set_show_region_grid(p_enabled) : void(); }
-	bool get_show_region_grid() const { return (_material != nullptr) ? _material->get_show_region_grid() : false; }
-	void set_show_instancer_grid(const bool p_enabled) { (_material != nullptr) ? _material->set_show_instancer_grid(p_enabled) : void(); }
-	bool get_show_instancer_grid() const { return (_material != nullptr) ? _material->get_show_instancer_grid() : false; }
-	void set_show_vertex_grid(const bool p_enabled) { (_material != nullptr) ? _material->set_show_vertex_grid(p_enabled) : void(); }
-	bool get_show_vertex_grid() const { return (_material != nullptr) ? _material->get_show_vertex_grid() : false; }
+	void set_show_checkered(const bool p_enabled) { _material.is_valid() ? _material->set_show_checkered(p_enabled) : void(); }
+	bool get_show_checkered() const { return _material.is_valid() ? _material->get_show_checkered() : false; }
+	void set_show_grey(const bool p_enabled) { _material.is_valid() ? _material->set_show_grey(p_enabled) : void(); }
+	bool get_show_grey() const { return _material.is_valid() ? _material->get_show_grey() : false; }
+	void set_show_heightmap(const bool p_enabled) { _material.is_valid() ? _material->set_show_heightmap(p_enabled) : void(); }
+	bool get_show_heightmap() const { return _material.is_valid() ? _material->get_show_heightmap() : false; }
+	void set_show_colormap(const bool p_enabled) { _material.is_valid() ? _material->set_show_colormap(p_enabled) : void(); }
+	bool get_show_colormap() const { return _material.is_valid() ? _material->get_show_colormap() : false; }
+	void set_show_roughmap(const bool p_enabled) { _material.is_valid() ? _material->set_show_roughmap(p_enabled) : void(); }
+	bool get_show_roughmap() const { return _material.is_valid() ? _material->get_show_roughmap() : false; }
+	void set_show_control_texture(const bool p_enabled) { _material.is_valid() ? _material->set_show_control_texture(p_enabled) : void(); }
+	bool get_show_control_texture() const { return _material.is_valid() ? _material->get_show_control_texture() : false; }
+	void set_show_control_angle(const bool p_enabled) { _material.is_valid() ? _material->set_show_control_angle(p_enabled) : void(); }
+	bool get_show_control_angle() const { return _material.is_valid() ? _material->get_show_control_angle() : false; }
+	void set_show_control_scale(const bool p_enabled) { _material.is_valid() ? _material->set_show_control_scale(p_enabled) : void(); }
+	bool get_show_control_scale() const { return _material.is_valid() ? _material->get_show_control_scale() : false; }
+	void set_show_control_blend(const bool p_enabled) { _material.is_valid() ? _material->set_show_control_blend(p_enabled) : void(); }
+	bool get_show_control_blend() const { return _material.is_valid() ? _material->get_show_control_blend() : false; }
+	void set_show_autoshader(const bool p_enabled) { _material.is_valid() ? _material->set_show_autoshader(p_enabled) : void(); }
+	bool get_show_autoshader() const { return _material.is_valid() ? _material->get_show_autoshader() : false; }
+	void set_show_navigation(const bool p_enabled) { _material.is_valid() ? _material->set_show_navigation(p_enabled) : void(); }
+	bool get_show_navigation() const { return _material.is_valid() ? _material->get_show_navigation() : false; }
+	void set_show_texture_height(const bool p_enabled) { _material.is_valid() ? _material->set_show_texture_height(p_enabled) : void(); }
+	bool get_show_texture_height() const { return _material.is_valid() ? _material->get_show_texture_height() : false; }
+	void set_show_texture_normal(const bool p_enabled) { _material.is_valid() ? _material->set_show_texture_normal(p_enabled) : void(); }
+	bool get_show_texture_normal() const { return _material.is_valid() ? _material->get_show_texture_normal() : false; }
+	void set_show_texture_rough(const bool p_enabled) { _material.is_valid() ? _material->set_show_texture_rough(p_enabled) : void(); }
+	bool get_show_texture_rough() const { return _material.is_valid() ? _material->get_show_texture_rough() : false; }
+	void set_show_region_grid(const bool p_enabled) { _material.is_valid() ? _material->set_show_region_grid(p_enabled) : void(); }
+	bool get_show_region_grid() const { return _material.is_valid() ? _material->get_show_region_grid() : false; }
+	void set_show_instancer_grid(const bool p_enabled) { _material.is_valid() ? _material->set_show_instancer_grid(p_enabled) : void(); }
+	bool get_show_instancer_grid() const { return _material.is_valid() ? _material->get_show_instancer_grid() : false; }
+	void set_show_vertex_grid(const bool p_enabled) { _material.is_valid() ? _material->set_show_vertex_grid(p_enabled) : void(); }
+	bool get_show_vertex_grid() const { return _material.is_valid() ? _material->get_show_vertex_grid() : false; }
 
 protected:
 	void _notification(const int p_what);

--- a/src/terrain_3d_collision.cpp
+++ b/src/terrain_3d_collision.cpp
@@ -160,7 +160,7 @@ void Terrain3DCollision::_shape_set_data(const int p_shape_id, const Dictionary 
 
 void Terrain3DCollision::_reload_physics_material() {
 	if (is_editor_mode()) {
-		if (_static_body != nullptr) {
+		if (_static_body) {
 			_static_body->set_physics_material_override(_physics_material);
 		}
 	} else {
@@ -198,7 +198,7 @@ void Terrain3DCollision::initialize(Terrain3D *p_terrain) {
 }
 
 void Terrain3DCollision::build() {
-	if (_terrain == nullptr) {
+	if (!_terrain) {
 		LOG(DEBUG, "Build called before terrain initialized. Returning.");
 		return;
 	}
@@ -435,7 +435,7 @@ void Terrain3DCollision::destroy() {
 		memdelete_safely(shape);
 	}
 	_shapes.clear();
-	if (_static_body != nullptr) {
+	if (_static_body) {
 		LOG(DEBUG, "Freeing StaticBody3D");
 		remove_from_tree(_static_body);
 		memdelete_safely(_static_body);
@@ -486,7 +486,7 @@ void Terrain3DCollision::set_layer(const uint32_t p_layers) {
 	LOG(INFO, "Setting collision layers: ", p_layers);
 	_layer = p_layers;
 	if (is_editor_mode()) {
-		if (_static_body != nullptr) {
+		if (_static_body) {
 			_static_body->set_collision_layer(_layer);
 		}
 	} else {
@@ -500,7 +500,7 @@ void Terrain3DCollision::set_mask(const uint32_t p_mask) {
 	LOG(INFO, "Setting collision mask: ", p_mask);
 	_mask = p_mask;
 	if (is_editor_mode()) {
-		if (_static_body != nullptr) {
+		if (_static_body) {
 			_static_body->set_collision_mask(_mask);
 		}
 	} else {
@@ -514,7 +514,7 @@ void Terrain3DCollision::set_priority(const real_t p_priority) {
 	LOG(INFO, "Setting collision priority: ", p_priority);
 	_priority = p_priority;
 	if (is_editor_mode()) {
-		if (_static_body != nullptr) {
+		if (_static_body) {
 			_static_body->set_collision_priority(_priority);
 		}
 	} else {
@@ -544,7 +544,7 @@ RID Terrain3DCollision::get_rid() const {
 	if (!is_editor_mode()) {
 		return _static_body_rid;
 	} else {
-		if (_static_body != nullptr) {
+		if (_static_body) {
 			return _static_body->get_rid();
 		}
 	}

--- a/src/terrain_3d_data.cpp
+++ b/src/terrain_3d_data.cpp
@@ -624,7 +624,7 @@ Color Terrain3DData::get_pixel(const MapType p_map_type, const Vector3 &p_global
 	Vector3 descaled_pos = p_global_position / _vertex_spacing;
 	Vector2i img_pos = Vector2i(descaled_pos.x - global_offset.x, descaled_pos.z - global_offset.y);
 	img_pos = img_pos.clamp(V2I_ZERO, Vector2i(_region_size - 1, _region_size - 1));
-	Ref<Image> map = region->get_map(p_map_type);
+	Image *map = region->get_map_ptr(p_map_type);
 	return map->get_pixelv(img_pos);
 }
 
@@ -638,7 +638,7 @@ real_t Terrain3DData::get_height(const Vector3 &p_global_position) const {
 	// Round to nearest vertex
 	Vector3 pos_round = pos.snapped(Vector3(step, 0.f, step));
 	// If requested position is close to a vertex, return its height
-	if ((pos - pos_round).length() < 0.01f) {
+	if ((pos - pos_round).length_squared() < 0.0001f) {
 		return get_pixel(TYPE_HEIGHT, pos).r;
 	} else {
 		// Otherwise, bilinearly interpolate 4 surrounding vertices

--- a/src/terrain_3d_data.h
+++ b/src/terrain_3d_data.h
@@ -104,6 +104,7 @@ public:
 	bool has_region(const Vector2i &p_region_loc) const { return get_region_id(p_region_loc) != -1; }
 	bool has_regionp(const Vector3 &p_global_position) const { return get_region_idp(p_global_position) != -1; }
 	Ref<Terrain3DRegion> get_region(const Vector2i &p_region_loc) const;
+	Terrain3DRegion *get_region_ptr(const Vector2i &p_region_loc) const;
 	Ref<Terrain3DRegion> get_regionp(const Vector3 &p_global_position) const;
 
 	void set_region_modified(const Vector2i &p_region_loc, const bool p_modified = true);
@@ -234,6 +235,13 @@ inline int Terrain3DData::get_region_idp(const Vector3 &p_global_position) const
 
 inline Ref<Terrain3DRegion> Terrain3DData::get_region(const Vector2i &p_region_loc) const {
 	return _regions.get(p_region_loc, Ref<Terrain3DRegion>());
+}
+
+inline Terrain3DRegion *Terrain3DData::get_region_ptr(const Vector2i &p_region_loc) const {
+	if (has_region(p_region_loc)) {
+		return cast_to<Terrain3DRegion>(_regions[p_region_loc]);
+	}
+	return nullptr;
 }
 
 inline Ref<Terrain3DRegion> Terrain3DData::get_regionp(const Vector3 &p_global_position) const {

--- a/src/terrain_3d_editor.h
+++ b/src/terrain_3d_editor.h
@@ -86,7 +86,7 @@ private:
 	uint64_t _last_pen_tick = 0;
 
 	void _send_region_aabb(const Vector2i &p_region_loc, const Vector2 &p_height_range = Vector2());
-	Ref<Terrain3DRegion> _operate_region(const Vector2i &p_region_loc);
+	Terrain3DRegion *_operate_region(const Vector2i &p_region_loc);
 	void _operate_map(const Vector3 &p_global_position, const real_t p_camera_direction);
 	MapType _get_map_type() const;
 	bool _is_in_bounds(const Point2i &p_pixel, const Point2i &p_size) const;

--- a/src/terrain_3d_instancer.cpp
+++ b/src/terrain_3d_instancer.cpp
@@ -27,8 +27,8 @@ void Terrain3DInstancer::_update_mmis(const Vector2i &p_region_loc, const int p_
 	}
 	for (int r = 0; r < region_locations.size(); r++) {
 		Vector2i region_loc = region_locations[r];
-		Ref<Terrain3DRegion> region = _terrain->get_data()->get_region(region_loc);
-		if (region.is_null()) {
+		Terrain3DRegion *region = _terrain->get_data()->get_region_ptr(region_loc);
+		if (!region) {
 			LOG(WARN, "Errant null region found at: ", region_loc);
 			continue;
 		}
@@ -122,7 +122,7 @@ void Terrain3DInstancer::_update_mmis(const Vector2i &p_region_loc, const int p_
 
 						//Attach to tree
 						Node *node_container = _terrain->get_mmi_parent()->get_node_internal(rname);
-						if (node_container == nullptr) {
+						if (!node_container) {
 							LOG(ERROR, rname, " isn't attached to the tree.");
 							continue;
 						}
@@ -180,7 +180,7 @@ void Terrain3DInstancer::_update_mmis(const Vector2i &p_region_loc, const int p_
 }
 
 void Terrain3DInstancer::_setup_mmi_lod_ranges(MultiMeshInstance3D *p_mmi, const Ref<Terrain3DMeshAsset> &p_ma, const int p_lod) {
-	if (p_mmi == nullptr || p_ma.is_null()) {
+	if (!p_mmi || p_ma.is_null()) {
 		return;
 	}
 	real_t margin = p_ma->get_fade_margin();
@@ -205,8 +205,8 @@ void Terrain3DInstancer::_update_vertex_spacing(const real_t p_vertex_spacing) {
 	Array region_locations = _terrain->get_data()->get_region_locations();
 	for (int r = 0; r < region_locations.size(); r++) {
 		Vector2i region_loc = region_locations[r];
-		Ref<Terrain3DRegion> region = _terrain->get_data()->get_region(region_loc);
-		if (region.is_null()) {
+		Terrain3DRegion *region = _terrain->get_data()->get_region_ptr(region_loc);
+		if (!region) {
 			LOG(WARN, "Errant null region found at: ", region_loc);
 			continue;
 		}
@@ -321,14 +321,14 @@ void Terrain3DInstancer::_destroy_mmi_by_location(const Vector2i &p_region_loc, 
 }
 
 void Terrain3DInstancer::_backup_regionl(const Vector2i &p_region_loc) {
-	if (_terrain->get_data() != nullptr) {
+	if (_terrain && _terrain->get_data()) {
 		Ref<Terrain3DRegion> region = _terrain->get_data()->get_region(p_region_loc);
 		_backup_region(region);
 	}
 }
 
 void Terrain3DInstancer::_backup_region(const Ref<Terrain3DRegion> &p_region) {
-	if (_terrain->get_editor() != nullptr) {
+	if (_terrain && _terrain->get_editor()) {
 		_terrain->get_editor()->backup_region(p_region);
 	} else {
 		p_region->set_modified(true);
@@ -589,7 +589,11 @@ void Terrain3DInstancer::remove_instances(const Vector3 &p_global_position, cons
 
 	for (int r = 0; r < region_queue.size(); r++) {
 		Vector2i region_loc = region_queue[r];
-		Ref<Terrain3DRegion> region = data->get_region(region_loc);
+		Terrain3DRegion *region = data->get_region_ptr(region_loc);
+		if (!region) {
+			LOG(WARN, "Errant null region found at: ", region_loc);
+			continue;
+		}
 
 		Dictionary mesh_inst_dict = region->get_instances();
 		Array mesh_types = mesh_inst_dict.keys();
@@ -940,7 +944,7 @@ void Terrain3DInstancer::update_transforms(const AABB &p_aabb) {
 // p_src_rect is the vertex/pixel offset into the region data, NOT a global position
 // Need to force_update_mmis() after
 void Terrain3DInstancer::copy_paste_dfr(const Terrain3DRegion *p_src_region, const Rect2i &p_src_rect, const Terrain3DRegion *p_dst_region) {
-	if (p_src_region == nullptr || p_dst_region == nullptr) {
+	if (!p_src_region || !p_dst_region) {
 		LOG(ERROR, "Source (", p_src_region, ") or destination (", p_dst_region, ") regions are null");
 		return;
 	}

--- a/src/terrain_3d_material.cpp
+++ b/src/terrain_3d_material.cpp
@@ -566,7 +566,7 @@ void Terrain3DMaterial::_set_shader_parameters(const Dictionary &p_dict) {
 // Godot likes to create resource objects at startup, so this prevents it from creating
 // uninitialized materials.
 void Terrain3DMaterial::initialize(Terrain3D *p_terrain) {
-	if (p_terrain != nullptr) {
+	if (p_terrain) {
 		_terrain = p_terrain;
 	} else {
 		LOG(ERROR, "Initialization failed, p_terrain is null");

--- a/src/terrain_3d_material.h
+++ b/src/terrain_3d_material.h
@@ -87,7 +87,7 @@ public:
 
 	void update();
 	RID get_material_rid() const { return _material; }
-	RID get_shader_rid() const { return _shader->get_rid(); }
+	RID get_shader_rid() const { return _shader.is_valid() ? _shader->get_rid() : RID(); }
 
 	// Material settings
 	void set_world_background(const WorldBackground p_background);

--- a/src/terrain_3d_mesh_asset.cpp
+++ b/src/terrain_3d_mesh_asset.cpp
@@ -169,7 +169,7 @@ void Terrain3DMeshAsset::set_scene_file(const Ref<PackedScene> &p_scene_file) {
 	_meshes.clear();
 	if (_packed_scene.is_valid()) {
 		Node *node = _packed_scene->instantiate();
-		if (node == nullptr) {
+		if (!node) {
 			LOG(ERROR, "Drag a non-empty glb, fbx, scn, or tscn file into the scene_file slot");
 			_packed_scene.unref();
 			return;

--- a/src/terrain_3d_region.cpp
+++ b/src/terrain_3d_region.cpp
@@ -54,6 +54,23 @@ Ref<Image> Terrain3DRegion::get_map(const MapType p_map_type) const {
 	}
 }
 
+Image *Terrain3DRegion::get_map_ptr(const MapType p_map_type) const {
+	switch (p_map_type) {
+		case TYPE_HEIGHT:
+			return *_height_map;
+			break;
+		case TYPE_CONTROL:
+			return *_control_map;
+			break;
+		case TYPE_COLOR:
+			return *_color_map;
+			break;
+		default:
+			LOG(ERROR, "Requested map type is invalid");
+			return nullptr;
+	}
+}
+
 void Terrain3DRegion::set_maps(const TypedArray<Image> &p_maps) {
 	if (p_maps.size() != TYPE_MAX) {
 		LOG(ERROR, "Expected ", TYPE_MAX - 1, " maps. Received ", p_maps.size());

--- a/src/terrain_3d_region.cpp
+++ b/src/terrain_3d_region.cpp
@@ -41,15 +41,12 @@ Ref<Image> Terrain3DRegion::get_map(const MapType p_map_type) const {
 	switch (p_map_type) {
 		case TYPE_HEIGHT:
 			return get_height_map();
-			break;
 		case TYPE_CONTROL:
 			return get_control_map();
-			break;
 		case TYPE_COLOR:
 			return get_color_map();
-			break;
 		default:
-			LOG(ERROR, "Requested map type is invalid");
+			LOG(ERROR, "Requested map type ", p_map_type, ", is invalid");
 			return Ref<Image>();
 	}
 }
@@ -58,15 +55,12 @@ Image *Terrain3DRegion::get_map_ptr(const MapType p_map_type) const {
 	switch (p_map_type) {
 		case TYPE_HEIGHT:
 			return *_height_map;
-			break;
 		case TYPE_CONTROL:
 			return *_control_map;
-			break;
 		case TYPE_COLOR:
 			return *_color_map;
-			break;
 		default:
-			LOG(ERROR, "Requested map type is invalid");
+			LOG(ERROR, "Requested map type ", p_map_type, ", is invalid");
 			return nullptr;
 	}
 }

--- a/src/terrain_3d_region.h
+++ b/src/terrain_3d_region.h
@@ -72,6 +72,7 @@ public:
 	// Maps
 	void set_map(const MapType p_map_type, const Ref<Image> &p_image);
 	Ref<Image> get_map(const MapType p_map_type) const;
+	Image *get_map_ptr(const MapType p_map_type) const;
 	void set_maps(const TypedArray<Image> &p_maps);
 	TypedArray<Image> get_maps() const;
 	void set_height_map(const Ref<Image> &p_map);

--- a/src/terrain_3d_util.cpp
+++ b/src/terrain_3d_util.cpp
@@ -2,6 +2,7 @@
 
 #include <godot_cpp/classes/engine.hpp>
 #include <godot_cpp/classes/file_access.hpp>
+#include <godot_cpp/classes/time.hpp>
 
 #include "logger.h"
 #include "terrain_3d_util.h"
@@ -420,6 +421,40 @@ Ref<Image> Terrain3DUtil::luminance_to_height(const Ref<Image> &p_src_rgb) {
 		}
 	}
 	return dst;
+}
+
+void Terrain3DUtil::benchmark(Terrain3D *p_terrain) {
+	if (!p_terrain) {
+		return;
+	}
+	Terrain3DData *data = p_terrain->get_data();
+	if (!data) {
+		return;
+	}
+	uint64_t start_time;
+	Vector3 vec;
+	for (int i = 0; i < 3; i++) {
+		start_time = Time::get_singleton()->get_ticks_msec();
+		for (uint32_t j = 0; j < 10000000; j++) {
+			data->get_pixel(TYPE_HEIGHT, vec);
+		}
+		LOG(MESG, "get_pixel() 10M: ", Time::get_singleton()->get_ticks_msec() - start_time, "ms");
+	}
+
+	vec = Vector3(0.5f, 0.f, 0.5f);
+	for (int i = 0; i < 3; i++) {
+		start_time = Time::get_singleton()->get_ticks_msec();
+		for (uint32_t j = 0; j < 1000000; j++) {
+			data->get_height(vec);
+		}
+		LOG(MESG, "get_height() 1M interpolated: ", Time::get_singleton()->get_ticks_msec() - start_time, "ms");
+	}
+
+	for (int i = 0; i < 2; i++) {
+		start_time = Time::get_singleton()->get_ticks_msec();
+		p_terrain->bake_mesh(0);
+		LOG(MESG, "Bake ArrayMesh: ", Time::get_singleton()->get_ticks_msec() - start_time, "ms");
+	}
 }
 
 ///////////////////////////

--- a/src/terrain_3d_util.h
+++ b/src/terrain_3d_util.h
@@ -50,6 +50,7 @@ public:
 			const bool p_invert_alpha = false,
 			const int p_alpha_channel = 0);
 	static Ref<Image> luminance_to_height(const Ref<Image> &p_src_rgb);
+	static void benchmark(Terrain3D *p_terrain);
 
 protected:
 	static void _bind_methods();
@@ -248,7 +249,7 @@ inline bool gd_is_auto(const uint32_t p_pixel) { return is_auto(p_pixel); }
 
 template <typename TType>
 _FORCE_INLINE_ bool memdelete_safely(TType *&p_ptr) {
-	if (p_ptr != nullptr) {
+	if (p_ptr) {
 		memdelete(p_ptr);
 		p_ptr = nullptr;
 		return true;
@@ -258,9 +259,9 @@ _FORCE_INLINE_ bool memdelete_safely(TType *&p_ptr) {
 
 _FORCE_INLINE_ bool remove_from_tree(Node *p_node) {
 	// Note: is_in_tree() doesn't work in Godot-cpp 4.1.3
-	if (p_node != nullptr) {
+	if (p_node) {
 		Node *parent = p_node->get_parent();
-		if (parent != nullptr) {
+		if (parent) {
 			parent->remove_child(p_node);
 			return true;
 		}
@@ -273,10 +274,10 @@ _FORCE_INLINE_ bool remove_from_tree(Node *p_node) {
 // See https://github.com/godotengine/godot-cpp/issues/1390#issuecomment-1937570699
 _FORCE_INLINE_ bool is_instance_valid(const uint64_t p_instance_id, Object *p_object = nullptr) {
 	Object *obj = ObjectDB::get_instance(p_instance_id);
-	if (p_object != nullptr) {
+	if (p_object) {
 		return p_instance_id > 0 && p_object == obj;
 	} else {
-		return p_instance_id > 0 && obj != nullptr;
+		return p_instance_id > 0 && obj;
 	}
 }
 


### PR DESCRIPTION
Admin edit
* Optimizes Terrain3DData, eg. set/get_pixel(), get_height() and more by replacing creation of Refs with pointer usage
* Meshing will be optimized in or after #622 
* Checks more pointers before using
* Consolidates nullptr checks using implicit boolean conversion
* Fixes some improper usage 


Results
```
10M get_pixel(): 2836ms => 1713ms, +39.6%
1M get_height() interpolated: 1571ms => 982ms, +37.5%
bake_mesh 3x1024: 40765ms => 34750ms, +14.8%
```

-------
This PR should cut down navigation mesh baking time by about half. Terrain3D::_generate_triangle_pair uses fewer control map lookups (-6 when p_require_nav is false, -2 if true), and Terrain3DStorage::get_pixel uses a modified private version of get_map_region that returns an Image* and skips converting it to a godot::Ref, reducing the time spent on get_pixel by about 1/3rd. This is based on the assumption that nobody will put anything other than godot::Image in the height/control/color map arrays, which should be true because they're TypedArrays and they're not directly accessible from outside the extension.

The modified version of get_map_region introduces some code duplication, and it might be good to use this modified version in other places where a Ref really isn't needed, so this PR isn't as clean as it perhaps could've been. I'm personally unlikely to even use it in my project, as it should be much faster to just directly sample the physics shapes I'm making, which can also be generated in a thread, unlike Terrain3D.