### PR TITLE
Compatibility renderer support

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ A high performance, editable terrain system for Godot 4.
 * Written in C++ as a GDExtension addon, which works with official engine builds
 * Can be accessed by GDScript, C#, and any language Godot supports
 * Geometric Clipmap Mesh Terrain, as used in The Witcher 3. See [System Architecture](https://terrain3d.readthedocs.io/en/stable/docs/system_architecture.html) 
-* Up to 16k x 16k in 1k regions (imagine multiple islands without paying for 16k^2 vram)
+* Terrains as small as 64x64m up to 65.5x65.5km (4295km^2) in variable sized regions
 * Up to 32 textures
 * Up to 10 levels of detail
 * Foliage instancing

--- a/doc/api/class_terrain3d.rst
+++ b/doc/api/class_terrain3d.rst
@@ -108,6 +108,8 @@ Methods
    +-----------------------------------------------------+-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
    | :ref:`EditorPlugin<class_EditorPlugin>`             | :ref:`get_plugin<class_Terrain3D_method_get_plugin>`\ (\ ) |const|                                                                                                                                    |
    +-----------------------------------------------------+-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
+   | :ref:`bool<class_bool>`                             | :ref:`is_compatibility_mode<class_Terrain3D_method_is_compatibility_mode>`\ (\ ) |const|                                                                                                              |
+   +-----------------------------------------------------+-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
    | |void|                                              | :ref:`set_camera<class_Terrain3D_method_set_camera>`\ (\ camera\: :ref:`Camera3D<class_Camera3D>`\ )                                                                                                  |
    +-----------------------------------------------------+-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
    | |void|                                              | :ref:`set_editor<class_Terrain3D_method_set_editor>`\ (\ editor\: :ref:`Terrain3DEditor<class_Terrain3DEditor>`\ )                                                                                    |
@@ -822,6 +824,18 @@ It does require the use of an editor render layer (21-32) that should be dedicat
 :ref:`EditorPlugin<class_EditorPlugin>` **get_plugin**\ (\ ) |const| :ref:`🔗<class_Terrain3D_method_get_plugin>`
 
 Returns the EditorPlugin connected to Terrain3D.
+
+.. rst-class:: classref-item-separator
+
+----
+
+.. _class_Terrain3D_method_is_compatibility_mode:
+
+.. rst-class:: classref-method
+
+:ref:`bool<class_bool>` **is_compatibility_mode**\ (\ ) |const| :ref:`🔗<class_Terrain3D_method_is_compatibility_mode>`
+
+Returns true if Terrain3D has detected that the Compatibility renderer is in use.
 
 .. rst-class:: classref-item-separator
 

--- a/doc/api/class_terrain3ddata.rst
+++ b/doc/api/class_terrain3ddata.rst
@@ -282,7 +282,7 @@ Constants
 
 .. rst-class:: classref-constant
 
-**REGION_MAP_SIZE** = ``16`` :ref:`🔗<class_Terrain3DData_constant_REGION_MAP_SIZE>`
+**REGION_MAP_SIZE** = ``32`` :ref:`🔗<class_Terrain3DData_constant_REGION_MAP_SIZE>`
 
 Hard coded number of regions on a side. The total number of regions is this squared.
 
@@ -715,7 +715,7 @@ Returns the calculated region location for the given global position. This is ju
 
 :ref:`PackedInt32Array<class_PackedInt32Array>` **get_region_map**\ (\ ) |const| :ref:`🔗<class_Terrain3DData_method_get_region_map>`
 
-Returns a fully populated 16 x 16 array. The array location contains the region id + 1, or 0, which means no region.
+Returns a fully populated 32 x 32 array. The array location contains the region id + 1, or 0, which means no region.
 
 See :ref:`get_region_map_index<class_Terrain3DData_method_get_region_map_index>`.
 
@@ -731,7 +731,7 @@ See :ref:`get_region_map_index<class_Terrain3DData_method_get_region_map_index>`
 
 Given a region location, returns the index into the region map array. See :ref:`get_region_map<class_Terrain3DData_method_get_region_map>`.
 
-You can use this function to quickly determine if a location is within the greater world bounds (-8,-8) to (7, 7). It returns -1 if not.
+You can use this function to quickly determine if a location is within the greater world bounds (-16,-16) to (15, 15). It returns -1 if not.
 
 .. rst-class:: classref-item-separator
 
@@ -859,7 +859,7 @@ Imports an Image set (Height, Control, Color) into this resource. It does NOT no
 
 \ ``images`` - MapType.TYPE_MAX sized array of Images for Height, Control, Color. Images can be blank or null.
 
-\ ``global_position`` - X,0,Z position on the region map. Valid range is :ref:`Terrain3D.vertex_spacing<class_Terrain3D_property_vertex_spacing>` \* (+/-8192, +/-8192).
+\ ``global_position`` - X,0,Z position on the region map. Valid range is :ref:`Terrain3D.vertex_spacing<class_Terrain3D_property_vertex_spacing>` \* :ref:`Terrain3D.region_size<class_Terrain3D_property_region_size>` \* (+/-16, +/-16).
 
 \ ``offset`` - Add this factor to all height values, can be negative.
 

--- a/doc/api/class_terrain3dstorage.rst
+++ b/doc/api/class_terrain3dstorage.rst
@@ -159,7 +159,7 @@ Constants
 
 .. rst-class:: classref-constant
 
-**REGION_MAP_SIZE** = ``16`` :ref:`🔗<class_Terrain3DStorage_constant_REGION_MAP_SIZE>`
+**REGION_MAP_SIZE** = ``32`` :ref:`🔗<class_Terrain3DStorage_constant_REGION_MAP_SIZE>`
 
 .. container:: contribute
 

--- a/doc/classes/Terrain3D.xml
+++ b/doc/classes/Terrain3D.xml
@@ -68,6 +68,12 @@
 				Returns the EditorPlugin connected to Terrain3D.
 			</description>
 		</method>
+		<method name="is_compatibility_mode" qualifiers="const">
+			<return type="bool" />
+			<description>
+				Returns true if Terrain3D has detected that the Compatibility renderer is in use.
+			</description>
+		</method>
 		<method name="set_camera">
 			<return type="void" />
 			<param index="0" name="camera" type="Camera3D" />

--- a/doc/classes/Terrain3DData.xml
+++ b/doc/classes/Terrain3DData.xml
@@ -212,7 +212,7 @@
 		<method name="get_region_map" qualifiers="const">
 			<return type="PackedInt32Array" />
 			<description>
-				Returns a fully populated 16 x 16 array. The array location contains the region id + 1, or 0, which means no region.
+				Returns a fully populated 32 x 32 array. The array location contains the region id + 1, or 0, which means no region.
 				See [method get_region_map_index].
 			</description>
 		</method>
@@ -221,7 +221,7 @@
 			<param index="0" name="region_location" type="Vector2i" />
 			<description>
 				Given a region location, returns the index into the region map array. See [method get_region_map].
-				You can use this function to quickly determine if a location is within the greater world bounds (-8,-8) to (7, 7). It returns -1 if not.
+				You can use this function to quickly determine if a location is within the greater world bounds (-16,-16) to (15, 15). It returns -1 if not.
 			</description>
 		</method>
 		<method name="get_regionp" qualifiers="const">
@@ -297,7 +297,7 @@
 			<description>
 				Imports an Image set (Height, Control, Color) into this resource. It does NOT normalize values to 0-1. You must do that using get_min_max() and adjusting scale and offset.
 				[code skip-lint]images[/code] - MapType.TYPE_MAX sized array of Images for Height, Control, Color. Images can be blank or null.
-				[code skip-lint]global_position[/code] - X,0,Z position on the region map. Valid range is [member Terrain3D.vertex_spacing] * (+/-8192, +/-8192).
+				[code skip-lint]global_position[/code] - X,0,Z position on the region map. Valid range is [member Terrain3D.vertex_spacing] * [member Terrain3D.region_size] * (+/-16, +/-16).
 				[code skip-lint]offset[/code] - Add this factor to all height values, can be negative.
 				[code skip-lint]scale[/code] - Scale all height values by this factor (applied after offset).
 			</description>
@@ -500,7 +500,7 @@
 		<constant name="HEIGHT_FILTER_MINIMUM" value="1" enum="HeightFilter">
 			Samples (1 &lt;&lt; lod) * 2 heights around the given coordinates and returns the lowest.
 		</constant>
-		<constant name="REGION_MAP_SIZE" value="16">
+		<constant name="REGION_MAP_SIZE" value="32">
 			Hard coded number of regions on a side. The total number of regions is this squared.
 		</constant>
 	</constants>

--- a/doc/classes/Terrain3DStorage.xml
+++ b/doc/classes/Terrain3DStorage.xml
@@ -53,7 +53,7 @@
 		</constant>
 		<constant name="SIZE_1024" value="1024" enum="RegionSize">
 		</constant>
-		<constant name="REGION_MAP_SIZE" value="16">
+		<constant name="REGION_MAP_SIZE" value="32">
 		</constant>
 	</constants>
 </class>

--- a/doc/docs/double_precision.md
+++ b/doc/docs/double_precision.md
@@ -15,7 +15,7 @@ For a more detailed explanation, see [Large World Coordinates](https://docs.godo
 * This feature is experimental and has had only one user give a positive report so far.
 * There are many caveats listed in the link above. You should read them all before beginning this process.
 * You must build Godot and Terrain3D from source.
-* Terrain3D currently only supports a maximum world of 16k by 16k, or (+/-8192, +/-8192). Although with `mesh_vertex_spacing`, you can expand this up to 10x. You can also have Terrain3D located around the origin, then have your own meshes or a shader generated terrain outside of that world. See [Support more region sizes #70](https://github.com/TokisanGames/Terrain3D/issues/77) for supporting worlds up to 90k per side and more.
+* Terrain3D currently supports a maximum world of 65.5x65.5km. Although with `vertex_spacing`, you can expand this up to 10x. You can also have Terrain3D located around the origin, then have your own meshes or a shader generated terrain outside of that world. See [Support more region sizes #70](https://github.com/TokisanGames/Terrain3D/issues/77) for supporting worlds up to 90k per side and more.
 * Shaders do not support double precision. Clayjohn wrote an article demonstrating how to [Emulate Double Precision](https://godotengine.org/article/emulating-double-precision-gpu-render-large-worlds/) in shaders. He wrote that the camera and model transform matrices needed to be emulated to support double precision. This is now done automatically in the engine when building it with double precision. There may be other cases where shaders will need this emulation.
 
 

--- a/doc/docs/import_export.md
+++ b/doc/docs/import_export.md
@@ -18,8 +18,8 @@ Currently importing and exporting is possible via code or our import tool. We wi
 4) Specify the `import_position` of where in the world you want to import. Values are rounded to the nearest `region_size` (defaults to 1024). So a location of (-2000, 1000) will be imported at (-2048, 1024).
 
      Notes:
-     * You can import multiple times into the greater 16k^2 world map by specifying different positions. So you could import multiple maps as separate islands or combined regions.
-     * It will slice and pad odd sized images into region sized chunks ([default is 1024x1024](https://github.com/TokisanGames/Terrain3D/issues/77)). e.g. You could import a 4k x 2k, several 1k x 1ks, and a 5123 x 3769 and position them so they are adjacent.
+     * You can import multiple times into the greater world map by specifying different positions. So you could import multiple maps as separate islands or combined regions.
+     * It will slice and pad odd sized images into region sized chunks (default is 256x256). e.g. You could import a 4k x 2k, several 1k x 1ks, and a 5123 x 3769 and position them so they are adjacent.
      * You can also reimport to the same location to overwrite anything there using individual maps or a complete set of height, control, and/or color.
 
 5) Specify any desired `height_offset` or `import_scale`. The scale gets applied first. (eg. 100, -100 would scale the terrain by 100, then lower the whole terrain by 100).
@@ -86,7 +86,7 @@ We can import any supported image format Godot can read. These include:
 
 Notes:
 
-* The exporter takes the smallest rectangle that will fit around all active regions in the 16k^2 world and export that as an image. So, if you have a 1k x 1k island in the NW corner, and a 2k x 3k island in the center, with a 1k strait between them, the resulting export image will be something like 4k x 5k. You'll need to specify the location (rounded to `region_size`) when reimporting to have a perfect round trip.
+* The exporter takes the smallest rectangle that will fit around all active regions in the world and export that as an image. So, if you have a 1k x 1k island in the NW corner, and a 2k x 3k island in the center, with a 1k strait between them, the resulting export image will be something like 4k x 5k. You'll need to specify the location (rounded to `region_size`) when reimporting to have a perfect round trip.
 
 * The exporter tool does not offer region by region export, but there is an API where you can retrieve any given region, then you can use `Image` to save it externally yourself.
 

--- a/doc/docs/installation.md
+++ b/doc/docs/installation.md
@@ -24,8 +24,7 @@ Terrain3D is listed in the Asset Library [here](https://godotengine.org/asset-li
 7. In `Project Settings / Plugins`, ensure that Terrain3D is enabled.
 8. Select `Project / Reload Current Project` to restart once more.
 9. Open `demo/Demo.tscn`. You should see a terrain. Run the scene by pressing `F6`. 
-
-**Updated for 0.9.3-dev:** When using Terrain3D in your own scene, select the Terrain3D node in the Scene panel. In the Inspector, click the folder icon to the right of `data directory`, and specify a directory to store your data. This directory can be used shared with other scenes.
+10. When using Terrain3D in your own scene, select the Terrain3D node in the Scene panel. In the Inspector, click the folder icon to the right of `data directory`, then specify a directory to store your data. This directory can be used shared with other scenes.
 
 Next, learn how to [prepare your textures](texture_prep.md).
 
@@ -48,7 +47,7 @@ If the demo isn't working for you, watch the [tutorial videos](tutorial_videos.m
 4. In `Project Settings / Plugins`, ensure that Terrain3D is enabled.
 5. Select `Project / Reload Current Project` to restart once more.
 6. Create or open a 3D scene and add a new Terrain3D node.
-7. **Updated 0.9.3-dev:** Select Terrain3D in the Scene panel. In the Inspector, click the folder icon to the right of `data directory` and specify a directory to store your data. This directory can be used shared with other scenes.
+7. Select Terrain3D in the Scene panel. In the Inspector, click the folder icon to the right of `data directory` and specify a directory to store your data. This directory can be used shared with other scenes.
 
 Next, learn how to [prepare your textures](texture_prep.md).
 
@@ -63,7 +62,7 @@ To update Terrain3D:
 
 Don't just copy the new folder over the old, as this won't remove any files that we may have intentionally removed.
 
-4. Upgrading to 0.9.3, when opening your scene and selecting your Terrain3D node, a directory selection wizard will popup. Terrain3D now stores data in a directory. Follow the popup to select your old storage file and a new storage directory, and it will upgrade your data. Save afterwards.
+4. **Upgrading to 0.9.3:** Terrain3D now stores data in a directory. When opening your scene and selecting your Terrain3D node, a directory selection wizard will popup. Follow the directions to select your old storage file and a new storage directory, and it will upgrade your data. Save afterwards.
 
 ### Upgrade Path
 

--- a/doc/docs/platforms.md
+++ b/doc/docs/platforms.md
@@ -31,7 +31,7 @@ Fully supported. See [renderers](#supported-renderers).
 
 ## macOS
 
-Godot and Terrain3D work fine on macOS, however Apple security is overly aggressive when using the release binaries.
+Godot and Terrain3D work fine on macOS, however Apple security is overly aggressive when using our release binaries.
 
 Users have reported errors like this:
 
@@ -47,7 +47,8 @@ $ xattr -dr com.apple.quarantine addons/terrain_3d/bin/libterrain.macos.release.
 You can also [read comments and workarounds](https://github.com/TokisanGames/Terrain3D/issues/227)
 from other users. 
 
-If disabling Apple security is not working, or if approaching a release date, macOS users should [build from source](building_from_source.md) so you can sign the binaries with your own account.
+If bypassing Apple security is not working, or if approaching a release date, macOS users should [build from source](building_from_source.md) so you can sign the binaries with your own developer account.
+
 
 ## Android
 
@@ -62,6 +63,7 @@ There is a [texture artifact](https://github.com/TokisanGames/Terrain3D/issues/1
 
 Further reading:
 * [Issue 197](https://github.com/TokisanGames/Terrain3D/issues/197)
+
 
 ## IOS
 
@@ -100,14 +102,16 @@ The user got it working with the following:
 * Install `glibc` and `linux-api-headers` in addition to the standard Godot dependencies
 * [Build from source](building_from_source.md)
 
-
 Further reading:
 * [Issue 220](https://github.com/TokisanGames/Terrain3D/issues/220#issuecomment-1837552459)
 
 
 ## WebGL
 
-Terrain3D does export to WebGL, however it requires the [Compatibility Renderer (read more)](#compatibility).
+The Terrain3D library can be exported to WebGL, however the terrain will not currently render. It requires the [Compatibility Renderer (read more)](#compatibility), which is now supported, and but there are some additional shader elements that need to be sorted out before it will work. 
+
+Further reading:
+* [Issue 502](https://github.com/TokisanGames/Terrain3D/issues/502)
 
 
 Supported Renderers
@@ -137,12 +141,25 @@ The Forward Vulkan Mobile renderer is fully supported in Terrain3D 0.9.3. There 
 
 ## Compatibility
 
-The OpenGLES 3.0 Compatibility renderer has recently reached "feature complete" status in Godot 4.3. Features are still lacking in 4.2.
+The OpenGLES 3.0 Compatibility renderer is supported from Terrain3D 0.9.3 with Godot 4.3. There is partial support for Godot 4.2.
 
-It is not yet fully supported by Terrain3D. The terrain mesh builds and is reported to work fine. The remaining issue is that the texturing shader and the mouse cursor do not work due to the lack of necessary features.
+* If using a custom override shader, we add a special COMPATIBILITY_DEFINES block to your shader that will allow certain features to work properly (eg the fma() function). We remove this block from your shader if you switch back to Mobile or Forward. It is normal to receive a shader dump in your console during this transition, but it should not repeat every start, once saved.
 
-Some work has been done to partially support Compatibility in Godot 4.2 and full support coming in Terrain3D 0.9.4 with Godot 4.3+.
+* `IS_COMPATIBILITY` is defined in this block should you wish to check against it with your own custom preprocessor statements.
 
+* If enabling compatibility mode on the command line, we cannot detect that currently. You can tell Terrain3D with a special parameter:
+
+    `Godot_v4.3-stable_win64_console.exe --rendering-driver opengl3 -e project.godot --terrain3d-renderer=compatibility`
+
+**Godot 4.2**
+
+In addition to the above notes, OpenGLES is incomplete in 4.2. It does work with the following caveats:
+
+* There are some startup warnings about depth textures and glow that you can ignore.
+* `VRAM Compressed` is not supported. In the `Import` panel, you must set your texture files to either `VRAM Uncompressed` or `Lossless` and reimport.
+* The command line option `--rendering-method gl_compatibility` breaks the terrain in 4.2. Don't use it. The above command works for 4.2 or 4.3.
+ 
 Further reading:
 
 * [Issue 217](https://github.com/TokisanGames/Terrain3D/issues/217)
+* [PR 500](https://github.com/TokisanGames/Terrain3D/pull/500)

--- a/doc/docs/project_status.md
+++ b/doc/docs/project_status.md
@@ -27,7 +27,7 @@ See the [Roadmap](https://github.com/users/TokisanGames/projects/3/views/1) for 
 | Jolt | [Godot-Jolt](https://github.com/godot-jolt/godot-jolt) v0.6+ works as a drop-in replacement for Godot Physics. The above restriction applies.
 | **Navigation Server** | Supported. See [Navigation](navigation.md)
 | **Data** |
-| Large terrains | Supports terrains up to 16km^2. [Collision will take up ~4-6GB RAM](https://github.com/TokisanGames/Terrain3D/issues/161), but that will be [improved](https://github.com/TokisanGames/Terrain3D/pull/278).
+| Large terrains | Supports terrains up to 65.5x65.5km (4295km^2). [Collision will take up ~4-6GB RAM](https://github.com/TokisanGames/Terrain3D/issues/161), but that will be [improved](https://github.com/TokisanGames/Terrain3D/pull/278).
 | Importing / Exporting | Works. See [Importing data](import_export.md)
 | Double precision floats | [Supported](double_precision.md).
 | **Rendering** |

--- a/project/addons/terrain_3d/editor.gd
+++ b/project/addons/terrain_3d/editor.gd
@@ -21,6 +21,13 @@ var current_region_position: Vector2
 var mouse_global_position: Vector3 = Vector3.ZERO
 var godot_editor_window: Window # The Godot Editor window
 
+# Compatibility decals, indices; 0 = main brush, 1 = slope point A, 2 = slope point B
+var editor_decal_position: Array[Vector2]
+var editor_decal_rotation: Array[float]
+var editor_decal_size: Array[float]
+var editor_decal_color: Array[Color]
+var editor_decal_visible: Array[bool]
+
 
 func _init() -> void:
 	# Get the Godot Editor window. Structure is root:Window/EditorNode/Base Control
@@ -40,6 +47,12 @@ func _enter_tree() -> void:
 
 	asset_dock = load(ASSET_DOCK).instantiate()
 	asset_dock.initialize(self)
+	
+	editor_decal_position.resize(3)
+	editor_decal_rotation.resize(3)
+	editor_decal_size.resize(3)
+	editor_decal_color.resize(3)
+	editor_decal_visible.resize(3)
 
 
 func _exit_tree() -> void:
@@ -99,6 +112,14 @@ func _edit(p_object: Object) -> void:
 		terrain.set_editor(editor)
 		ui.set_visible(true)
 		terrain.set_meta("_edit_lock_", true)
+		
+		if terrain.is_compatibility_mode():
+			ui.decal_timer.timeout.connect(func():
+				var mat_rid: RID = terrain.material.get_material_rid()
+				editor_decal_visible[0] = false
+				RenderingServer.material_set_param(mat_rid, "_editor_decal_visible", editor_decal_visible)
+				#RenderingServer.material_set_param(mat_rid, "_editor_decal_visible", false)
+				)
 
 		if terrain.storage:
 			ui.terrain_menu.directory_setup.directory_setup_popup()
@@ -179,7 +200,45 @@ func _forward_3d_gui_input(p_viewport_camera: Camera3D, p_event: InputEvent) -> 
 		## Update decal
 		ui.decal.global_position = mouse_global_position
 		ui.update_decal()
-
+		
+		## Compatibility "Decal"
+		if terrain.is_compatibility_mode():
+			var mat_rid: RID = terrain.material.get_material_rid()
+			if ui.decal.visible:
+				editor_decal_position[0] = Vector2(mouse_global_position.x,mouse_global_position.z)
+				editor_decal_rotation[0] = ui.decal.rotation.y
+				editor_decal_size[0] = ui.brush_data.get("size")
+				editor_decal_color[0] = ui.decal.modulate
+				editor_decal_visible[0] = ui.decal.visible
+				RenderingServer.material_set_param(
+					mat_rid, "_editor_decal_0", ui.decal.texture_albedo.get_rid()
+					)
+			if ui.gradient_decals.size() >= 1:
+				editor_decal_position[1] = Vector2(ui.gradient_decals[0].global_position.x,
+					ui.gradient_decals[0].global_position.z)
+				editor_decal_rotation[1] = ui.gradient_decals[0].rotation.y
+				editor_decal_size[1] = 10.0
+				editor_decal_color[1] = ui.gradient_decals[0].modulate
+				editor_decal_visible[1] = ui.gradient_decals[0].visible
+				RenderingServer.material_set_param(
+					mat_rid, "_editor_decal_1", ui.gradient_decals[0].texture_albedo.get_rid()
+					)
+			if ui.gradient_decals.size() >= 2:
+				editor_decal_position[2] = Vector2(ui.gradient_decals[1].global_position.x,
+					ui.gradient_decals[1].global_position.z)
+				editor_decal_rotation[2] = ui.gradient_decals[1].rotation.y
+				editor_decal_size[2] = 10.0
+				editor_decal_color[2] = ui.gradient_decals[1].modulate
+				editor_decal_visible[2] = ui.gradient_decals[1].visible
+				RenderingServer.material_set_param(
+					mat_rid, "_editor_decal_2", ui.gradient_decals[1].texture_albedo.get_rid()
+					)
+			RenderingServer.material_set_param(mat_rid, "_editor_decal_position", editor_decal_position)
+			RenderingServer.material_set_param(mat_rid, "_editor_decal_rotation", editor_decal_rotation)
+			RenderingServer.material_set_param(mat_rid, "_editor_decal_size", editor_decal_size)
+			RenderingServer.material_set_param(mat_rid, "_editor_decal_color", editor_decal_color)
+			RenderingServer.material_set_param(mat_rid, "_editor_decal_visible", editor_decal_visible)
+	
 		## Update region highlight
 		var region_position: Vector2 = ( Vector2(mouse_global_position.x, mouse_global_position.z) \
 			/ (terrain.get_region_size() * terrain.get_vertex_spacing()) ).floor()

--- a/project/addons/terrain_3d/editor.gd
+++ b/project/addons/terrain_3d/editor.gd
@@ -118,7 +118,6 @@ func _edit(p_object: Object) -> void:
 				var mat_rid: RID = terrain.material.get_material_rid()
 				editor_decal_visible[0] = false
 				RenderingServer.material_set_param(mat_rid, "_editor_decal_visible", editor_decal_visible)
-				#RenderingServer.material_set_param(mat_rid, "_editor_decal_visible", false)
 				)
 
 		if terrain.storage:

--- a/src/shaders/editor_functions.glsl
+++ b/src/shaders/editor_functions.glsl
@@ -13,14 +13,13 @@ R"(
 
 //INSERT: EDITOR_COMPATIBILITY_DEFINES
 // COMPATIBILITY_DEFINES - This code block is added and removed by the editor, do not modify it.
-// This is added automatically when in compatibility mode. It is not required for Mobile or Forward+
-// and should not be present when exporting your project, as Terrain3D will inject this if required.
+// This is added automatically when in compatibility mode. It is not required for Mobile or Forward+.
 #define IS_COMPATIBILITY
 #define fma(a, b, c) (a) * (b) + (c)
 #define dFdxCoarse(a) dFdx(a)
 #define dFdyCoarse(a) dFdy(a)
 #define textureQueryLod(a, b) vec4(0.0)
-#define texelOffset(b, c) ivec3(ivec2(b.xy * _region_size + c -0.4979), int(b.z))
+#define texelOffset(b, c) ivec3(ivec2(b.xy * _region_size + c - 0.4979), int(b.z))
 #define textureGather(a, b) vec4( \
     texelFetch(a, texelOffset(b, vec2(0,1)), 0).r, \
     texelFetch(a, texelOffset(b, vec2(1,1)), 0).r, \
@@ -59,16 +58,17 @@ vec3 get_decal(vec3 albedo, vec2 uv) {
 		// which might not be the case - so use a switch to read the correct uniform.
 		switch (i) {
 			case 0 :
-				decal = texture(_editor_decal_0,decal_uv + 0.5).r;
+				decal = texture(_editor_decal_0, decal_uv + 0.5).r;
 				break;
 			case 1:
-				decal = texture(_editor_decal_1,decal_uv + 0.5).r;
+				decal = texture(_editor_decal_1, decal_uv + 0.5).r;
 				break;
 			case 2:
-				decal = texture(_editor_decal_2,decal_uv + 0.5).r;
+				decal = texture(_editor_decal_2, decal_uv + 0.5).r;
 				break;
 		}
-		albedo =  mix(albedo, _editor_decal_color[i].rgb, smoothstep(0.1,1.0,decal) * _editor_decal_color[i].a);
+		// Blend in decal; reduce opacity 55% to account for differences in Opengl/Vulkan and/or decals
+		albedo =  mix(albedo, _editor_decal_color[i].rgb, clamp(decal * _editor_decal_color[i].a * .55, 0., .55));
 	}
 
 	return albedo;

--- a/src/shaders/editor_functions.glsl
+++ b/src/shaders/editor_functions.glsl
@@ -10,4 +10,71 @@ R"(
 		ALBEDO *= vec3(.5, .0, .85);
 	}
 
+
+//INSERT: EDITOR_COMPATIBILITY_DEFINES
+// COMPATIBILITY_DEFINES - This code block is added and removed by the editor, do not modify it.
+// This is added automatically when in compatibility mode. It is not required for Mobile or Forward+
+// and should not be present when exporting your project, as Terrain3D will inject this if required.
+#define IS_COMPATIBILITY
+#define fma(a, b, c) (a) * (b) + (c)
+#define dFdxCoarse(a) dFdx(a)
+#define dFdyCoarse(a) dFdy(a)
+#define textureQueryLod(a, b) vec4(0.0)
+#define texelOffset(b, c) ivec3(ivec2(b.xy * _region_size + c -0.4979), int(b.z))
+#define textureGather(a, b) vec4( \
+    texelFetch(a, texelOffset(b, vec2(0,1)), 0).r, \
+    texelFetch(a, texelOffset(b, vec2(1,1)), 0).r, \
+    texelFetch(a, texelOffset(b, vec2(1,0)), 0).r, \
+    texelFetch(a, texelOffset(b, vec2(0,0)), 0).r  \
+)
+// END_COMPAT_DEFINES
+
+//INSERT: EDITOR_SETUP_DECAL
+uniform highp sampler2D _editor_decal_0 : source_color, filter_linear, repeat_disable;
+uniform highp sampler2D _editor_decal_1 : source_color, filter_linear, repeat_disable;
+uniform highp sampler2D _editor_decal_2 : source_color, filter_linear, repeat_disable;
+uniform vec2 _editor_decal_position[3];
+uniform float _editor_decal_size[3];
+uniform float _editor_decal_rotation[3];
+uniform vec4 _editor_decal_color[3] : source_color;
+uniform bool _editor_decal_visible[3];
+
+// expects uv (Texture/world space 0 to +/- inf 1m units).
+vec3 get_decal(vec3 albedo, vec2 uv) {
+	for (int i = 0; i < 3; ++i) {
+		if (!_editor_decal_visible[i]) {
+			continue;
+		}
+		float size = 1.0 / _editor_decal_size[i];
+		float cosa = cos(_editor_decal_rotation[i]);
+		float sina = sin(_editor_decal_rotation[i]);
+		vec2 decal_uv = (vec2(cosa * uv.x - sina * uv.y, sina * uv.x + cosa * uv.y) - 
+			vec2(cosa * _editor_decal_position[i].x - sina * _editor_decal_position[i].y,
+			sina * _editor_decal_position[i].x + cosa * _editor_decal_position[i].y) * _vertex_density) * size * _vertex_spacing;
+		if (abs(decal_uv.x) > 0.499 || abs(decal_uv.y) > 0.499) {
+			continue;
+		}
+		float decal = 0.0;
+		// For webGL we cannot use sampler2D[], sampler2DArray requires all textures be the same size,
+		// which might not be the case - so use a switch to read the correct uniform.
+		switch (i) {
+			case 0 :
+				decal = texture(_editor_decal_0,decal_uv + 0.5).r;
+				break;
+			case 1:
+				decal = texture(_editor_decal_1,decal_uv + 0.5).r;
+				break;
+			case 2:
+				decal = texture(_editor_decal_2,decal_uv + 0.5).r;
+				break;
+		}
+		albedo =  mix(albedo, _editor_decal_color[i].rgb, smoothstep(0.1,1.0,decal) * _editor_decal_color[i].a);
+	}
+
+	return albedo;
+}
+
+//INSERT: EDITOR_RENDER_DECAL
+	ALBEDO = get_decal(ALBEDO, uv);
+
 )"

--- a/src/shaders/gpu_depth.glsl
+++ b/src/shaders/gpu_depth.glsl
@@ -7,28 +7,33 @@ R"(
 shader_type spatial;
 render_mode unshaded;
 
-uniform sampler2D depth_texture : source_color, hint_depth_texture, filter_nearest, repeat_disable;
+uniform highp sampler2D depth_texture : source_color, hint_depth_texture, filter_nearest, repeat_disable;
 
 uniform float camera_far = 100000.0;
-
-// Mobile renderer HDR mode has limit of 1 or 2. Pack full range depth to RG
-// https://gamedev.stackexchange.com/questions/201151/24bit-float-to-rgb
-vec3 encode_rg(float value) {
-    vec2 kEncodeMul = vec2(1.0, 255.0);
-    float kEncodeBit = 1.0 / 255.0;
-    vec2 color = kEncodeMul * value / camera_far;
-    color = fract(color);
-    color.x -= color.y * kEncodeBit;
-	return vec3(color, 0.);
-}
+uniform bool compatibility = false;
 	
 void fragment() {
 	float depth = textureLod(depth_texture, SCREEN_UV, 0.).x;
+	if (compatibility) {
+	 depth = depth * 2.0 - 1.0;
+	}
 	vec3 ndc = vec3(SCREEN_UV * 2.0 - 1.0, depth);
 	vec4 view = INV_PROJECTION_MATRIX * vec4(ndc, 1.0);
 	view.xyz /= view.w;
 	float depth_linear = -view.z;
-	ALBEDO = encode_rg(depth_linear); // Encoded value for Mobile
+
+	// Normalize depth to the range 0 - 1
+	highp float scaledDepth = clamp(depth_linear / 100000.0, 0.0, 1.0);
+
+	// Encode using 127 steps, which map to the 128 - 255 range.
+	// Avoids precision loss for compatability and mobile renderer
+	// 21bit depth value
+	highp float r = (floor(scaledDepth * 127.0) + 128.0) / 255.0;
+	highp float g = (floor(fract(scaledDepth * 127.0) * 127.0) + 128.0) / 255.0;
+	highp float b = (floor(fract(scaledDepth * 127.0 * 127.0) * 127.0) + 128.0) / 255.0;
+		
+	ALBEDO = vec3(r, g, b); // Return encoded value, required for Mobile & Compatibility renderers
+
 }
 
 )"

--- a/src/shaders/main.glsl
+++ b/src/shaders/main.glsl
@@ -32,8 +32,8 @@ uniform float _vertex_density = 1.0; // = 1/_vertex_spacing
 uniform int _region_map_size = 32;
 uniform int _region_map[1024];
 uniform vec2 _region_locations[1024];
-uniform sampler2DArray _height_maps : repeat_disable;
-uniform usampler2DArray _control_maps : repeat_disable;
+uniform highp sampler2DArray _height_maps : repeat_disable;
+uniform highp usampler2DArray _control_maps : repeat_disable;
 //INSERT: TEXTURE_SAMPLERS_NEAREST
 //INSERT: TEXTURE_SAMPLERS_LINEAR
 uniform float _texture_uv_scale_array[32];

--- a/src/shaders/main.glsl
+++ b/src/shaders/main.glsl
@@ -180,7 +180,7 @@ vec3 get_normal(vec2 uv, out vec3 tangent, out vec3 binormal) {
 	float u, v, height;
 	vec3 normal;
 	// Use vertex normals within radius of vertex_normals_distance, and along region borders.
-	if (v_region_border_mask > 0.5 || v_vertex_xz_dist < vertex_normals_distance) {
+	if ((v_region_border_mask > 0.5 || v_vertex_xz_dist < vertex_normals_distance) && v_region.z >= 0) {
 		normal = normalize(v_normal);
 	} else {
 		height = get_height(uv);
@@ -188,8 +188,8 @@ vec3 get_normal(vec2 uv, out vec3 tangent, out vec3 binormal) {
 		v = height - get_height(uv + vec2(0, _region_texel_size));
 		normal = normalize(vec3(u, _vertex_spacing, v));
 	}
-	tangent = cross(normal, vec3(0, 0, 1));
-	binormal = cross(normal, tangent);
+	tangent = normalize(cross(normal, vec3(0, 0, 1)));
+	binormal = normalize(cross(normal, tangent));
 	return normal;
 }
 

--- a/src/shaders/uniforms.glsl
+++ b/src/shaders/uniforms.glsl
@@ -3,15 +3,15 @@
 R"(
 
 //INSERT: TEXTURE_SAMPLERS_LINEAR
-uniform sampler2DArray _color_maps : source_color, filter_linear_mipmap_anisotropic, repeat_disable;
-uniform sampler2DArray _texture_array_albedo : source_color, filter_linear_mipmap_anisotropic, repeat_enable;
-uniform sampler2DArray _texture_array_normal : hint_normal, filter_linear_mipmap_anisotropic, repeat_enable;
-uniform sampler2D noise_texture : source_color, filter_linear_mipmap_anisotropic, repeat_enable;
+uniform highp sampler2DArray _color_maps : source_color, filter_linear_mipmap_anisotropic, repeat_disable;
+uniform highp sampler2DArray _texture_array_albedo : source_color, filter_linear_mipmap_anisotropic, repeat_enable;
+uniform highp sampler2DArray _texture_array_normal : hint_normal, filter_linear_mipmap_anisotropic, repeat_enable;
+uniform highp sampler2D noise_texture : source_color, filter_linear_mipmap_anisotropic, repeat_enable;
 
 //INSERT: TEXTURE_SAMPLERS_NEAREST
-uniform sampler2DArray _color_maps : source_color, filter_nearest_mipmap_anisotropic, repeat_disable;
-uniform sampler2DArray _texture_array_albedo : source_color, filter_nearest_mipmap_anisotropic, repeat_enable;
-uniform sampler2DArray _texture_array_normal : hint_normal, filter_nearest_mipmap_anisotropic, repeat_enable;
-uniform sampler2D noise_texture : source_color, filter_nearest_mipmap_anisotropic, repeat_enable;
+uniform highp sampler2DArray _color_maps : source_color, filter_nearest_mipmap_anisotropic, repeat_disable;
+uniform highp sampler2DArray _texture_array_albedo : source_color, filter_nearest_mipmap_anisotropic, repeat_enable;
+uniform highp sampler2DArray _texture_array_normal : hint_normal, filter_nearest_mipmap_anisotropic, repeat_enable;
+uniform highp sampler2D noise_texture : source_color, filter_nearest_mipmap_anisotropic, repeat_enable;
 
 )"

--- a/src/terrain_3d.h
+++ b/src/terrain_3d.h
@@ -96,6 +96,7 @@ private:
 	RenderingServer::ShadowCastingSetting _cast_shadows = RenderingServer::SHADOW_CASTING_SETTING_ON;
 	GeometryInstance3D::GIMode _gi_mode = GeometryInstance3D::GI_MODE_STATIC;
 	real_t _cull_margin = 0.0f;
+	bool _compatibility = false;
 
 	// Mouse cursor
 	SubViewport *_mouse_vp = nullptr;
@@ -208,6 +209,7 @@ public:
 	GeometryInstance3D::GIMode get_gi_mode() const { return _gi_mode; }
 	void set_cull_margin(const real_t p_margin);
 	real_t get_cull_margin() const { return _cull_margin; };
+	bool is_compatibility_mode() const { return _compatibility; };
 
 	// Processing
 	void snap(const Vector3 &p_cam_pos);

--- a/src/terrain_3d_material.h
+++ b/src/terrain_3d_material.h
@@ -40,6 +40,7 @@ private:
 	Ref<Shader> _shader_override; // User's shader we copy code from
 	mutable TypedArray<StringName> _active_params; // All shader params in the current shader
 	mutable Dictionary _shader_params; // Public shader params saved to disk
+	bool _compatibility = false; // If true, some shader functions will be overriden using #defines.
 
 	// Material Features
 	WorldBackground _world_background = FLAT;


### PR DESCRIPTION
Admin edit:
Fixes #217

* Enables compatibility support
* Modifies custom shaders w/ special defines
* Improves GPU mouse and shader; supports compatibility mode
* Fixes not-normalized normals for all renderers
* Hides the region border normal fix outside of regions (was noticable at small region sizes)

----

Detects whether Godot is using the compatibility renderer.

If so,
The generated shader will have a set of #defines added that allow full support for the standard shader.
The shader override will have the #defines visible at the begining on the shader, before shader_type.

The editor will inject code at the begining, and the end either the standard shader, or any provided override shader
in order to draw a "decal" on the terrain.

in the interest of simplicity, the gdscript changes are as small as possible, tho some things are a bit inneficient,
performace is fine and its only during editing anyways.

~~The slope tool doesnt have propper decal support.~~

adding terrain3d.get_compatibility() seems a bit dubious to me, but saved repeating a ton of code in gdscript, and ensures that the editor is always on the same page.

Finally, there are no warnings at the moment when the albedo and normal arrays are in compressed mode. for 4.3 this is fixed anyways, but for 4.2 all textures will be black. The workaround is to re-import all textures as "Lossless". Resizing to half resolution results in the same VRAM use for Lossless vs Compressed at the original size.

EDIT: recently updated test version is available: https://github.com/Xtarsia/Terrain3D/actions/runs/11079134556
