### PR TITLE
Fix background mode none region borders

### DIFF
--- a/src/shaders/main.glsl
+++ b/src/shaders/main.glsl
@@ -139,7 +139,7 @@ void vertex() {
 
 	// Show holes to all cameras except mouse camera (on exactly 1 layer)
 	if ( !(CAMERA_VISIBLE_LAYERS == _mouse_layer) && 
-			(hole || (_background_mode == 0u && v_region.z < 0)) ) {
+			(hole || (_background_mode == 0u && (get_region_uv(UV - _region_texel_size) & v_region).z < 0))) {
 		VERTEX.x = 0. / 0.;
 	} else {		
 		// Set final vertex height & calculate vertex normals. 3 lookups.


### PR DESCRIPTION
examples with mesh size 8;

before:
![image](https://github.com/user-attachments/assets/a56a61b0-ebe6-4cb1-b5d9-d733f790af4a)

after:
![image](https://github.com/user-attachments/assets/033dcbff-6797-4b8e-89b9-9ccfac98b8d0)