### PR TITLE
Fix set/get_pixel near zero precision error

### DIFF
--- a/src/terrain_3d_storage.cpp
+++ b/src/terrain_3d_storage.cpp
@@ -453,11 +453,9 @@ void Terrain3DStorage::set_pixel(const MapType p_map_type, const Vector3 &p_glob
 		return;
 	}
 	Vector2i global_offset = Vector2i(_region_offsets[region]) * _region_size;
-	Vector3 descaled_position = p_global_position / _terrain->get_mesh_vertex_spacing();
-	Vector2i img_pos = Vector2i(
-			Vector2(descaled_position.x - global_offset.x,
-					descaled_position.z - global_offset.y)
-					.floor());
+	Vector3 descaled_pos = p_global_position / _terrain->get_mesh_vertex_spacing();
+	Vector2i img_pos = Vector2i(descaled_pos.x - global_offset.x, descaled_pos.z - global_offset.y);
+	img_pos = img_pos.clamp(Vector2i(), Vector2i(_region_size - 1, _region_size - 1));
 	Ref<Image> map = get_map_region(p_map_type, region);
 	map->set_pixelv(img_pos, p_pixel);
 }
@@ -473,11 +471,8 @@ Color Terrain3DStorage::get_pixel(const MapType p_map_type, const Vector3 &p_glo
 		return COLOR_NAN;
 	}
 	Vector2i global_offset = Vector2i(_region_offsets[region]) * _region_size;
-	Vector3 descaled_position = p_global_position / _terrain->get_mesh_vertex_spacing();
-	Vector2i img_pos = Vector2i(
-			Vector2(descaled_position.x - global_offset.x,
-					descaled_position.z - global_offset.y)
-					.floor());
+	Vector3 descaled_pos = p_global_position / _terrain->get_mesh_vertex_spacing();
+	Vector2i img_pos = Vector2i(descaled_pos.x - global_offset.x, descaled_pos.z - global_offset.y);
 	img_pos = img_pos.clamp(Vector2i(), Vector2i(_region_size - 1, _region_size - 1));
 	Ref<Image> map = get_map_region(p_map_type, region);
 	return map->get_pixelv(img_pos);


### PR DESCRIPTION
Both C++ and GDScript have an issue where values >= -0.00001 and < 0 are not properly truncated nor floored to the next unit down. When calling set_pixel with (-0.00001, 0, -0.00001), though it reads the proper region, the image pixel position is converted to (1024, 1024). The max is 1023.

```gdscript
for x in [-1, -.5, -.1, -.01, -.001, -1e-4, -1e-5, -1e-6, 0, 1e-6, 1, 1024 - 1e-4, 1024 - 1e-5, 1024 - 1e-6]:
	var pos := Vector3(x, 0, x)
	var region_loc:Vector2i = $"../Terrain3D".get_storage().get_region_location(pos) # (or get_region_offset)
	var global_loc:Vector2i = region_loc * 1024
	var descaled_position := pos
	print(pos)
	print("vec2: ", Vector2(descaled_position.x - global_loc.x, descaled_position.z - global_loc.y))
	print("vec2 floored: ", Vector2(descaled_position.x - global_loc.x, descaled_position.z - global_loc.y).floor())
	var img_pos := Vector2i(Vector2(descaled_position.x - global_loc.x, descaled_position.z - global_loc.y).floor());
	print("img_pos floor: ", img_pos)
	img.get_pixelv(img_pos)
	img_pos = Vector2i(descaled_position.x - global_loc.x, descaled_position.z - global_loc.y);
	print("img_pos trunc: ", img_pos)
	img.get_pixelv(img_pos)

-------------
(-0.0001, 0, -0.0001)
vec2: (1024, 1024)
vec2 floored: (1023, 1023)
img_pos floor: (1023, 1023)
img_pos trunc: (1023, 1023)

-------------
(-0.00001, 0, -0.00001)
vec2: (1024, 1024)
vec2 floored: (1024, 1024)
img_pos floor: (1024, 1024)
ERROR: Index p_x = 1024 is out of bounds (width = 1024).
   at: get_pixel (core/io/image.cpp:3280)
img_pos  trunc: (1023, 1023)
```

In GDScript, we can simplify this pixel position equation, removing floor() and allow Vector2i to truncate. This resolves the issue as you can see in `img_pos trunc` above.

However, the same does not work in C++. Both the floor() and vec2i truncation result in pixel 1024. Only truncation and clamping suffices.

```
-------------
Terrain3DStorage#0426:set_pixel: (-0.0001, 0, -0.0001)
Terrain3DStorage#0426:set_pixel: Region offset: (-1024, -1024)
Terrain3DStorage#0426:set_pixel: Region id: 4
Terrain3DStorage#0426:set_pixel: dsc: (-0.0001, 0, -0.0001)
Terrain3DStorage#0426:set_pixel: vec2: (1024, 1024)
Terrain3DStorage#0426:set_pixel: vec2 floored: (1023, 1023)
Terrain3DStorage#0426:set_pixel: img_pos floor: (1023, 1023)
Terrain3DStorage#0426:set_pixel: img_pos trunc: (1023, 1023)
Terrain3DStorage#0426:set_pixel: img_pos clamp: (1023, 1023)

-------------
Terrain3DStorage#0426:set_pixel: (-0.00001, 0, -0.00001)
Terrain3DStorage#0426:set_pixel: Region offset: (-1024, -1024)
Terrain3DStorage#0426:set_pixel: Region id: 4
Terrain3DStorage#0426:set_pixel: dsc: (-0.00001, 0, -0.00001)
Terrain3DStorage#0426:set_pixel: vec2: (1024, 1024)
Terrain3DStorage#0426:set_pixel: vec2 floored: (1024, 1024)
Terrain3DStorage#0426:set_pixel: img_pos floor: (1024, 1024)
Terrain3DStorage#0426:set_pixel: img_pos trunc: (1024, 1024)
ERROR: Index p_x = 1024 is out of bounds (width = 1024).
   at: get_pixel (core/io/image.cpp:3280)
Terrain3DStorage#0426:set_pixel: img_pos clamp: (1023, 1023)
```

1023.99999 does not have this issue:
```
Terrain3DStorage#0426:set_pixel: (1024, 0, 1024)
Terrain3DStorage#0426:set_pixel: Region offset: (0, 0)
Terrain3DStorage#0426:set_pixel: Region id: 1
Terrain3DStorage#0426:set_pixel: dsc: (1024, 0, 1024)
Terrain3DStorage#0426:set_pixel: vec2: (1024, 1024)
Terrain3DStorage#0426:set_pixel: vec2 floored: (1023, 1023)
Terrain3DStorage#0426:set_pixel: img_pos floor: (1023, 1023)
Terrain3DStorage#0426:set_pixel: img_pos trunc: (1023, 1023)
Terrain3DStorage#0426:set_pixel: img_pos clamp: (1023, 1023)
```

A full test:
```gdscript
func _ready() -> void:
	for x in [-1, -.5, -.1, -.01, -.001, -1e-4, -1e-5, -1e-6, 0, 1e-6, 1, 1024 - 1e-4, 1024 - 1e-5, 1024 - 1e-6]:
		$"../Terrain3D".get_storage().set_color(Vector3(x, 0, x), Color.FUCHSIA)
```

This shows the positions get the correct region, not changing until >=0, and when truncated and clamped, the right pixel. Global position 1023.9999 is truncated down to a 1023 pixel position, but larger (eg 1023.99999) is rounded to 1024 and is read on the next region.

```
-------------
Terrain3DStorage#0426:set_pixel: (-1, 0, -1)
Terrain3DStorage#0426:set_pixel: Region id: 4
Terrain3DStorage#0426:set_pixel: vec2: (1023, 1023)
Terrain3DStorage#0426:set_pixel: vec2 floored: (1023, 1023)
Terrain3DStorage#0426:set_pixel: img_pos floor: (1023, 1023)
Terrain3DStorage#0426:set_pixel: img_pos trunc: (1023, 1023)
Terrain3DStorage#0426:set_pixel: img_pos clamp: (1023, 1023)

-------------
Terrain3DStorage#0426:set_pixel: (-0.5, 0, -0.5)
Terrain3DStorage#0426:set_pixel: Region id: 4
Terrain3DStorage#0426:set_pixel: vec2: (1023.5, 1023.5)
Terrain3DStorage#0426:set_pixel: vec2 floored: (1023, 1023)
Terrain3DStorage#0426:set_pixel: img_pos floor: (1023, 1023)
Terrain3DStorage#0426:set_pixel: img_pos trunc: (1023, 1023)
Terrain3DStorage#0426:set_pixel: img_pos clamp: (1023, 1023)

-------------
Terrain3DStorage#0426:set_pixel: (-0.1, 0, -0.1)
Terrain3DStorage#0426:set_pixel: Region id: 4
Terrain3DStorage#0426:set_pixel: vec2: (1023.9, 1023.9)
Terrain3DStorage#0426:set_pixel: vec2 floored: (1023, 1023)
Terrain3DStorage#0426:set_pixel: img_pos floor: (1023, 1023)
Terrain3DStorage#0426:set_pixel: img_pos trunc: (1023, 1023)
Terrain3DStorage#0426:set_pixel: img_pos clamp: (1023, 1023)

-------------
Terrain3DStorage#0426:set_pixel: (-0.01, 0, -0.01)
Terrain3DStorage#0426:set_pixel: Region id: 4
Terrain3DStorage#0426:set_pixel: vec2: (1023.99, 1023.99)
Terrain3DStorage#0426:set_pixel: vec2 floored: (1023, 1023)
Terrain3DStorage#0426:set_pixel: img_pos floor: (1023, 1023)
Terrain3DStorage#0426:set_pixel: img_pos trunc: (1023, 1023)
Terrain3DStorage#0426:set_pixel: img_pos clamp: (1023, 1023)

-------------
Terrain3DStorage#0426:set_pixel: (-0.001, 0, -0.001)
Terrain3DStorage#0426:set_pixel: Region id: 4
Terrain3DStorage#0426:set_pixel: vec2: (1023.999, 1023.999)
Terrain3DStorage#0426:set_pixel: vec2 floored: (1023, 1023)
Terrain3DStorage#0426:set_pixel: img_pos floor: (1023, 1023)
Terrain3DStorage#0426:set_pixel: img_pos trunc: (1023, 1023)
Terrain3DStorage#0426:set_pixel: img_pos clamp: (1023, 1023)

-------------
Terrain3DStorage#0426:set_pixel: (-0.0001, 0, -0.0001)
Terrain3DStorage#0426:set_pixel: Region id: 4
Terrain3DStorage#0426:set_pixel: vec2: (1024, 1024)
Terrain3DStorage#0426:set_pixel: vec2 floored: (1023, 1023)
Terrain3DStorage#0426:set_pixel: img_pos floor: (1023, 1023)
Terrain3DStorage#0426:set_pixel: img_pos trunc: (1023, 1023)
Terrain3DStorage#0426:set_pixel: img_pos clamp: (1023, 1023)

-------------
Terrain3DStorage#0426:set_pixel: (-0.00001, 0, -0.00001)
Terrain3DStorage#0426:set_pixel: Region id: 4
Terrain3DStorage#0426:set_pixel: vec2: (1024, 1024)
Terrain3DStorage#0426:set_pixel: vec2 floored: (1024, 1024)
Terrain3DStorage#0426:set_pixel: img_pos floor: (1024, 1024)
Terrain3DStorage#0426:set_pixel: img_pos trunc: (1024, 1024)
Terrain3DStorage#0426:set_pixel: img_pos clamp: (1023, 1023)

-------------
Terrain3DStorage#0426:set_pixel: (-0.000001, 0, -0.000001)
Terrain3DStorage#0426:set_pixel: Region id: 4
Terrain3DStorage#0426:set_pixel: vec2: (1024, 1024)
Terrain3DStorage#0426:set_pixel: vec2 floored: (1024, 1024)
Terrain3DStorage#0426:set_pixel: img_pos floor: (1024, 1024)
Terrain3DStorage#0426:set_pixel: img_pos trunc: (1024, 1024)
Terrain3DStorage#0426:set_pixel: img_pos clamp: (1023, 1023)

-------------
Terrain3DStorage#0426:set_pixel: (0, 0, 0)
Terrain3DStorage#0426:set_pixel: Region id: 1
Terrain3DStorage#0426:set_pixel: vec2: (0, 0)
Terrain3DStorage#0426:set_pixel: vec2 floored: (0, 0)
Terrain3DStorage#0426:set_pixel: img_pos floor: (0, 0)
Terrain3DStorage#0426:set_pixel: img_pos trunc: (0, 0)
Terrain3DStorage#0426:set_pixel: img_pos clamp: (0, 0)

-------------
Terrain3DStorage#0426:set_pixel: (0.000001, 0, 0.000001)
Terrain3DStorage#0426:set_pixel: Region id: 1
Terrain3DStorage#0426:set_pixel: vec2: (0.000001, 0.000001)
Terrain3DStorage#0426:set_pixel: vec2 floored: (0, 0)
Terrain3DStorage#0426:set_pixel: img_pos floor: (0, 0)
Terrain3DStorage#0426:set_pixel: img_pos trunc: (0, 0)
Terrain3DStorage#0426:set_pixel: img_pos clamp: (0, 0)

-------------
Terrain3DStorage#0426:set_pixel: (1, 0, 1)
Terrain3DStorage#0426:set_pixel: Region id: 1
Terrain3DStorage#0426:set_pixel: vec2: (1, 1)
Terrain3DStorage#0426:set_pixel: vec2 floored: (1, 1)
Terrain3DStorage#0426:set_pixel: img_pos floor: (1, 1)
Terrain3DStorage#0426:set_pixel: img_pos trunc: (1, 1)
Terrain3DStorage#0426:set_pixel: img_pos clamp: (1, 1)

-------------
Terrain3DStorage#0426:set_pixel: (1024, 0, 1024)   **Actually 1023.9999**
Terrain3DStorage#0426:set_pixel: Region id: 1
Terrain3DStorage#0426:set_pixel: vec2: (1024, 1024)
Terrain3DStorage#0426:set_pixel: vec2 floored: (1023, 1023)
Terrain3DStorage#0426:set_pixel: img_pos floor: (1023, 1023)
Terrain3DStorage#0426:set_pixel: img_pos trunc: (1023, 1023)
Terrain3DStorage#0426:set_pixel: img_pos clamp: (1023, 1023)
```