### PR TITLE
[4.3] Replace Godot deprecated functions

### DIFF
--- a/project/addons/terrain_3d/src/baker.gd
+++ b/project/addons/terrain_3d/src/baker.gd
@@ -194,7 +194,7 @@ func _bake_nav_region_nav_mesh(p_nav_region: NavigationRegion3D) -> void:
 	assert(nav_mesh != null)
 	
 	var source_geometry_data := NavigationMeshSourceGeometryData3D.new()
-	NavigationMeshGenerator.parse_source_geometry_data(nav_mesh, source_geometry_data, p_nav_region)
+	NavigationServer3D.parse_source_geometry_data(nav_mesh, source_geometry_data, p_nav_region)
 	
 	for terrain in find_nav_region_terrains(p_nav_region):
 		var aabb: AABB = nav_mesh.filter_baking_aabb
@@ -204,7 +204,7 @@ func _bake_nav_region_nav_mesh(p_nav_region: NavigationRegion3D) -> void:
 		if not faces.is_empty():
 			source_geometry_data.add_faces(faces, Transform3D.IDENTITY)
 	
-	NavigationMeshGenerator.bake_from_source_geometry_data(nav_mesh, source_geometry_data)
+	NavigationServer3D.bake_from_source_geometry_data(nav_mesh, source_geometry_data)
 	
 	_postprocess_nav_mesh(nav_mesh)
 	

--- a/project/demo/src/CodeGenerated.gd
+++ b/project/demo/src/CodeGenerated.gd
@@ -18,7 +18,7 @@ func _ready():
 	# Generate 32-bit noise and import it with scale
 	var noise := FastNoiseLite.new()
 	noise.frequency = 0.0005
-	var img: Image = Image.create(2048, 2048, false, Image.FORMAT_RF)
+	var img: Image = Image.create_empty(2048, 2048, false, Image.FORMAT_RF)
 	for x in 2048:
 		for y in 2048:
 			img.set_pixel(x, y, Color(noise.get_noise_2d(x, y)*0.5, 0., 0., 1.))

--- a/project/demo/src/RuntimeNavigationBaker.gd
+++ b/project/demo/src/RuntimeNavigationBaker.gd
@@ -79,7 +79,7 @@ func set_template(p_value: NavigationMesh) -> void:
 
 func parse_scene() -> void:
 	_scene_geometry = NavigationMeshSourceGeometryData3D.new()
-	NavigationMeshGenerator.parse_source_geometry_data(template, _scene_geometry, self)
+	NavigationServer3D.parse_source_geometry_data(template, _scene_geometry, self)
 
 
 func _update_map_cell_size() -> void:
@@ -131,7 +131,7 @@ func _task_bake(p_center: Vector3) -> void:
 		source_geometry.add_faces(faces, Transform3D.IDENTITY)
 	
 	if source_geometry.has_data():
-		NavigationMeshGenerator.bake_from_source_geometry_data(nav_mesh, source_geometry)
+		NavigationServer3D.bake_from_source_geometry_data(nav_mesh, source_geometry)
 		_bake_finished.call_deferred(nav_mesh)
 	else:
 		_bake_finished.call_deferred(null)

--- a/src/terrain_3d_data.cpp
+++ b/src/terrain_3d_data.cpp
@@ -887,7 +887,7 @@ void Terrain3DData::import_images(const TypedArray<Image> &p_images, const Vecto
 		// Apply scale and offsets to a new heightmap if applicable
 		if (i == TYPE_HEIGHT && (p_offset != 0.f || p_scale != 1.f)) {
 			LOG(DEBUG, "Creating new temp image to adjust scale: ", p_scale, " offset: ", p_offset);
-			Ref<Image> newimg = Image::create(img->get_size().x, img->get_size().y, false, FORMAT[TYPE_HEIGHT]);
+			Ref<Image> newimg = Image::create_empty(img->get_size().x, img->get_size().y, false, FORMAT[TYPE_HEIGHT]);
 			for (int y = 0; y < img->get_height(); y++) {
 				for (int x = 0; x < img->get_width(); x++) {
 					Color clr = img->get_pixel(x, y);

--- a/src/terrain_3d_util.cpp
+++ b/src/terrain_3d_util.cpp
@@ -111,7 +111,7 @@ Ref<Image> Terrain3DUtil::black_to_alpha(const Ref<Image> &p_image) {
 	if (p_image.is_null()) {
 		return Ref<Image>();
 	}
-	Ref<Image> img = Image::create(p_image->get_width(), p_image->get_height(), p_image->has_mipmaps(), Image::FORMAT_RGBAF);
+	Ref<Image> img = Image::create_empty(p_image->get_width(), p_image->get_height(), p_image->has_mipmaps(), Image::FORMAT_RGBAF);
 	for (int y = 0; y < img->get_height(); y++) {
 		for (int x = 0; x < img->get_width(); x++) {
 			Color pixel = p_image->get_pixel(x, y);
@@ -184,7 +184,7 @@ Ref<Image> Terrain3DUtil::get_thumbnail(const Ref<Image> &p_image, const Vector2
 	hmax = (hmax == 0) ? 0.001f : hmax;
 
 	// Create a new image w / normalized values
-	Ref<Image> thumb = Image::create(size.x, size.y, false, Image::FORMAT_RGB8);
+	Ref<Image> thumb = Image::create_empty(size.x, size.y, false, Image::FORMAT_RGB8);
 	for (int y = 0; y < thumb->get_height(); y++) {
 		for (int x = 0; x < thumb->get_width(); x++) {
 			Color col = img->get_pixel(x, y);
@@ -247,7 +247,7 @@ Ref<Image> Terrain3DUtil::get_filled_image(const Vector2i &p_size, const Color &
 		}
 	}
 
-	Ref<Image> img = Image::create(p_size.x, p_size.y, p_create_mipmaps, format);
+	Ref<Image> img = Image::create_empty(p_size.x, p_size.y, p_create_mipmaps, format);
 
 	Color color = p_color;
 	if (fill_image) {
@@ -310,7 +310,7 @@ Ref<Image> Terrain3DUtil::load_image(const String &p_file_name, const int p_cach
 			LOG(DEBUG, "Total file size is: ", fsize, " calculated width: ", fwidth, " dimensions: ", r16_size);
 			file->seek(0);
 		}
-		img = Image::create(r16_size.x, r16_size.y, false, FORMAT[TYPE_HEIGHT]);
+		img = Image::create_empty(r16_size.x, r16_size.y, false, FORMAT[TYPE_HEIGHT]);
 		for (int y = 0; y < r16_size.y; y++) {
 			for (int x = 0; x < r16_size.x; x++) {
 				real_t h = real_t(file->get_16()) / 65535.0f;
@@ -364,7 +364,7 @@ Ref<Image> Terrain3DUtil::pack_image(const Ref<Image> &p_src_rgb, const Ref<Imag
 		LOG(ERROR, "Source Channel of Height/Roughness invalid. Cannot Pack")
 		return Ref<Image>();
 	}
-	Ref<Image> dst = Image::create(p_src_rgb->get_width(), p_src_rgb->get_height(), false, Image::FORMAT_RGBA8);
+	Ref<Image> dst = Image::create_empty(p_src_rgb->get_width(), p_src_rgb->get_height(), false, Image::FORMAT_RGBA8);
 	LOG(INFO, "Creating image from source RGB + source channel images");
 	for (int y = 0; y < p_src_rgb->get_height(); y++) {
 		for (int x = 0; x < p_src_rgb->get_width(); x++) {
@@ -405,7 +405,7 @@ Ref<Image> Terrain3DUtil::luminance_to_height(const Ref<Image> &p_src_rgb) {
 		}
 	}
 	lum_contrast = 1.0f / MAX(l_max - l_min, 1e-6);
-	Ref<Image> dst = Image::create(p_src_rgb->get_width(), p_src_rgb->get_height(), false, Image::FORMAT_RGB8);
+	Ref<Image> dst = Image::create_empty(p_src_rgb->get_width(), p_src_rgb->get_height(), false, Image::FORMAT_RGB8);
 	for (int y = 0; y < p_src_rgb->get_height(); y++) {
 		for (int x = 0; x < p_src_rgb->get_width(); x++) {
 			Color col = p_src_rgb->get_pixel(x, y);


### PR DESCRIPTION
Image::create() is deprecated, thus it does not exist if Godot is built with the Scons option "deprecated=no".
It must be changed to Image::create_empty() for better compatibility.

FYI:
https://github.com/godotengine/godot/blob/4.3-stable/core/io/image.cpp#L3428