### PR TITLE
Upscale brush images when loading

### DIFF
--- a/project/addons/terrain_3d/src/tool_settings.gd
+++ b/project/addons/terrain_3d/src/tool_settings.gd
@@ -243,6 +243,8 @@ func add_brushes(p_parent: Control) -> void:
 			if !dir.current_is_dir() and file_name.ends_with(".exr"):
 				var img: Image = Image.load_from_file(BRUSH_PATH + "/" + file_name)
 				img = Terrain3DUtil.black_to_alpha(img)
+				if img.get_width() < 1024 and img.get_height() < 1024:
+					img.resize(1024, 1024, Image.INTERPOLATE_CUBIC)
 				var tex: ImageTexture = ImageTexture.create_from_image(img)
 
 				var btn: Button = Button.new()

--- a/src/terrain_3d_editor.cpp
+++ b/src/terrain_3d_editor.cpp
@@ -607,7 +607,7 @@ void Terrain3DEditor::set_brush_data(const Dictionary &p_data) {
 
 	// Santize editor data
 	_brush_data["size"] = CLAMP(real_t(p_data.get("size", 10.f)), 2.f, 4096.f); // Diameter in meters
-	_brush_data["strength"] = CLAMP(real_t(p_data.get("strength", .1f)) * .01f, .01f, 100.f); // 1-10k%
+	_brush_data["strength"] = CLAMP(real_t(p_data.get("strength", .1f)) * .01f, .01f, 1000.f); // 1-100k% (eg max of 1000m per click)
 	_brush_data["mouse_pressure"] = CLAMP(real_t(p_data.get("mouse_pressure", 0.f)), 0.f, 1.f);
 	_brush_data["height"] = CLAMP(real_t(p_data.get("height", 0.f)), -65536.f, 65536.f); // Meters
 	_brush_data["asset_id"] = CLAMP(int(p_data.get("asset_id", 0)), 0, Terrain3DAssets::MAX_MESHES);


### PR DESCRIPTION
closes #445

I tested 2k and 4k and saw no noticeable improvement over 1k, however project load time when opening the editor did increase a little with 2k and a lot with 4k.