### PR TITLE
Replacing Shader Code for FMA

### DIFF
--- a/src/shaders/world_noise.glsl
+++ b/src/shaders/world_noise.glsl
@@ -40,15 +40,15 @@ float hashf(float f) {
 }
 
 float hashv2(vec2 v) {
-	return fract(1e4 * sin(17.0 * v.x + v.y * 0.1) * (0.1 + abs(sin(v.y * 13.0 + v.x))));
+	return fract(1e4 * sin(fma(17.0, v.x, v.y * 0.1)) * (0.1 + abs(sin(fma(v.y, 13.0, v.x)))));
 }
 
 // https://iquilezles.org/articles/morenoise/
 vec3 noise2D(vec2 x) {
     vec2 f = fract(x);
     // Quintic Hermine Curve.  Similar to SmoothStep()
-    vec2 u = f*f*f*(f*(f*6.0-15.0)+10.0);
-    vec2 du = 30.0*f*f*(f*(f-2.0)+1.0);
+    vec2 u = f * f * f * fma(f, fma(f, vec2(6.0), vec2(-15.0)), vec2(10.0));
+    vec2 du = 30.0 * f * f * fma(f, (f - 2.0), vec2(1.0));
 
     vec2 p = floor(x);
 
@@ -63,8 +63,8 @@ vec3 noise2D(vec2 x) {
     float k1 =   b - a;
     float k2 =   c - a;
     float k3 =   a - b - c + d;
-    return vec3( k0 + k1 * u.x + k2 * u.y + k3 * u.x * u.y,
-                du * ( vec2(k1, k2) + k3 * u.yx) );
+    return vec3( fma(k3, u.x * u.y, fma(u.y, k2, fma(k1, u.x, k0))),
+		du * fma(u.yx, vec2(k3), vec2(k1, k2)) );
 }
 
 float world_noise(vec2 p) {


### PR DESCRIPTION
I added fma into all shader snippets I could identify, fulfilling #26.2, but since fma only accepts variables of the same type I had to replace some float constants with vectors.

fma combines multiplication and addition into a single operator which should double the speed of that specific operation, but since the Shader contains many other more complex operations, this resulted in an **insignificant performance increase of about 1%** which makes me doubt whether this should be merged at all, but that's up to you.

It should be compatible with the changes in #500 because it introduces a replacement macro for fma.