### PR TITLE
Alt mode; Instancer remove all; Ctrl+Height to zero

### DIFF
--- a/doc/docs/instancer.md
+++ b/doc/docs/instancer.md
@@ -63,8 +63,9 @@ Adjusting the vertex color requires that `vertex_color_use_as_albedo` is enabled
 
 ### 4. Paint On The Ground
 
-Paint instances on the terrain. You can remove instances by holding CTRL while painting.
+Paint instances on the terrain. You can remove instances of the selected mesh by holding CTRL while painting.
 
+Press CTRL+ALT to remove mesh instances of any type.
 
 ## Limitations
 

--- a/doc/docs/user_interface.md
+++ b/doc/docs/user_interface.md
@@ -27,6 +27,11 @@ The following mouse and keyboard shortcuts are available:
 * <kbd>Alt + LMB</kbd> - **Lift floors** mode. Sculpting only. This lifts up lower portions of the terrain without affecting higher terrain around it. Use it along the bottom of cliff faces. See [videos demonstrating before and after](https://github.com/TokisanGames/Terrain3D/pull/409). 
 * <kbd>Ctrl + Alt + LMB</kbd> - **Flatten peaks** mode. Sculpting only. The inverse of the above. This reduces peaks and ridges without affecting lower terrain around it.
 
+**Instancer Operations**
+* <kbd>LMB</kbd> - Add the selected mesh instance to the terrain.
+* <kbd>Ctrl + LMB</kbd> - Remove instances of the selected type.
+* <kbd>Ctrl + Alt + LMB</kbd> - Remove instances of any type.
+
 Note: Touchscreen users have an `Invert` checkbox on the settings bar which acts like <kbd>Ctrl</kbd> to inverse operations.
 
 **Godot Shortcuts**

--- a/project/addons/terrain_3d/src/tool_settings.gd
+++ b/project/addons/terrain_3d/src/tool_settings.gd
@@ -69,9 +69,6 @@ func _ready() -> void:
 	add_setting({ "name":"strength", "type":SettingType.SLIDER, "list":main_list, "default":33, 
 								"unit":"%", "range":Vector3(1, 100, 1), "flags":ALLOW_LARGER })
 
-	add_setting({ "name":"lift_flatten", "type":SettingType.CHECKBOX, "list":main_list,
-								"default":false, "flags":NO_SAVE })
-
 	add_setting({ "name":"height", "type":SettingType.SLIDER, "list":main_list, "default":20, 
 								"unit":"m", "range":Vector3(-500, 500, 0.1), "flags":ALLOW_OUT_OF_BOUNDS })
 	add_setting({ "name":"height_picker", "type":SettingType.PICKER, "list":main_list, 

--- a/project/addons/terrain_3d/src/tool_settings.gd
+++ b/project/addons/terrain_3d/src/tool_settings.gd
@@ -110,7 +110,7 @@ func _ready() -> void:
 	add_setting({ "name":"slope", "type":SettingType.DOUBLE_SLIDER, "list":main_list, 
 								"default":0, "unit":"°", "range":Vector3(0, 180, 1) })
 	add_setting({ "name":"gradient_points", "type":SettingType.MULTI_PICKER, "label":"Points", 
-								"list":main_list, "default":Terrain3DEditor.HEIGHT, "flags":ADD_SEPARATOR })
+								"list":main_list, "default":Terrain3DEditor.SCULPT, "flags":ADD_SEPARATOR })
 	add_setting({ "name":"drawable", "type":SettingType.CHECKBOX, "list":main_list, "default":false, 
 								"flags":ADD_SEPARATOR })
 	settings["drawable"].toggled.connect(_on_drawable_toggled)

--- a/project/addons/terrain_3d/src/toolbar.gd
+++ b/project/addons/terrain_3d/src/toolbar.gd
@@ -35,17 +35,18 @@ func _ready() -> void:
 	
 	add_child(HSeparator.new())
 	
-	add_tool_button({ "tool":Terrain3DEditor.HEIGHT, 
+	add_tool_button({ "tool":Terrain3DEditor.SCULPT, 
 		"add_text":"Raise", "add_op":Terrain3DEditor.ADD, "add_icon":ICON_HEIGHT_ADD,
 		"sub_text":"Lower", "sub_op":Terrain3DEditor.SUBTRACT, "sub_icon":ICON_HEIGHT_SUB })
 
-	add_tool_button({ "tool":Terrain3DEditor.HEIGHT, 
+	add_tool_button({ "tool":Terrain3DEditor.SCULPT, 
 		"add_text":"Smooth", "add_op":Terrain3DEditor.AVERAGE, "add_icon":ICON_HEIGHT_SMOOTH })
 
 	add_tool_button({ "tool":Terrain3DEditor.HEIGHT, 
-		"add_text":"Height", "add_op":Terrain3DEditor.REPLACE, "add_icon":ICON_HEIGHT_FLAT })
+		"add_text":"Height", "add_op":Terrain3DEditor.ADD, "add_icon":ICON_HEIGHT_FLAT,
+		"sub_text":"Zero", "sub_op":Terrain3DEditor.SUBTRACT, "sub_icon":ICON_HEIGHT_FLAT })
 
-	add_tool_button({ "tool":Terrain3DEditor.HEIGHT, 
+	add_tool_button({ "tool":Terrain3DEditor.SCULPT, 
 		"add_text":"Slope", "add_op":Terrain3DEditor.GRADIENT, "add_icon":ICON_HEIGHT_SLOPE })
 
 	add_child(HSeparator.new())

--- a/project/addons/terrain_3d/src/ui.gd
+++ b/project/addons/terrain_3d/src/ui.gd
@@ -149,19 +149,23 @@ func _on_tool_changed(p_tool: Terrain3DEditor.Tool, p_operation: Terrain3DEditor
 				to_show.push_back("instructions")
 				to_show.push_back("remove")
 
-		Terrain3DEditor.HEIGHT:
+		Terrain3DEditor.SCULPT:
 			to_show.push_back("brush")
 			to_show.push_back("size")
 			to_show.push_back("strength")
 			if p_operation in [Terrain3DEditor.ADD, Terrain3DEditor.SUBTRACT]:
 					to_show.push_back("remove")
-			elif p_operation == Terrain3DEditor.REPLACE:
-				to_show.push_back("height")
-				to_show.push_back("height_picker")
 			elif p_operation == Terrain3DEditor.GRADIENT:
 				to_show.push_back("gradient_points")
 				to_show.push_back("drawable")
-		
+
+		Terrain3DEditor.HEIGHT:
+			to_show.push_back("brush")
+			to_show.push_back("size")
+			to_show.push_back("strength")
+			to_show.push_back("height")
+			to_show.push_back("height_picker")
+
 		Terrain3DEditor.TEXTURE:
 			to_show.push_back("brush")
 			to_show.push_back("size")
@@ -300,7 +304,7 @@ func update_decal() -> void:
 	else:
 		decal.texture_albedo = brush_data["brush"][1]
 		match plugin.editor.get_tool():
-			Terrain3DEditor.HEIGHT:
+			Terrain3DEditor.SCULPT:
 				match plugin.editor.get_operation():
 					Terrain3DEditor.ADD:
 						if modifier_alt:
@@ -316,15 +320,15 @@ func update_decal() -> void:
 						else:
 							decal.modulate = COLOR_LOWER
 							decal.modulate.a = clamp(brush_data["strength"], .2, .5) + .5
-					Terrain3DEditor.REPLACE:
-						decal.modulate = COLOR_HEIGHT
-						decal.modulate.a = clamp(brush_data["strength"], .2, .5)
 					Terrain3DEditor.AVERAGE:
 						decal.modulate = COLOR_SMOOTH
 						decal.modulate.a = clamp(brush_data["strength"], .2, .5) + .2
 					Terrain3DEditor.GRADIENT:
 						decal.modulate = COLOR_SLOPE
 						decal.modulate.a = clamp(brush_data["strength"], .2, .5)
+			Terrain3DEditor.HEIGHT:
+				decal.modulate = COLOR_HEIGHT
+				decal.modulate.a = clamp(brush_data["strength"], .2, .5)
 			Terrain3DEditor.TEXTURE:
 				match plugin.editor.get_operation():
 					Terrain3DEditor.REPLACE:
@@ -457,7 +461,7 @@ func set_modifier(p_modifier: int, p_pressed: bool) -> void:
 	if p_modifier == KEY_SHIFT && modifier_shift != p_pressed:
 		modifier_shift = p_pressed
 		if modifier_shift:
-			plugin.editor.set_tool(Terrain3DEditor.HEIGHT)
+			plugin.editor.set_tool(Terrain3DEditor.SCULPT)
 			plugin.editor.set_operation(Terrain3DEditor.AVERAGE)
 		else:
 			plugin.editor.set_tool(last_tool)
@@ -469,7 +473,7 @@ func set_modifier(p_modifier: int, p_pressed: bool) -> void:
 func _modify_operation(p_operation: Terrain3DEditor.Operation) -> Terrain3DEditor.Operation:
 	var remove_checked: bool = false
 	if DisplayServer.is_touchscreen_available():
-		var removable_tools := [Terrain3DEditor.REGION, Terrain3DEditor.HEIGHT, Terrain3DEditor.AUTOSHADER,
+		var removable_tools := [Terrain3DEditor.REGION, Terrain3DEditor.SCULPT, Terrain3DEditor.HEIGHT, Terrain3DEditor.AUTOSHADER,
 			Terrain3DEditor.HOLES, Terrain3DEditor.INSTANCER, Terrain3DEditor.NAVIGATION, 
 			Terrain3DEditor.COLOR, Terrain3DEditor.ROUGHNESS]
 		remove_checked = brush_data.get("remove", false) && plugin.editor.get_tool() in removable_tools

--- a/project/addons/terrain_3d/src/ui.gd
+++ b/project/addons/terrain_3d/src/ui.gd
@@ -451,7 +451,7 @@ func set_modifier(p_modifier: int, p_pressed: bool) -> void:
 	# Alt (modify) key. Change the raise/lower operation to lift floors / flatten peaks.
 	if p_modifier == KEY_ALT && modifier_alt != p_pressed:
 		modifier_alt = p_pressed
-		tool_settings.set_setting("lift_flatten", p_pressed)
+		brush_data["alt_mode"] = p_pressed
 
 	# Shift (smooth) key
 	if p_modifier == KEY_SHIFT && modifier_shift != p_pressed:

--- a/src/terrain_3d_editor.cpp
+++ b/src/terrain_3d_editor.cpp
@@ -145,7 +145,7 @@ void Terrain3DEditor::_operate_map(const Vector3 &p_global_position, const real_
 
 	real_t gamma = _brush_data["gamma"];
 	PackedVector3Array gradient_points = _brush_data["gradient_points"];
-	bool lift_flatten = _brush_data["lift_flatten"];
+	bool alt_mode = _brush_data["alt_mode"];
 
 	real_t randf = UtilityFunctions::randf();
 	real_t rot = randf * Math_PI * real_t(_brush_data["jitter"]);
@@ -224,7 +224,8 @@ void Terrain3DEditor::_operate_map(const Vector3 &p_global_position, const real_
 
 				switch (_operation) {
 					case ADD: {
-						if (lift_flatten && !std::isnan(p_global_position.y)) {
+						if (alt_mode && !std::isnan(p_global_position.y)) {
+							// Lift troughs
 							real_t brush_center_y = p_global_position.y + brush_alpha * strength;
 							destf = Math::clamp(brush_center_y, srcf, srcf + brush_alpha * strength);
 						} else {
@@ -233,7 +234,8 @@ void Terrain3DEditor::_operate_map(const Vector3 &p_global_position, const real_
 						break;
 					}
 					case SUBTRACT: {
-						if (lift_flatten && !std::isnan(p_global_position.y)) {
+						if (alt_mode && !std::isnan(p_global_position.y)) {
+							// Flatten peaks
 							real_t brush_center_y = p_global_position.y - brush_alpha * strength;
 							destf = Math::clamp(brush_center_y, srcf - brush_alpha * strength, srcf);
 						} else {

--- a/src/terrain_3d_editor.h
+++ b/src/terrain_3d_editor.h
@@ -16,6 +16,38 @@ class Terrain3DEditor : public Object {
 	CLASS_NAME();
 
 public: // Constants
+	enum Tool {
+		REGION,
+		SCULPT,
+		HEIGHT,
+		TEXTURE,
+		COLOR,
+		ROUGHNESS,
+		AUTOSHADER,
+		HOLES,
+		NAVIGATION,
+		INSTANCER,
+		ANGLE, // used for picking, TODO change to a picking tool
+		SCALE, // used for picking
+		TOOL_MAX,
+	};
+
+	static inline const char *TOOLNAME[] = {
+		"Region",
+		"Sculpt",
+		"Height",
+		"Texture",
+		"Color",
+		"Roughness",
+		"Auto Shader",
+		"Holes",
+		"Navigation",
+		"Instancer",
+		"Angle",
+		"Scale",
+		"TOOL_MAX",
+	};
+
 	enum Operation {
 		ADD,
 		SUBTRACT,
@@ -32,36 +64,6 @@ public: // Constants
 		"Average",
 		"Gradient",
 		"OP_MAX",
-	};
-
-	enum Tool {
-		REGION,
-		HEIGHT,
-		TEXTURE,
-		COLOR,
-		ROUGHNESS,
-		AUTOSHADER,
-		HOLES,
-		NAVIGATION,
-		INSTANCER,
-		ANGLE, // used for picking, TODO change to a picking tool
-		SCALE, // used for picking
-		TOOL_MAX,
-	};
-
-	static inline const char *TOOLNAME[] = {
-		"Region",
-		"Height",
-		"Texture",
-		"Color",
-		"Roughness",
-		"Auto Shader",
-		"Holes",
-		"Navigation",
-		"Instancer",
-		"Angle",
-		"Scale",
-		"TOOL_MAX",
 	};
 
 private:
@@ -124,6 +126,7 @@ VARIANT_ENUM_CAST(Terrain3DEditor::Tool);
 
 inline MapType Terrain3DEditor::_get_map_type() const {
 	switch (_tool) {
+		case SCULPT:
 		case HEIGHT:
 		case INSTANCER:
 			return TYPE_HEIGHT;

--- a/src/terrain_3d_instancer.h
+++ b/src/terrain_3d_instancer.h
@@ -27,7 +27,7 @@ class Terrain3DInstancer : public Object {
 	Dictionary _mmis;
 
 	uint32_t _instance_counter = 0;
-	int _get_instace_count(const real_t p_density);
+	uint32_t _get_instace_count(const real_t p_density);
 
 	void _update_mmis(const Vector2i &p_region_loc = V2I_MAX, const int p_mesh_id = -1);
 	void _destroy_mmi_by_location(const Vector2i &p_region_loc, const int p_mesh_id);
@@ -75,12 +75,12 @@ protected:
 
 // Allows us to instance every X function calls for sparse placement
 // Modifies _instance_counter, not const!
-inline int Terrain3DInstancer::_get_instace_count(const real_t p_density) {
+inline uint32_t Terrain3DInstancer::_get_instace_count(const real_t p_density) {
 	uint32_t count = 0;
-	if (p_density < 1.f && _instance_counter++ % int(1.f / p_density) == 0) {
+	if (p_density < 1.f && _instance_counter++ % uint32_t(1.f / p_density) == 0) {
 		count = 1;
 	} else if (p_density >= 1.f) {
-		count = int(p_density);
+		count = uint32_t(p_density);
 	}
 	return count;
 }


### PR DESCRIPTION
* Renames lift_flatten to alt_mode, which is enabled whenever ALT is pressed
* Instancer CTRL+ALT now removes all mesh types
* Height brush + CTRL flattens to 0