### PR TITLE
Update TextureArray by layers

### DIFF
--- a/src/generated_texture.cpp
+++ b/src/generated_texture.cpp
@@ -39,6 +39,11 @@ RID GeneratedTexture::create(const TypedArray<Image> &p_layers) {
 	return _rid;
 }
 
+void GeneratedTexture::update(const Ref<Image> &p_image, const int &p_layer) {
+	LOG(EXTREME, "RenderingServer updating Texture2DArray at index: ", p_layer);
+	RS->texture_2d_update(_rid, p_image, p_layer);
+}
+
 RID GeneratedTexture::create(const Ref<Image> &p_image) {
 	LOG(EXTREME, "RenderingServer creating Texture2D");
 	_image = p_image;

--- a/src/generated_texture.h
+++ b/src/generated_texture.h
@@ -21,6 +21,7 @@ public:
 	void clear();
 	bool is_dirty() const { return _dirty; }
 	RID create(const TypedArray<Image> &p_layers);
+	void update(const Ref<Image> &p_image, const int &p_layer);
 	RID create(const Ref<Image> &p_image);
 	Ref<Image> get_image() const { return _image; }
 	RID get_rid() const { return _rid; }

--- a/src/terrain_3d_data.h
+++ b/src/terrain_3d_data.h
@@ -130,8 +130,9 @@ public:
 	TypedArray<Image> get_color_maps() const { return _color_maps; }
 	TypedArray<Image> get_maps(const MapType p_map_type) const;
 
-	void force_update_maps(const MapType p_map = TYPE_MAX, const bool p_generate_mipmaps = false);
-	void update_maps();
+	void force_update_maps(const MapType p_map_type = TYPE_MAX, const bool p_generate_mipmaps = false);
+	void update_maps(const MapType p_map_type = TYPE_MAX);
+
 	RID get_height_maps_rid() const { return _generated_height_maps.get_rid(); }
 	RID get_control_maps_rid() const { return _generated_control_maps.get_rid(); }
 	RID get_color_maps_rid() const { return _generated_color_maps.get_rid(); }


### PR DESCRIPTION
Adds GeneratedTexture::update() function.

Implemented update for undo/redo, and painting texture arrays will now update individual layers, rather than regenerating the entire array when feasible.

maintains usability when painting / undo / redo even with 200+ regions.

only adding / removing regions causes slow downs, as the array has to be resized, and map order will change.

automatic regions works as well!

closes #381