### PR TITLE
Added alternate key binding setting and updated documentation

### DIFF
--- a/doc/docs/user_interface.md
+++ b/doc/docs/user_interface.md
@@ -26,6 +26,7 @@ The following mouse and keyboard shortcuts are available:
 * <kbd>Ctrl + LMB</kbd> - **Inverses the operation** where applicable. Eg. Add or *remove* regions. Raise or *lower* terrain. Create or *remove* holes, foliage, navigation, etc.
 * <kbd>Alt + LMB</kbd> - **Lift floors** mode. Sculpting only. This lifts up lower portions of the terrain without affecting higher terrain around it. Use it along the bottom of cliff faces. See [videos demonstrating before and after](https://github.com/TokisanGames/Terrain3D/pull/409). 
 * <kbd>Ctrl + Alt + LMB</kbd> - **Flatten peaks** mode. Sculpting only. The inverse of the above. This reduces peaks and ridges without affecting lower terrain around it.
+* <kbd>RMB (Alternate Binding)</kbd> - If the "Alternate Key Bindings" option is enabled in the editor settings, RMB (Right Mouse Button) replaces the default Alt + LMB behavior. This allows sculpting operations to be performed with RMB.
 
 Note: Touchscreen users have an `Invert` checkbox on the settings bar which acts like <kbd>Ctrl</kbd> to inverse operations.
 

--- a/jesus
+++ b/jesus
@@ -1,0 +1,2 @@
+* [32mfeature-alternate-keybinding[m
+  main[m

--- a/project/addons/terrain_3d/editor.gd
+++ b/project/addons/terrain_3d/editor.gd
@@ -37,6 +37,9 @@ func _init() -> void:
 func _enter_tree() -> void:
 	editor = Terrain3DEditor.new()
 	editor_settings = EditorInterface.get_editor_settings()
+	    # Initialize the new key binding option
+    if not editor_settings.has_setting("config/alternate_key_binding"):
+        editor_settings.set_setting("config/alternate_key_binding", false)
 	ui = UI.new()
 	ui.plugin = self
 	add_child(ui)

--- a/project/addons/terrain_3d/editor.gd
+++ b/project/addons/terrain_3d/editor.gd
@@ -259,8 +259,22 @@ func _forward_3d_gui_input(p_viewport_camera: Camera3D, p_event: InputEvent) -> 
 		if p_event.get_button_index() == MOUSE_BUTTON_RIGHT and p_event.is_released():
 			ui.last_rmb_time = Time.get_ticks_msec()
 		ui.update_decal()
-			
-		if p_event.get_button_index() == MOUSE_BUTTON_LEFT:
+
+		    # Fetch the alternate key binding setting
+    	var use_rmb = editor_settings.get_setting("config/alternate_key_binding")
+
+			# If alternate keybinding is enabled, use RMB instead of ALT + LMB
+		    if use_rmb and p_event.get_button_index() == MOUSE_BUTTON_RIGHT:
+        if p_event.is_pressed():
+            if not editor.is_operating():
+                editor.start_operation(mouse_global_position)
+            editor.operate(mouse_global_position, p_viewport_camera.rotation.y)
+            return AFTER_GUI_INPUT_STOP
+        elif editor.is_operating() and p_event.is_released():
+            editor.stop_operation()
+            return AFTER_GUI_INPUT_STOP
+
+		elif not use_rmb and p_event.get_button_index() == MOUSE_BUTTON_LEFT:
 			if p_event.is_pressed():
 				if Input.is_mouse_button_pressed(MOUSE_BUTTON_RIGHT):
 					return AFTER_GUI_INPUT_STOP


### PR DESCRIPTION
This pull request adds a new editor setting (config/alternate_key_binding) to toggle between ALT+LMB and RMB for terrain editing operations. Documentation has also been updated to reflect this new option.