### PR TITLE
Improve brushing

### DIFF
--- a/project/addons/terrain_3d/src/asset_dock.gd
+++ b/project/addons/terrain_3d/src/asset_dock.gd
@@ -293,7 +293,7 @@ func _on_meshes_pressed() -> void:
 func _on_tool_changed(p_tool: Terrain3DEditor.Tool, p_operation: Terrain3DEditor.Operation) -> void:
 	if p_tool == Terrain3DEditor.INSTANCER:
 		_on_meshes_pressed()
-	elif p_tool == Terrain3DEditor.TEXTURE:
+	elif p_tool in [ Terrain3DEditor.TEXTURE, Terrain3DEditor.COLOR, Terrain3DEditor.ROUGHNESS ]:
 		_on_textures_pressed()
 
 
@@ -542,7 +542,8 @@ class ListContainer extends Container:
 		plugin.select_terrain()
 
 		# Select Paint tool if clicking a texture
-		if type == Terrain3DAssets.TYPE_TEXTURE and plugin.editor.get_tool() != Terrain3DEditor.TEXTURE:
+		if type == Terrain3DAssets.TYPE_TEXTURE and \
+				not plugin.editor.get_tool() in [ Terrain3DEditor.TEXTURE, Terrain3DEditor.COLOR, Terrain3DEditor.ROUGHNESS ]:
 			var paint_btn: Button = plugin.ui.toolbar.get_node_or_null("PaintBaseTexture")
 			if paint_btn:
 				paint_btn.set_pressed(true)

--- a/project/addons/terrain_3d/src/tool_settings.gd
+++ b/project/addons/terrain_3d/src/tool_settings.gd
@@ -88,7 +88,10 @@ func _ready() -> void:
 								"default":Terrain3DEditor.ROUGHNESS, "flags":NO_LABEL })
 
 	add_setting({ "name":"enable_texture", "label":"Texture", "type":SettingType.CHECKBOX, 
-								"list":main_list, "default":true })
+								"list":main_list, "default":true, "flags":ADD_SEPARATOR })
+
+	add_setting({ "name":"margin", "type":SettingType.SLIDER, "list":main_list, "default":0, 
+								"unit":"", "range":Vector3(-50, 50, 1), "flags":ALLOW_OUT_OF_BOUNDS })
 
 	add_setting({ "name":"enable_angle", "label":"Angle", "type":SettingType.CHECKBOX, 
 								"list":main_list, "default":true, "flags":ADD_SEPARATOR })

--- a/project/addons/terrain_3d/src/ui.gd
+++ b/project/addons/terrain_3d/src/ui.gd
@@ -182,6 +182,8 @@ func _on_tool_changed(p_tool: Terrain3DEditor.Tool, p_operation: Terrain3DEditor
 			to_show.push_back("strength")
 			to_show.push_back("color")
 			to_show.push_back("color_picker")
+			to_show.push_back("enable_texture")
+			to_show.push_back("margin")
 			to_show.push_back("remove")
 
 		Terrain3DEditor.ROUGHNESS:
@@ -190,6 +192,8 @@ func _on_tool_changed(p_tool: Terrain3DEditor.Tool, p_operation: Terrain3DEditor
 			to_show.push_back("strength")
 			to_show.push_back("roughness")
 			to_show.push_back("roughness_picker")
+			to_show.push_back("enable_texture")
+			to_show.push_back("margin")
 			to_show.push_back("remove")
 
 		Terrain3DEditor.AUTOSHADER, Terrain3DEditor.HOLES, Terrain3DEditor.NAVIGATION:


### PR DESCRIPTION
Changed alpha threshold to 0.5 along with extra conditions to make painting feel a bit more intuitive. 

~~blending may be a little slower again with the default circle 0 brush, useing circle 1 is similar to before~~

painting over the auto shader, or painting base onto base, or spray onto spray now follows the percieved brush shape much better.

angle and scale now also much more closley follow the visibility of the selected texture too.

images with height textures that are not centered around 0.5 maybe end up with a small inward, or outward halo for angle/scale values, however this is still an improvement over the entire brush square getting overwritten as it did before this change.

closes #481 tho a pure solution would be seperate values for base/over but that is probably not needed.

----
Admin edit
Fixes #192 