### PR TITLE
Fixed Terrain3DUtil issues with GDScript

### DIFF
--- a/src/terrain_3d_util.h
+++ b/src/terrain_3d_util.h
@@ -132,15 +132,15 @@ inline uint32_t gd_get_base(const uint32_t p_pixel) { return get_base(p_pixel); 
 inline uint32_t gd_enc_base(const uint32_t p_base) { return enc_base(p_base); }
 inline uint32_t gd_get_overlay(const uint32_t p_pixel) { return get_overlay(p_pixel); }
 inline uint32_t gd_enc_overlay(const uint32_t p_over) { return enc_overlay(p_over); }
-inline uint32_t gd_get_blend(const uint32_t p_pixel) { return get_overlay(p_pixel); }
+inline uint32_t gd_get_blend(const uint32_t p_pixel) { return get_blend(p_pixel); }
 inline uint32_t gd_enc_blend(const uint32_t p_blend) { return enc_blend(p_blend); }
 inline bool gd_is_hole(const uint32_t p_pixel) { return is_hole(p_pixel); }
 inline bool gd_is_auto(const uint32_t p_pixel) { return is_auto(p_pixel); }
 inline bool gd_is_nav(const uint32_t p_pixel) { return is_nav(p_pixel); }
 inline uint32_t gd_get_uv_rotation(const uint32_t p_pixel) { return get_uv_rotation(p_pixel); }
 inline uint32_t gd_enc_uv_rotation(const uint32_t p_rotation) { return enc_uv_rotation(p_rotation); }
-inline uint32_t gd_get_uv_scale(const uint32_t p_pixel) { return get_uv_rotation(p_pixel); }
-inline uint32_t gd_enc_uv_scale(const uint32_t p_scale) { return enc_uv_rotation(p_scale); }
+inline uint32_t gd_get_uv_scale(const uint32_t p_pixel) { return get_uv_scale(p_pixel); }
+inline uint32_t gd_enc_uv_scale(const uint32_t p_scale) { return enc_uv_scale(p_scale); }
 
 ///////////////////////////
 // Memory


### PR DESCRIPTION
The GDScript alias functions for the Terrain3DUtil Object now refer to the correct functions.

This typo was so small I didn't bother to open issue and just fixed it myself. It got in the way when I was trying to sample the terrain texture on the CPU to bake its albedo into my grass instances.