### PR TITLE
control map api changes

### DIFF
--- a/doc/api/class_terrain3ddata.rst
+++ b/doc/api/class_terrain3ddata.rst
@@ -62,15 +62,29 @@ Methods
    +----------------------------------------------------------------------------+----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
    | |void|                                                                     | :ref:`force_update_maps<class_Terrain3DData_method_force_update_maps>`\ (\ map_type\: :ref:`MapType<enum_Terrain3DRegion_MapType>` = 3, generate_mipmaps\: :ref:`bool<class_bool>` = false\ )                                                                                                |
    +----------------------------------------------------------------------------+----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
-   | :ref:`float<class_float>`                                                  | :ref:`get_angle<class_Terrain3DData_method_get_angle>`\ (\ global_position\: :ref:`Vector3<class_Vector3>`\ ) |const|                                                                                                                                                                        |
-   +----------------------------------------------------------------------------+----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
    | :ref:`Color<class_Color>`                                                  | :ref:`get_color<class_Terrain3DData_method_get_color>`\ (\ global_position\: :ref:`Vector3<class_Vector3>`\ ) |const|                                                                                                                                                                        |
    +----------------------------------------------------------------------------+----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
    | :ref:`RID<class_RID>`                                                      | :ref:`get_color_maps_rid<class_Terrain3DData_method_get_color_maps_rid>`\ (\ ) |const|                                                                                                                                                                                                       |
    +----------------------------------------------------------------------------+----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
    | :ref:`int<class_int>`                                                      | :ref:`get_control<class_Terrain3DData_method_get_control>`\ (\ global_position\: :ref:`Vector3<class_Vector3>`\ ) |const|                                                                                                                                                                    |
    +----------------------------------------------------------------------------+----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
+   | :ref:`float<class_float>`                                                  | :ref:`get_control_angle<class_Terrain3DData_method_get_control_angle>`\ (\ global_position\: :ref:`Vector3<class_Vector3>`\ ) |const|                                                                                                                                                        |
+   +----------------------------------------------------------------------------+----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
+   | :ref:`bool<class_bool>`                                                    | :ref:`get_control_auto<class_Terrain3DData_method_get_control_auto>`\ (\ global_position\: :ref:`Vector3<class_Vector3>`\ ) |const|                                                                                                                                                          |
+   +----------------------------------------------------------------------------+----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
+   | :ref:`int<class_int>`                                                      | :ref:`get_control_base_id<class_Terrain3DData_method_get_control_base_id>`\ (\ global_position\: :ref:`Vector3<class_Vector3>`\ ) |const|                                                                                                                                                    |
+   +----------------------------------------------------------------------------+----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
+   | :ref:`float<class_float>`                                                  | :ref:`get_control_blend<class_Terrain3DData_method_get_control_blend>`\ (\ global_position\: :ref:`Vector3<class_Vector3>`\ ) |const|                                                                                                                                                        |
+   +----------------------------------------------------------------------------+----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
+   | :ref:`bool<class_bool>`                                                    | :ref:`get_control_hole<class_Terrain3DData_method_get_control_hole>`\ (\ global_position\: :ref:`Vector3<class_Vector3>`\ ) |const|                                                                                                                                                          |
+   +----------------------------------------------------------------------------+----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
    | :ref:`RID<class_RID>`                                                      | :ref:`get_control_maps_rid<class_Terrain3DData_method_get_control_maps_rid>`\ (\ ) |const|                                                                                                                                                                                                   |
+   +----------------------------------------------------------------------------+----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
+   | :ref:`bool<class_bool>`                                                    | :ref:`get_control_navigation<class_Terrain3DData_method_get_control_navigation>`\ (\ global_position\: :ref:`Vector3<class_Vector3>`\ ) |const|                                                                                                                                              |
+   +----------------------------------------------------------------------------+----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
+   | :ref:`int<class_int>`                                                      | :ref:`get_control_overlay_id<class_Terrain3DData_method_get_control_overlay_id>`\ (\ global_position\: :ref:`Vector3<class_Vector3>`\ ) |const|                                                                                                                                              |
+   +----------------------------------------------------------------------------+----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
+   | :ref:`float<class_float>`                                                  | :ref:`get_control_scale<class_Terrain3DData_method_get_control_scale>`\ (\ global_position\: :ref:`Vector3<class_Vector3>`\ ) |const|                                                                                                                                                        |
    +----------------------------------------------------------------------------+----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
    | :ref:`float<class_float>`                                                  | :ref:`get_height<class_Terrain3DData_method_get_height>`\ (\ global_position\: :ref:`Vector3<class_Vector3>`\ ) |const|                                                                                                                                                                      |
    +----------------------------------------------------------------------------+----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
@@ -108,8 +122,6 @@ Methods
    +----------------------------------------------------------------------------+----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
    | :ref:`float<class_float>`                                                  | :ref:`get_roughness<class_Terrain3DData_method_get_roughness>`\ (\ global_position\: :ref:`Vector3<class_Vector3>`\ ) |const|                                                                                                                                                                |
    +----------------------------------------------------------------------------+----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
-   | :ref:`float<class_float>`                                                  | :ref:`get_scale<class_Terrain3DData_method_get_scale>`\ (\ global_position\: :ref:`Vector3<class_Vector3>`\ ) |const|                                                                                                                                                                        |
-   +----------------------------------------------------------------------------+----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
    | :ref:`Vector3<class_Vector3>`                                              | :ref:`get_texture_id<class_Terrain3DData_method_get_texture_id>`\ (\ global_position\: :ref:`Vector3<class_Vector3>`\ ) |const|                                                                                                                                                              |
    +----------------------------------------------------------------------------+----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
    | :ref:`bool<class_bool>`                                                    | :ref:`has_region<class_Terrain3DData_method_has_region>`\ (\ region_location\: :ref:`Vector2i<class_Vector2i>`\ ) |const|                                                                                                                                                                    |
@@ -141,6 +153,22 @@ Methods
    | |void|                                                                     | :ref:`set_color<class_Terrain3DData_method_set_color>`\ (\ global_position\: :ref:`Vector3<class_Vector3>`, color\: :ref:`Color<class_Color>`\ )                                                                                                                                             |
    +----------------------------------------------------------------------------+----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
    | |void|                                                                     | :ref:`set_control<class_Terrain3DData_method_set_control>`\ (\ global_position\: :ref:`Vector3<class_Vector3>`, control\: :ref:`int<class_int>`\ )                                                                                                                                           |
+   +----------------------------------------------------------------------------+----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
+   | |void|                                                                     | :ref:`set_control_angle<class_Terrain3DData_method_set_control_angle>`\ (\ global_position\: :ref:`Vector3<class_Vector3>`, degrees\: :ref:`float<class_float>`\ )                                                                                                                           |
+   +----------------------------------------------------------------------------+----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
+   | |void|                                                                     | :ref:`set_control_auto<class_Terrain3DData_method_set_control_auto>`\ (\ global_position\: :ref:`Vector3<class_Vector3>`, enable\: :ref:`bool<class_bool>`\ )                                                                                                                                |
+   +----------------------------------------------------------------------------+----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
+   | |void|                                                                     | :ref:`set_control_base_id<class_Terrain3DData_method_set_control_base_id>`\ (\ global_position\: :ref:`Vector3<class_Vector3>`, texture_id\: :ref:`int<class_int>`\ )                                                                                                                        |
+   +----------------------------------------------------------------------------+----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
+   | |void|                                                                     | :ref:`set_control_blend<class_Terrain3DData_method_set_control_blend>`\ (\ global_position\: :ref:`Vector3<class_Vector3>`, blend_value\: :ref:`float<class_float>`\ )                                                                                                                       |
+   +----------------------------------------------------------------------------+----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
+   | |void|                                                                     | :ref:`set_control_hole<class_Terrain3DData_method_set_control_hole>`\ (\ global_position\: :ref:`Vector3<class_Vector3>`, enable\: :ref:`bool<class_bool>`\ )                                                                                                                                |
+   +----------------------------------------------------------------------------+----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
+   | |void|                                                                     | :ref:`set_control_navigation<class_Terrain3DData_method_set_control_navigation>`\ (\ global_position\: :ref:`Vector3<class_Vector3>`, enable\: :ref:`bool<class_bool>`\ )                                                                                                                    |
+   +----------------------------------------------------------------------------+----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
+   | |void|                                                                     | :ref:`set_control_overlay_id<class_Terrain3DData_method_set_control_overlay_id>`\ (\ global_position\: :ref:`Vector3<class_Vector3>`, texture_id\: :ref:`int<class_int>`\ )                                                                                                                  |
+   +----------------------------------------------------------------------------+----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
+   | |void|                                                                     | :ref:`set_control_scale<class_Terrain3DData_method_set_control_scale>`\ (\ global_position\: :ref:`Vector3<class_Vector3>`, percentage_modifier\: :ref:`float<class_float>`\ )                                                                                                               |
    +----------------------------------------------------------------------------+----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
    | |void|                                                                     | :ref:`set_height<class_Terrain3DData_method_set_height>`\ (\ global_position\: :ref:`Vector3<class_Vector3>`, height\: :ref:`float<class_float>`\ )                                                                                                                                          |
    +----------------------------------------------------------------------------+----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
@@ -483,20 +511,6 @@ This function needs to be called after editing any of the maps.
 
 ----
 
-.. _class_Terrain3DData_method_get_angle:
-
-.. rst-class:: classref-method
-
-:ref:`float<class_float>` **get_angle**\ (\ global_position\: :ref:`Vector3<class_Vector3>`\ ) |const| :ref:`🔗<class_Terrain3DData_method_get_angle>`
-
-Returns the angle, aka uv rotation, painted on the control map at the requested position. Values are fixed to 22.5 degree intervals, for a maximum of 16 angles. 360 / 16 = 22.5.
-
-Returns ``NAN`` if the position is outside of defined regions.
-
-.. rst-class:: classref-item-separator
-
-----
-
 .. _class_Terrain3DData_method_get_color:
 
 .. rst-class:: classref-method
@@ -537,6 +551,76 @@ Returns ``4,294,967,295`` aka ``UINT32_MAX`` if the position is outside of defin
 
 ----
 
+.. _class_Terrain3DData_method_get_control_angle:
+
+.. rst-class:: classref-method
+
+:ref:`float<class_float>` **get_control_angle**\ (\ global_position\: :ref:`Vector3<class_Vector3>`\ ) |const| :ref:`🔗<class_Terrain3DData_method_get_control_angle>`
+
+Returns the angle, aka uv rotation, on the control map at the requested position. Values are fixed to 22.5 degree intervals, for a maximum of 16 angles. 360 / 16 = 22.5.
+
+Returns ``NAN`` if the position is outside of defined regions.
+
+.. rst-class:: classref-item-separator
+
+----
+
+.. _class_Terrain3DData_method_get_control_auto:
+
+.. rst-class:: classref-method
+
+:ref:`bool<class_bool>` **get_control_auto**\ (\ global_position\: :ref:`Vector3<class_Vector3>`\ ) |const| :ref:`🔗<class_Terrain3DData_method_get_control_auto>`
+
+Returns whether the autoshader is enabled on the control map at the requested position.
+
+Returns ``false`` if the position is outside of defined regions.
+
+.. rst-class:: classref-item-separator
+
+----
+
+.. _class_Terrain3DData_method_get_control_base_id:
+
+.. rst-class:: classref-method
+
+:ref:`int<class_int>` **get_control_base_id**\ (\ global_position\: :ref:`Vector3<class_Vector3>`\ ) |const| :ref:`🔗<class_Terrain3DData_method_get_control_base_id>`
+
+Returns the base texture ID on the control map at the requested position. Values are 0 - 31, which matches the ID of the texture asset in the asset dock.
+
+Returns ``4,294,967,295`` aka ``UINT32_MAX`` if the position is outside of defined regions.
+
+.. rst-class:: classref-item-separator
+
+----
+
+.. _class_Terrain3DData_method_get_control_blend:
+
+.. rst-class:: classref-method
+
+:ref:`float<class_float>` **get_control_blend**\ (\ global_position\: :ref:`Vector3<class_Vector3>`\ ) |const| :ref:`🔗<class_Terrain3DData_method_get_control_blend>`
+
+Returns the blend value between the base texture ID and the overlay texture ID. The value is clamped between 0.0 - 1.0 where 0.0 shows only the base texture, and 1.0 shows only the overlay texture.
+
+Returns ``NAN`` if the position is outside of defined regions.
+
+.. rst-class:: classref-item-separator
+
+----
+
+.. _class_Terrain3DData_method_get_control_hole:
+
+.. rst-class:: classref-method
+
+:ref:`bool<class_bool>` **get_control_hole**\ (\ global_position\: :ref:`Vector3<class_Vector3>`\ ) |const| :ref:`🔗<class_Terrain3DData_method_get_control_hole>`
+
+Returns whether there is a hole on the control map at the requested position.
+
+Returns ``false`` if the position is outside of defined regions.
+
+.. rst-class:: classref-item-separator
+
+----
+
 .. _class_Terrain3DData_method_get_control_maps_rid:
 
 .. rst-class:: classref-method
@@ -544,6 +628,48 @@ Returns ``4,294,967,295`` aka ``UINT32_MAX`` if the position is outside of defin
 :ref:`RID<class_RID>` **get_control_maps_rid**\ (\ ) |const| :ref:`🔗<class_Terrain3DData_method_get_control_maps_rid>`
 
 Returns the resource ID of the generated control map Texture Array sent to the shader. You can use this RID with the RenderingServer to set it as a shader parameter for a sampler2DArray uniform in your own shader. See `Tips <../docs/tips.html#using-the-generated-height-map-in-other-shaders>`__ for an example.
+
+.. rst-class:: classref-item-separator
+
+----
+
+.. _class_Terrain3DData_method_get_control_navigation:
+
+.. rst-class:: classref-method
+
+:ref:`bool<class_bool>` **get_control_navigation**\ (\ global_position\: :ref:`Vector3<class_Vector3>`\ ) |const| :ref:`🔗<class_Terrain3DData_method_get_control_navigation>`
+
+Returns whether navigation is enabled on the control map at the requested position.
+
+Returns ``false`` if the position is outside of defined regions.
+
+.. rst-class:: classref-item-separator
+
+----
+
+.. _class_Terrain3DData_method_get_control_overlay_id:
+
+.. rst-class:: classref-method
+
+:ref:`int<class_int>` **get_control_overlay_id**\ (\ global_position\: :ref:`Vector3<class_Vector3>`\ ) |const| :ref:`🔗<class_Terrain3DData_method_get_control_overlay_id>`
+
+Returns the overlay texture ID on the control map at the requested position. Values are 0 - 31, which matches the ID of the texture asset in the asset dock.
+
+Returns ``4,294,967,295`` aka ``UINT32_MAX`` if the position is outside of defined regions.
+
+.. rst-class:: classref-item-separator
+
+----
+
+.. _class_Terrain3DData_method_get_control_scale:
+
+.. rst-class:: classref-method
+
+:ref:`float<class_float>` **get_control_scale**\ (\ global_position\: :ref:`Vector3<class_Vector3>`\ ) |const| :ref:`🔗<class_Terrain3DData_method_get_control_scale>`
+
+Returns the uv scale on the control map at the requested position. The value is rounded to the nearest 20% difference from 100%, ranging between -60% to +80%. Eg. +20% or -40%.
+
+Returns ``NAN`` if the position is outside of defined regions.
 
 .. rst-class:: classref-item-separator
 
@@ -791,20 +917,6 @@ Returns ``Color(NAN, NAN, NAN, NAN)`` if the position is outside of defined regi
 
 ----
 
-.. _class_Terrain3DData_method_get_scale:
-
-.. rst-class:: classref-method
-
-:ref:`float<class_float>` **get_scale**\ (\ global_position\: :ref:`Vector3<class_Vector3>`\ ) |const| :ref:`🔗<class_Terrain3DData_method_get_scale>`
-
-Returns the uv scale painted on the control map at the requested position. The value is a percentage difference from 100% scale. Eg. +20% or -40%. 
-
-Returns ``NAN`` if the position is outside of defined regions.
-
-.. rst-class:: classref-item-separator
-
-----
-
 .. _class_Terrain3DData_method_get_texture_id:
 
 .. rst-class:: classref-method
@@ -1019,6 +1131,114 @@ Sets the value on the control map pixel associated with the specified position. 
 
 ----
 
+.. _class_Terrain3DData_method_set_control_angle:
+
+.. rst-class:: classref-method
+
+|void| **set_control_angle**\ (\ global_position\: :ref:`Vector3<class_Vector3>`, degrees\: :ref:`float<class_float>`\ ) :ref:`🔗<class_Terrain3DData_method_set_control_angle>`
+
+Sets the angle, aka uv rotation, on the control map at the requested position. Values are rounded to the nearest 22.5 degree interval, for a maximum of 16 angles. 360 / 16 = 22.5.
+
+See :ref:`set_pixel<class_Terrain3DData_method_set_pixel>` for important information.
+
+.. rst-class:: classref-item-separator
+
+----
+
+.. _class_Terrain3DData_method_set_control_auto:
+
+.. rst-class:: classref-method
+
+|void| **set_control_auto**\ (\ global_position\: :ref:`Vector3<class_Vector3>`, enable\: :ref:`bool<class_bool>`\ ) :ref:`🔗<class_Terrain3DData_method_set_control_auto>`
+
+Sets if the material should render the autoshader or manual texturing on the control map at the requested position.
+
+See :ref:`set_pixel<class_Terrain3DData_method_set_pixel>` for important information.
+
+.. rst-class:: classref-item-separator
+
+----
+
+.. _class_Terrain3DData_method_set_control_base_id:
+
+.. rst-class:: classref-method
+
+|void| **set_control_base_id**\ (\ global_position\: :ref:`Vector3<class_Vector3>`, texture_id\: :ref:`int<class_int>`\ ) :ref:`🔗<class_Terrain3DData_method_set_control_base_id>`
+
+Sets the base texture ID on the control map at the requested position. Values are clamped to 0 - 31, matching the ID of the texture asset in the asset dock.
+
+See :ref:`set_pixel<class_Terrain3DData_method_set_pixel>` for important information.
+
+.. rst-class:: classref-item-separator
+
+----
+
+.. _class_Terrain3DData_method_set_control_blend:
+
+.. rst-class:: classref-method
+
+|void| **set_control_blend**\ (\ global_position\: :ref:`Vector3<class_Vector3>`, blend_value\: :ref:`float<class_float>`\ ) :ref:`🔗<class_Terrain3DData_method_set_control_blend>`
+
+Sets the blend value between the base texture ID, and the overlay texture ID. The value is clamped between 0.0 - 1.0 where 0.0 shows only the base texture, and 1.0 shows only the overlay texture.
+
+See :ref:`set_pixel<class_Terrain3DData_method_set_pixel>` for important information.
+
+.. rst-class:: classref-item-separator
+
+----
+
+.. _class_Terrain3DData_method_set_control_hole:
+
+.. rst-class:: classref-method
+
+|void| **set_control_hole**\ (\ global_position\: :ref:`Vector3<class_Vector3>`, enable\: :ref:`bool<class_bool>`\ ) :ref:`🔗<class_Terrain3DData_method_set_control_hole>`
+
+Sets if a hole should be rendered on the control map at the requested position. See :ref:`set_pixel<class_Terrain3DData_method_set_pixel>` for important information.
+
+.. rst-class:: classref-item-separator
+
+----
+
+.. _class_Terrain3DData_method_set_control_navigation:
+
+.. rst-class:: classref-method
+
+|void| **set_control_navigation**\ (\ global_position\: :ref:`Vector3<class_Vector3>`, enable\: :ref:`bool<class_bool>`\ ) :ref:`🔗<class_Terrain3DData_method_set_control_navigation>`
+
+Sets if navigation generation is enabled on the control map at the requested position. See :ref:`set_pixel<class_Terrain3DData_method_set_pixel>` for important information.
+
+.. rst-class:: classref-item-separator
+
+----
+
+.. _class_Terrain3DData_method_set_control_overlay_id:
+
+.. rst-class:: classref-method
+
+|void| **set_control_overlay_id**\ (\ global_position\: :ref:`Vector3<class_Vector3>`, texture_id\: :ref:`int<class_int>`\ ) :ref:`🔗<class_Terrain3DData_method_set_control_overlay_id>`
+
+Sets the overlay texture ID on the control map at the requested position. Values are clamped to 0 - 31, matching the ID of the texture asset in the asset dock.
+
+See :ref:`set_pixel<class_Terrain3DData_method_set_pixel>` for important information.
+
+.. rst-class:: classref-item-separator
+
+----
+
+.. _class_Terrain3DData_method_set_control_scale:
+
+.. rst-class:: classref-method
+
+|void| **set_control_scale**\ (\ global_position\: :ref:`Vector3<class_Vector3>`, percentage_modifier\: :ref:`float<class_float>`\ ) :ref:`🔗<class_Terrain3DData_method_set_control_scale>`
+
+Sets the uv scale on the control map at the requested position. The value is rounded to the nearest 20% difference from 100%, ranging between -60% to +80%.
+
+See :ref:`set_pixel<class_Terrain3DData_method_set_pixel>` for important information.
+
+.. rst-class:: classref-item-separator
+
+----
+
 .. _class_Terrain3DData_method_set_height:
 
 .. rst-class:: classref-method
@@ -1039,7 +1259,7 @@ Unlike :ref:`get_height<class_Terrain3DData_method_get_height>`, which interpola
 
 |void| **set_pixel**\ (\ map_type\: :ref:`MapType<enum_Terrain3DRegion_MapType>`, global_position\: :ref:`Vector3<class_Vector3>`, pixel\: :ref:`Color<class_Color>`\ ) :ref:`🔗<class_Terrain3DData_method_set_pixel>`
 
-Sets the pixel for the map type associated with the specified position. This method is fine for setting a few pixels, but if you wish to modify thousands of pixels quickly, you should get the region and :ref:`Terrain3DRegion.get_map<class_Terrain3DRegion_method_get_map>` to edit the images directly.
+Sets the pixel for the map type associated with the specified position. This method is fine for setting a few pixels, but if you wish to modify thousands of pixels quickly, you should get the region and use :ref:`Terrain3DRegion.get_map<class_Terrain3DRegion_method_get_map>`, then edit the images directly.
 
 After setting pixels you need to call :ref:`force_update_maps<class_Terrain3DData_method_force_update_maps>`. You may also need to regenerate collision if you don't have dynamic collision enabled.
 

--- a/doc/classes/Terrain3DData.xml
+++ b/doc/classes/Terrain3DData.xml
@@ -81,14 +81,6 @@
 				- generate_mipmaps - Generates mipmaps for the color maps. This can also be done on individual regions with [code skip-lint]region.get_color_map().generate_mipmaps()[/code].
 			</description>
 		</method>
-		<method name="get_angle" qualifiers="const">
-			<return type="float" />
-			<param index="0" name="global_position" type="Vector3" />
-			<description>
-				Returns the angle, aka uv rotation, painted on the control map at the requested position. Values are fixed to 22.5 degree intervals, for a maximum of 16 angles. 360 / 16 = 22.5.
-				Returns [code skip-lint]NAN[/code] if the position is outside of defined regions.
-			</description>
-		</method>
 		<method name="get_color" qualifiers="const">
 			<return type="Color" />
 			<param index="0" name="global_position" type="Vector3" />
@@ -111,10 +103,74 @@
 				Returns [code skip-lint]4,294,967,295[/code] aka [code skip-lint]UINT32_MAX[/code] if the position is outside of defined regions.
 			</description>
 		</method>
+		<method name="get_control_angle" qualifiers="const">
+			<return type="float" />
+			<param index="0" name="global_position" type="Vector3" />
+			<description>
+				Returns the angle, aka uv rotation, on the control map at the requested position. Values are fixed to 22.5 degree intervals, for a maximum of 16 angles. 360 / 16 = 22.5.
+				Returns [code skip-lint]NAN[/code] if the position is outside of defined regions.
+			</description>
+		</method>
+		<method name="get_control_auto" qualifiers="const">
+			<return type="bool" />
+			<param index="0" name="global_position" type="Vector3" />
+			<description>
+				Returns whether the autoshader is enabled on the control map at the requested position.
+				Returns [code skip-lint]false[/code] if the position is outside of defined regions.
+			</description>
+		</method>
+		<method name="get_control_base_id" qualifiers="const">
+			<return type="int" />
+			<param index="0" name="global_position" type="Vector3" />
+			<description>
+				Returns the base texture ID on the control map at the requested position. Values are 0 - 31, which matches the ID of the texture asset in the asset dock.
+				Returns [code skip-lint]4,294,967,295[/code] aka [code skip-lint]UINT32_MAX[/code] if the position is outside of defined regions.
+			</description>
+		</method>
+		<method name="get_control_blend" qualifiers="const">
+			<return type="float" />
+			<param index="0" name="global_position" type="Vector3" />
+			<description>
+				Returns the blend value between the base texture ID and the overlay texture ID. The value is clamped between 0.0 - 1.0 where 0.0 shows only the base texture, and 1.0 shows only the overlay texture.
+				Returns [code skip-lint]NAN[/code] if the position is outside of defined regions.
+			</description>
+		</method>
+		<method name="get_control_hole" qualifiers="const">
+			<return type="bool" />
+			<param index="0" name="global_position" type="Vector3" />
+			<description>
+				Returns whether there is a hole on the control map at the requested position.
+				Returns [code skip-lint]false[/code] if the position is outside of defined regions.
+			</description>
+		</method>
 		<method name="get_control_maps_rid" qualifiers="const">
 			<return type="RID" />
 			<description>
 				Returns the resource ID of the generated control map Texture Array sent to the shader. You can use this RID with the RenderingServer to set it as a shader parameter for a sampler2DArray uniform in your own shader. See [url=../docs/tips.html#using-the-generated-height-map-in-other-shaders]Tips[/url] for an example.
+			</description>
+		</method>
+		<method name="get_control_navigation" qualifiers="const">
+			<return type="bool" />
+			<param index="0" name="global_position" type="Vector3" />
+			<description>
+				Returns whether navigation is enabled on the control map at the requested position.
+				Returns [code skip-lint]false[/code] if the position is outside of defined regions.
+			</description>
+		</method>
+		<method name="get_control_overlay_id" qualifiers="const">
+			<return type="int" />
+			<param index="0" name="global_position" type="Vector3" />
+			<description>
+				Returns the overlay texture ID on the control map at the requested position. Values are 0 - 31, which matches the ID of the texture asset in the asset dock.
+				Returns [code skip-lint]4,294,967,295[/code] aka [code skip-lint]UINT32_MAX[/code] if the position is outside of defined regions.
+			</description>
+		</method>
+		<method name="get_control_scale" qualifiers="const">
+			<return type="float" />
+			<param index="0" name="global_position" type="Vector3" />
+			<description>
+				Returns the uv scale on the control map at the requested position. The value is rounded to the nearest 20% difference from 100%, ranging between -60% to +80%. Eg. +20% or -40%.
+				Returns [code skip-lint]NAN[/code] if the position is outside of defined regions.
 			</description>
 		</method>
 		<method name="get_height" qualifiers="const">
@@ -255,14 +311,6 @@
 				Returns [code skip-lint]Color(NAN, NAN, NAN, NAN)[/code] if the position is outside of defined regions.
 			</description>
 		</method>
-		<method name="get_scale" qualifiers="const">
-			<return type="float" />
-			<param index="0" name="global_position" type="Vector3" />
-			<description>
-				Returns the uv scale painted on the control map at the requested position. The value is a percentage difference from 100% scale. Eg. +20% or -40%. 
-				Returns [code skip-lint]NAN[/code] if the position is outside of defined regions.
-			</description>
-		</method>
 		<method name="get_texture_id" qualifiers="const">
 			<return type="Vector3" />
 			<param index="0" name="global_position" type="Vector3" />
@@ -398,6 +446,76 @@
 				Sets the value on the control map pixel associated with the specified position. See [method set_pixel] for important information.
 			</description>
 		</method>
+		<method name="set_control_angle">
+			<return type="void" />
+			<param index="0" name="global_position" type="Vector3" />
+			<param index="1" name="degrees" type="float" />
+			<description>
+				Sets the angle, aka uv rotation, on the control map at the requested position. Values are rounded to the nearest 22.5 degree interval, for a maximum of 16 angles. 360 / 16 = 22.5.
+				See [method set_pixel] for important information.
+			</description>
+		</method>
+		<method name="set_control_auto">
+			<return type="void" />
+			<param index="0" name="global_position" type="Vector3" />
+			<param index="1" name="enable" type="bool" />
+			<description>
+				Sets if the material should render the autoshader or manual texturing on the control map at the requested position.
+				See [method set_pixel] for important information.
+			</description>
+		</method>
+		<method name="set_control_base_id">
+			<return type="void" />
+			<param index="0" name="global_position" type="Vector3" />
+			<param index="1" name="texture_id" type="int" />
+			<description>
+				Sets the base texture ID on the control map at the requested position. Values are clamped to 0 - 31, matching the ID of the texture asset in the asset dock.
+				See [method set_pixel] for important information.
+			</description>
+		</method>
+		<method name="set_control_blend">
+			<return type="void" />
+			<param index="0" name="global_position" type="Vector3" />
+			<param index="1" name="blend_value" type="float" />
+			<description>
+				Sets the blend value between the base texture ID, and the overlay texture ID. The value is clamped between 0.0 - 1.0 where 0.0 shows only the base texture, and 1.0 shows only the overlay texture.
+				See [method set_pixel] for important information.
+			</description>
+		</method>
+		<method name="set_control_hole">
+			<return type="void" />
+			<param index="0" name="global_position" type="Vector3" />
+			<param index="1" name="enable" type="bool" />
+			<description>
+				Sets if a hole should be rendered on the control map at the requested position. See [method set_pixel] for important information.
+			</description>
+		</method>
+		<method name="set_control_navigation">
+			<return type="void" />
+			<param index="0" name="global_position" type="Vector3" />
+			<param index="1" name="enable" type="bool" />
+			<description>
+				Sets if navigation generation is enabled on the control map at the requested position. See [method set_pixel] for important information.
+			</description>
+		</method>
+		<method name="set_control_overlay_id">
+			<return type="void" />
+			<param index="0" name="global_position" type="Vector3" />
+			<param index="1" name="texture_id" type="int" />
+			<description>
+				Sets the overlay texture ID on the control map at the requested position. Values are clamped to 0 - 31, matching the ID of the texture asset in the asset dock.
+				See [method set_pixel] for important information.
+			</description>
+		</method>
+		<method name="set_control_scale">
+			<return type="void" />
+			<param index="0" name="global_position" type="Vector3" />
+			<param index="1" name="percentage_modifier" type="float" />
+			<description>
+				Sets the uv scale on the control map at the requested position. The value is rounded to the nearest 20% difference from 100%, ranging between -60% to +80%.
+				See [method set_pixel] for important information.
+			</description>
+		</method>
 		<method name="set_height">
 			<return type="void" />
 			<param index="0" name="global_position" type="Vector3" />
@@ -413,7 +531,7 @@
 			<param index="1" name="global_position" type="Vector3" />
 			<param index="2" name="pixel" type="Color" />
 			<description>
-				Sets the pixel for the map type associated with the specified position. This method is fine for setting a few pixels, but if you wish to modify thousands of pixels quickly, you should get the region and [method Terrain3DRegion.get_map] to edit the images directly.
+				Sets the pixel for the map type associated with the specified position. This method is fine for setting a few pixels, but if you wish to modify thousands of pixels quickly, you should get the region and use [method Terrain3DRegion.get_map], then edit the images directly.
 				After setting pixels you need to call [method force_update_maps]. You may also need to regenerate collision if you don't have dynamic collision enabled.
 			</description>
 		</method>

--- a/doc/docs/controlmap_format.md
+++ b/doc/docs/controlmap_format.md
@@ -11,7 +11,7 @@ We process each uint32 pixel as a bit field with the following definition, start
 | Overlay texture id | 0-31 | 5 | 27-23 | `(x & 0x1F) <<22` | `x >>22 & 0x1F`
 | Texture blend | 0-255 | 8 | 22-15 | `(x & 0xFF) <<14` | `x >>14 & 0xFF`
 | UV angle | 0-15 | 4 | 14-11 | `(x & 0xF) <<10` | `x >>10 & 0xF`
-| UV scale | 0-8 | 3 | 10-8 | `(x & 0x7) <<6` | `x >>6 & 0x7`
+| UV scale | 0-8 | 3 | 10-8 | `(x & 0x7) <<7` | `x >>7 & 0x7`
 | ... reserved ... | | | 
 | Hole: 0 terrain, 1 hole | 0-1 | 1 | 3 | `(x & 0x1) <<2` | `x >>2 & 0x1`
 | Navigation: 0 no, 1 yes | 0-1 | 1 | 2 | `(x & 0x1) <<1` | `x >>1 & 0x1`

--- a/project/addons/terrain_3d/src/ui.gd
+++ b/project/addons/terrain_3d/src/ui.gd
@@ -418,9 +418,9 @@ func pick(p_global_position: Vector3) -> void:
 			Terrain3DEditor.COLOR:
 				color = plugin.terrain.data.get_color(p_global_position)
 			Terrain3DEditor.ANGLE:
-				color = Color(plugin.terrain.data.get_angle(p_global_position), 0., 0., 1.)
+				color = Color(plugin.terrain.data.get_control_angle(p_global_position), 0., 0., 1.)
 			Terrain3DEditor.SCALE:
-				color = Color(plugin.terrain.data.get_scale(p_global_position), 0., 0., 1.)
+				color = Color(plugin.terrain.data.get_control_scale(p_global_position), 0., 0., 1.)
 			_:
 				push_error("Unsupported picking type: ", picking)
 				return

--- a/src/terrain_3d_data.cpp
+++ b/src/terrain_3d_data.cpp
@@ -638,26 +638,6 @@ real_t Terrain3DData::get_height(const Vector3 &p_global_position) const {
 	}
 }
 
-real_t Terrain3DData::get_angle(const Vector3 &p_global_position) const {
-	float src = get_pixel(TYPE_CONTROL, p_global_position).r; // Must be 32-bit float, not double/real
-	if (std::isnan(src)) {
-		return NAN;
-	}
-	real_t angle = real_t(get_uv_rotation(src));
-	angle *= 22.5; // Return value in degrees.
-	return angle;
-}
-
-real_t Terrain3DData::get_scale(const Vector3 &p_global_position) const {
-	float src = get_pixel(TYPE_CONTROL, p_global_position).r; // Must be 32-bit float, not double/real
-	if (std::isnan(src)) {
-		return NAN;
-	}
-	std::array<real_t, 8> scale_values = { 0.0f, 20.0f, 40.0f, 60.0f, 80.0f, -60.0f, -40.0f, -20.0f };
-	real_t scale = scale_values[get_uv_scale(src)]; //select from array UI return values
-	return scale;
-}
-
 Vector3 Terrain3DData::get_normal(const Vector3 &p_global_position) const {
 	if (get_region_idp(p_global_position) < 0 || is_hole(get_control(p_global_position))) {
 		return Vector3(NAN, NAN, NAN);
@@ -1132,8 +1112,23 @@ void Terrain3DData::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("get_control", "global_position"), &Terrain3DData::get_control);
 	ClassDB::bind_method(D_METHOD("set_roughness", "global_position", "roughness"), &Terrain3DData::set_roughness);
 	ClassDB::bind_method(D_METHOD("get_roughness", "global_position"), &Terrain3DData::get_roughness);
-	ClassDB::bind_method(D_METHOD("get_angle", "global_position"), &Terrain3DData::get_angle);
-	ClassDB::bind_method(D_METHOD("get_scale", "global_position"), &Terrain3DData::get_scale);
+
+	ClassDB::bind_method(D_METHOD("set_control_base_id", "global_position", "texture_id"), &Terrain3DData::set_control_base_id);
+	ClassDB::bind_method(D_METHOD("get_control_base_id", "global_position"), &Terrain3DData::get_control_base_id);
+	ClassDB::bind_method(D_METHOD("set_control_overlay_id", "global_position", "texture_id"), &Terrain3DData::set_control_overlay_id);
+	ClassDB::bind_method(D_METHOD("get_control_overlay_id", "global_position"), &Terrain3DData::get_control_overlay_id);
+	ClassDB::bind_method(D_METHOD("set_control_blend", "global_position", "blend_value"), &Terrain3DData::set_control_blend);
+	ClassDB::bind_method(D_METHOD("get_control_blend", "global_position"), &Terrain3DData::get_control_blend);
+	ClassDB::bind_method(D_METHOD("set_control_angle", "global_position", "degrees"), &Terrain3DData::set_control_angle);
+	ClassDB::bind_method(D_METHOD("get_control_angle", "global_position"), &Terrain3DData::get_control_angle);
+	ClassDB::bind_method(D_METHOD("set_control_scale", "global_position", "percentage_modifier"), &Terrain3DData::set_control_scale);
+	ClassDB::bind_method(D_METHOD("get_control_scale", "global_position"), &Terrain3DData::get_control_scale);
+	ClassDB::bind_method(D_METHOD("set_control_hole", "global_position", "enable"), &Terrain3DData::set_control_hole);
+	ClassDB::bind_method(D_METHOD("get_control_hole", "global_position"), &Terrain3DData::get_control_hole);
+	ClassDB::bind_method(D_METHOD("set_control_navigation", "global_position", "enable"), &Terrain3DData::set_control_navigation);
+	ClassDB::bind_method(D_METHOD("get_control_navigation", "global_position"), &Terrain3DData::get_control_navigation);
+	ClassDB::bind_method(D_METHOD("set_control_auto", "global_position", "enable"), &Terrain3DData::set_control_auto);
+	ClassDB::bind_method(D_METHOD("get_control_auto", "global_position"), &Terrain3DData::get_control_auto);
 
 	ClassDB::bind_method(D_METHOD("get_normal", "global_position"), &Terrain3DData::get_normal);
 	ClassDB::bind_method(D_METHOD("get_texture_id", "global_position"), &Terrain3DData::get_texture_id);


### PR DESCRIPTION
Need some feedback about function names, everything tested and working ok.

this method of taking the original control, and masking before or-ing could be added to the util docs page too.
``(control & ~(0x1F << 27)) | (base >> 27 & 0x1F)``