### PR TITLE
Enable use of pre-processor in the generated shader

### DIFF
--- a/src/terrain_3d_material.cpp
+++ b/src/terrain_3d_material.cpp
@@ -225,8 +225,9 @@ void Terrain3DMaterial::_update_shader() {
 		shader_rid = _shader_tmp->get_rid();
 	} else {
 		String code = _generate_shader_code();
-		RS->shader_set_code(_shader, _inject_editor_code(code));
-		shader_rid = _shader;
+		_shader_tmp->set_code(_inject_editor_code(code));
+		shader_rid = _shader_tmp->get_rid();
+		_shader = shader_rid;
 	}
 	RS->material_set_shader(_material, shader_rid);
 	LOG(DEBUG, "Material rid: ", _material, ", shader rid: ", shader_rid);
@@ -415,7 +416,6 @@ void Terrain3DMaterial::initialize(Terrain3D *p_terrain) {
 	LOG(INFO, "Initializing material");
 	_preload_shaders();
 	_material = RS->material_create();
-	_shader = RS->shader_create();
 	_shader_tmp.instantiate();
 	LOG(DEBUG, "Mat RID: ", _material, ", _shader RID: ", _shader);
 	_update_shader();
@@ -426,7 +426,6 @@ Terrain3DMaterial::~Terrain3DMaterial() {
 	IS_INIT(VOID);
 	LOG(INFO, "Destroying material");
 	RS->free_rid(_material);
-	RS->free_rid(_shader);
 	_generated_region_blend_map.clear();
 }
 

--- a/src/terrain_3d_material.h
+++ b/src/terrain_3d_material.h
@@ -34,11 +34,10 @@ private:
 	Terrain3D *_terrain = nullptr;
 
 	RID _material;
-	RID _shader;
+	Ref<Shader> _shader; // Active shader
+	Dictionary _shader_code; // All loaded shader and INSERT code
 	bool _shader_override_enabled = false;
-	Ref<Shader> _shader_override;
-	Ref<Shader> _shader_tmp;
-	Dictionary _shader_code;
+	Ref<Shader> _shader_override; // User's shader we copy code from
 	mutable TypedArray<StringName> _active_params; // All shader params in the current shader
 	mutable Dictionary _shader_params; // Public shader params saved to disk
 	GeneratedTexture _generated_region_blend_map; // 512x512 blurred image of region_map
@@ -87,7 +86,7 @@ public:
 
 	void update();
 	RID get_material_rid() const { return _material; }
-	RID get_shader_rid() const;
+	RID get_shader_rid() const { return _shader->get_rid(); }
 	RID get_region_blend_map() const { return _generated_region_blend_map.get_rid(); }
 
 	// Material settings


### PR DESCRIPTION
Allows use of #define / #ifdef etc pre-processor statements in the generated shader and the //INSERT: system.