### PR TITLE
Subdivide LOD1 and higher

### DIFF
--- a/project/demo/Demo.tscn
+++ b/project/demo/Demo.tscn
@@ -86,6 +86,5 @@ material = SubResource("Terrain3DMaterial_jrc01")
 assets = ExtResource("8_g2of2")
 render_cull_margin = 1000.0
 collision_mask = 3
-mesh_size = 64
 top_level = true
 metadata/_edit_lock_ = true

--- a/src/geoclipmap.cpp
+++ b/src/geoclipmap.cpp
@@ -9,6 +9,106 @@
 // Private Functions
 ///////////////////////////
 
+// Half each triangle, have to check for longest side.
+void GeoClipMap::_subdivide_half(PackedVector3Array &vertices, PackedInt32Array &indices) {
+
+	// Hash for map for quick vertex search, for loop was very very slow!
+	struct Vector3Hash {
+		std::size_t operator()(const Vector3 &v) const {
+			std::size_t h1 = std::hash<float>()(v.x);
+			std::size_t h2 = std::hash<float>()(v.y);
+			std::size_t h3 = std::hash<float>()(v.z);
+			return h1 ^ (h2 << 1) ^ (h3 << 2);
+		}
+	};
+
+	PackedVector3Array new_vertices;
+	PackedInt32Array new_indices;
+
+	std::unordered_map<Vector3, int, Vector3Hash> vertex_map;
+
+	auto midpoint = [](const Vector3 &p1, const Vector3 &p2) -> Vector3 {
+		return (p1 + p2) / 2.0f;
+	};
+
+	auto find_or_add_vertex = [&vertex_map, &new_vertices](const Vector3 &vertex) -> int {
+		auto it = vertex_map.find(vertex);
+		if (it != vertex_map.end()) {
+			return it->second;
+		} else {
+			int index = new_vertices.size();
+			vertex_map[vertex] = index;
+			new_vertices.push_back(vertex);
+			return index;
+		}
+	};
+
+	for (int i = 0; i < indices.size(); i += 3) {
+		int id_0 = indices[i];
+		int id_1 = indices[i + 1];
+		int id_2 = indices[i + 2];
+
+		Vector3 A = vertices[id_0];
+		Vector3 B = vertices[id_1];
+		Vector3 C = vertices[id_2];
+
+		float length_AB = (B - A).length_squared();
+		float length_BC = (C - B).length_squared();
+		float length_CA = (A - C).length_squared();
+
+		// Determine the longest edge and its midpoint, chaos otherwise.
+		int A_id, B_id, C_id, mid_id;
+		if (length_AB >= length_BC && length_AB >= length_CA) {
+			A_id = find_or_add_vertex(A);
+			B_id = find_or_add_vertex(B);
+			C_id = find_or_add_vertex(C);
+			mid_id = find_or_add_vertex(midpoint(A, B));
+
+			new_indices.push_back(A_id);
+			new_indices.push_back(mid_id);
+			new_indices.push_back(C_id);
+
+			new_indices.push_back(mid_id);
+			new_indices.push_back(B_id);
+			new_indices.push_back(C_id);
+
+		} else if (length_BC >= length_AB && length_BC >= length_CA) {
+			A_id = find_or_add_vertex(A);
+			B_id = find_or_add_vertex(B);
+			C_id = find_or_add_vertex(C);
+			mid_id = find_or_add_vertex(midpoint(B, C));
+
+			new_indices.push_back(B_id);
+			new_indices.push_back(mid_id);
+			new_indices.push_back(A_id);
+
+			new_indices.push_back(mid_id);
+			new_indices.push_back(C_id);
+			new_indices.push_back(A_id);
+
+		} else {
+			// length_BC >= length_AB && length_BC >= length_CA
+			A_id = find_or_add_vertex(A);
+			B_id = find_or_add_vertex(B);
+			C_id = find_or_add_vertex(C);
+			mid_id = find_or_add_vertex(midpoint(C, A));
+
+			new_indices.push_back(C_id);
+			new_indices.push_back(mid_id);
+			new_indices.push_back(B_id);
+
+			new_indices.push_back(mid_id);
+			new_indices.push_back(A_id);
+			new_indices.push_back(B_id);
+		}
+	}
+
+	vertices.clear();
+	vertices.append_array(new_vertices);
+	indices.clear();
+	indices.append_array(new_indices);
+}
+
 RID GeoClipMap::_create_mesh(const PackedVector3Array &p_vertices, const PackedInt32Array &p_indices, const AABB &p_aabb) {
 	Array arrays;
 	arrays.resize(RenderingServer::ARRAY_MAX);
@@ -54,6 +154,9 @@ Vector<RID> GeoClipMap::generate(const int p_size, const int p_levels) {
 	RID trim_mesh;
 	RID cross_mesh;
 	RID seam_mesh;
+	RID tile_inner_mesh;
+	RID filler_inner_mesh;
+	RID trim_inner_mesh;
 
 	int TILE_RESOLUTION = p_size;
 	int PATCH_VERT_RESOLUTION = TILE_RESOLUTION + 1;
@@ -96,6 +199,8 @@ Vector<RID> GeoClipMap::generate(const int p_size, const int p_levels) {
 		}
 
 		aabb = AABB(V3_ZERO, Vector3(PATCH_VERT_RESOLUTION, 0.1f, PATCH_VERT_RESOLUTION));
+		tile_inner_mesh = _create_mesh(vertices, indices, aabb);
+		_subdivide_half(vertices, indices);
 		tile_mesh = _create_mesh(vertices, indices, aabb);
 	}
 
@@ -176,7 +281,8 @@ Vector<RID> GeoClipMap::generate(const int p_size, const int p_levels) {
 				indices[n++] = tr;
 			}
 		}
-
+		filler_inner_mesh = _create_mesh(vertices, indices, aabb);
+		_subdivide_half(vertices, indices);
 		filler_mesh = _create_mesh(vertices, indices, aabb);
 	}
 
@@ -235,7 +341,8 @@ Vector<RID> GeoClipMap::generate(const int p_size, const int p_levels) {
 			indices[n++] = start_of_horizontal + (i + 0) * 2 + 1;
 			indices[n++] = start_of_horizontal + (i + 1) * 2 + 0;
 		}
-
+		trim_inner_mesh = _create_mesh(vertices, indices, aabb);
+		_subdivide_half(vertices, indices);
 		trim_mesh = _create_mesh(vertices, indices, aabb);
 	}
 
@@ -388,7 +495,10 @@ Vector<RID> GeoClipMap::generate(const int p_size, const int p_levels) {
 		filler_mesh,
 		trim_mesh,
 		cross_mesh,
-		seam_mesh
+		seam_mesh,
+		tile_inner_mesh,
+		filler_inner_mesh,
+		trim_inner_mesh,
 	};
 
 	return meshes;

--- a/src/geoclipmap.h
+++ b/src/geoclipmap.h
@@ -13,6 +13,7 @@ class GeoClipMap {
 	CLASS_NAME_STATIC("Terrain3DGeoClipMap");
 
 	static inline int _patch_2d(const int x, const int y, const int res);
+	static void _subdivide_half(PackedVector3Array &vertices, PackedInt32Array &indices);
 	static RID _create_mesh(const PackedVector3Array &p_vertices, const PackedInt32Array &p_indices, const AABB &p_aabb);
 
 public:
@@ -22,6 +23,9 @@ public:
 		TRIM,
 		CROSS,
 		SEAM,
+		TILE_INNER,
+		FILLER_INNER,
+		TRIM_INNER,
 	};
 
 	static Vector<RID> generate(const int p_resolution, const int p_clipmap_levels);

--- a/src/terrain_3d.cpp
+++ b/src/terrain_3d.cpp
@@ -254,27 +254,41 @@ void Terrain3D::_build_meshes(const int p_mesh_lods, const int p_mesh_size) {
 	RS->instance_geometry_set_cast_shadows_setting(_mesh_data.cross, RenderingServer::ShadowCastingSetting(_cast_shadows));
 	RS->instance_set_layer_mask(_mesh_data.cross, _render_layers);
 
-	for (int l = 0; l < p_mesh_lods; l++) {
+	for (int lod = 0; lod < p_mesh_lods; lod++) {
 		for (int x = 0; x < 4; x++) {
 			for (int y = 0; y < 4; y++) {
-				if (l != 0 && (x == 1 || x == 2) && (y == 1 || y == 2)) {
+				if (lod != 0 && (x == 1 || x == 2) && (y == 1 || y == 2)) {
 					continue;
 				}
-
-				RID tile = RS->instance_create2(_meshes[GeoClipMap::TILE], scenario);
+				RID tile;
+				if (lod == 0) {
+					tile = RS->instance_create2(_meshes[GeoClipMap::TILE_INNER], scenario);
+				} else {
+					tile = RS->instance_create2(_meshes[GeoClipMap::TILE], scenario);
+				}
 				RS->instance_geometry_set_cast_shadows_setting(tile, RenderingServer::ShadowCastingSetting(_cast_shadows));
 				RS->instance_set_layer_mask(tile, _render_layers);
 				_mesh_data.tiles.push_back(tile);
 			}
 		}
 
-		RID filler = RS->instance_create2(_meshes[GeoClipMap::FILLER], scenario);
+		RID filler;
+		if (lod == 0) {
+			filler = RS->instance_create2(_meshes[GeoClipMap::FILLER_INNER], scenario);
+		} else {
+			filler = RS->instance_create2(_meshes[GeoClipMap::FILLER], scenario);
+		}
 		RS->instance_geometry_set_cast_shadows_setting(filler, RenderingServer::ShadowCastingSetting(_cast_shadows));
 		RS->instance_set_layer_mask(filler, _render_layers);
 		_mesh_data.fillers.push_back(filler);
 
-		if (l != p_mesh_lods - 1) {
-			RID trim = RS->instance_create2(_meshes[GeoClipMap::TRIM], scenario);
+		if (lod != p_mesh_lods - 1) {
+			RID trim;
+			if (lod == 0) {
+				trim = RS->instance_create2(_meshes[GeoClipMap::TRIM_INNER], scenario);
+			} else {
+				trim = RS->instance_create2(_meshes[GeoClipMap::TRIM], scenario);
+			}
 			RS->instance_geometry_set_cast_shadows_setting(trim, RenderingServer::ShadowCastingSetting(_cast_shadows));
 			RS->instance_set_layer_mask(trim, _render_layers);
 			_mesh_data.trims.push_back(trim);


### PR DESCRIPTION
Makes distant LOD levels look much better with a minimal Triangle count increase, so much so that useing half the mesh size yields visually similar results, as seen in this comparison:

mesh size 32 (LOD set to 7):
![image](https://github.com/user-attachments/assets/60891b58-bf49-4f29-a5d6-f1a0ca43ced9)

original, mesh size 64 (LOD set to 6):
![image](https://github.com/user-attachments/assets/afe4af39-a540-49e6-8817-302205090e0a)

Also, maintains 1:1 with current collision generation
![image](https://github.com/user-attachments/assets/844a0102-0926-4f6a-a147-b06c3c753f97)
