### PR TITLE
Instancer storage rework

### DIFF
--- a/project/addons/terrain_3d/editor.gd
+++ b/project/addons/terrain_3d/editor.gd
@@ -105,11 +105,11 @@ func _edit(p_object: Object) -> void:
 			return
 		terrain = p_object
 		_last_terrain = terrain
+		terrain.set_plugin(self)
+		terrain.set_editor(editor)
 		editor.set_terrain(terrain)
 		region_gizmo.set_node_3d(terrain)
 		terrain.add_gizmo(region_gizmo)
-		terrain.set_plugin(self)
-		terrain.set_editor(editor)
 		ui.set_visible(true)
 		terrain.set_meta("_edit_lock_", true)
 

--- a/project/addons/terrain_3d/editor.gd
+++ b/project/addons/terrain_3d/editor.gd
@@ -243,7 +243,12 @@ func _forward_3d_gui_input(p_viewport_camera: Camera3D, p_event: InputEvent) -> 
 
 func _read_input(p_event: InputEvent = null) -> void:
 	## Determine if user is moving camera or applying
-	_input_mode = 1 if Input.is_mouse_button_pressed(MOUSE_BUTTON_LEFT) else 0
+	if Input.is_mouse_button_pressed(MOUSE_BUTTON_LEFT) or \
+		p_event is InputEventMouseButton and p_event.is_released() and \
+		p_event.get_button_index() == MOUSE_BUTTON_LEFT:
+			_input_mode = 1 
+	else:
+			_input_mode = 0
 	
 	match get_setting("editors/3d/navigation/navigation_scheme", 0):
 		2, 1: # Modo, Maya

--- a/project/addons/terrain_3d/src/ui.gd
+++ b/project/addons/terrain_3d/src/ui.gd
@@ -316,7 +316,7 @@ func update_decal() -> void:
 
 	decal.position = plugin.mouse_global_position
 	decal.visible = true
-	decal.size = Vector3.ONE * brush_data["size"]
+	decal.size = Vector3.ONE * maxf(brush_data["size"], .5)
 	if brush_data["align_to_view"]:
 		var cam: Camera3D = plugin.terrain.get_camera();
 		if (cam):

--- a/project/demo/components/UI.tscn
+++ b/project/demo/components/UI.tscn
@@ -14,8 +14,53 @@ script = ExtResource("1_why5e")
 [node name="Label" type="Label" parent="."]
 unique_name_in_owner = true
 layout_mode = 1
-offset_right = 40.0
-offset_bottom = 23.0
+offset_left = 5.0
+offset_top = 5.0
+offset_right = 275.0
+offset_bottom = 340.0
 theme_override_colors/font_shadow_color = Color(0, 0, 0, 0.662745)
 theme_override_constants/shadow_offset_x = 1
 theme_override_constants/shadow_offset_y = 1
+text = "FPS: 100
+Position: (100, 100, 100)
+Move Speed: 10
+
+Player
+Move: WASDEQ,Space,Mouse
+Move speed: Wheel,+/-,Shift
+Camera view: V
+Gravity toggle: G
+Collision toggle: C
+
+Window
+Quit: F8
+UI toggle: F9
+Render mode: F10
+Full screen: F11
+Mouse toggle: Escape
+"
+
+[node name="Panel" type="Panel" parent="Label"]
+modulate = Color(1, 1, 1, 0.392157)
+show_behind_parent = true
+layout_mode = 0
+offset_left = -5.0
+offset_top = -5.0
+offset_right = 248.0
+offset_bottom = 444.0
+
+[node name="HSeparator" type="HSeparator" parent="Label/Panel"]
+top_level = true
+layout_mode = 0
+offset_left = 6.0
+offset_top = 129.0
+offset_right = 246.0
+offset_bottom = 138.0
+
+[node name="HSeparator2" type="HSeparator" parent="Label/Panel"]
+top_level = true
+layout_mode = 0
+offset_left = 6.0
+offset_top = 310.0
+offset_right = 246.0
+offset_bottom = 319.0

--- a/project/demo/data/assets.tres
+++ b/project/demo/data/assets.tres
@@ -5,16 +5,20 @@
 [ext_resource type="Texture2D" uid="uid://ddprscrpsofah" path="res://demo/assets/textures/ground037_alb_ht.png" id="3_g8f2m"]
 [ext_resource type="Texture2D" uid="uid://c1ots7w6i0i1q" path="res://demo/assets/textures/ground037_nrm_rgh.png" id="4_aw5y1"]
 
-[sub_resource type="StandardMaterial3D" id="StandardMaterial3D_6fvgb"]
+[sub_resource type="StandardMaterial3D" id="StandardMaterial3D_aubfq"]
+transparency = 4
 cull_mode = 2
 vertex_color_use_as_albedo = true
 backlight_enabled = true
 backlight = Color(0.5, 0.5, 0.5, 1)
+distance_fade_mode = 1
+distance_fade_min_distance = 960.0
+distance_fade_max_distance = 480.0
 
-[sub_resource type="Terrain3DMeshAsset" id="Terrain3DMeshAsset_xqljq"]
+[sub_resource type="Terrain3DMeshAsset" id="Terrain3DMeshAsset_dw1mh"]
 height_offset = 0.5
 density = 10.0
-material_override = SubResource("StandardMaterial3D_6fvgb")
+material_override = SubResource("StandardMaterial3D_aubfq")
 generated_type = 1
 
 [sub_resource type="Terrain3DTextureAsset" id="Terrain3DTextureAsset_mup2f"]
@@ -31,5 +35,5 @@ albedo_texture = ExtResource("3_g8f2m")
 normal_texture = ExtResource("4_aw5y1")
 
 [resource]
-mesh_list = Array[Terrain3DMeshAsset]([SubResource("Terrain3DMeshAsset_xqljq")])
+mesh_list = Array[Terrain3DMeshAsset]([SubResource("Terrain3DMeshAsset_dw1mh")])
 texture_list = Array[Terrain3DTextureAsset]([SubResource("Terrain3DTextureAsset_mup2f"), SubResource("Terrain3DTextureAsset_od0q7")])

--- a/project/demo/src/UI.gd
+++ b/project/demo/src/UI.gd
@@ -2,6 +2,7 @@ extends Control
 
 
 var player: Node
+var visible_mode: int = 1
 
 
 func _init() -> void:
@@ -10,26 +11,35 @@ func _init() -> void:
 
 func _process(p_delta) -> void:
 	$Label.text = "FPS: %s\n" % str(Engine.get_frames_per_second())
-	$Label.text += "Move Speed: %.1f\n" % player.MOVE_SPEED if player else ""
-	$Label.text += "Position: %.1v\n" % player.global_position if player else ""
-	$Label.text += "Move: WASDEQ/Space/Shift/Mouse\n"
-	$Label.text += "Move speed: Wheel,+/-\n"
-	$Label.text += "Camera View: V\n"
-	$Label.text += "Gravity toggle: G\n"
-	$Label.text += "Collision toggle: C\n"
-	$Label.text += "Hide UI: H\n"
-	$Label.text += "Full screen: F11\n"
-	$Label.text += "Mouse toggle: Escape\n"
-	$Label.text += "Quit: F8\n"
+	if(visible_mode == 1):
+		$Label.text += "Move Speed: %.1f\n" % player.MOVE_SPEED if player else ""
+		$Label.text += "Position: %.1v\n" % player.global_position if player else ""
+		$Label.text += """
+			Player
+			Move: WASDEQ,Space,Mouse
+			Move speed: Wheel,+/-,Shift
+			Camera View: V
+			Gravity toggle: G
+			Collision toggle: C
+
+			Window
+			Quit: F8
+			UI toggle: F9
+			Render mode: F10
+			Full screen: F11
+			Mouse toggle: Escape
+			"""
 
 
 func _unhandled_key_input(p_event: InputEvent) -> void:
 	if p_event is InputEventKey and p_event.pressed:
 		match p_event.keycode:
-			KEY_H:
-				visible = ! visible
 			KEY_F8:
 				get_tree().quit()
+			KEY_F9:
+				visible_mode = (visible_mode + 1 ) % 3
+				$Label/Panel.visible = (visible_mode == 1)
+				visible = visible_mode > 0
 			KEY_F10:
 				var vp = get_viewport()
 				vp.debug_draw = (vp.debug_draw + 1 ) % 6

--- a/src/constants.h
+++ b/src/constants.h
@@ -87,4 +87,23 @@ using namespace godot;
 		return ret;                                               \
 	}
 
+// Global Types
+
+struct Vector2iHash {
+	std::size_t operator()(const Vector2i &v) const {
+		std::size_t h1 = std::hash<int>()(v.x);
+		std::size_t h2 = std::hash<int>()(v.y);
+		return h1 ^ (h2 << 1);
+	}
+};
+
+struct Vector3Hash {
+	std::size_t operator()(const Vector3 &v) const {
+		std::size_t h1 = std::hash<float>()(v.x);
+		std::size_t h2 = std::hash<float>()(v.y);
+		std::size_t h3 = std::hash<float>()(v.z);
+		return h1 ^ (h2 << 1) ^ (h3 << 2);
+	}
+};
+
 #endif // CONSTANTS_CLASS_H

--- a/src/geoclipmap.cpp
+++ b/src/geoclipmap.cpp
@@ -11,17 +11,6 @@
 
 // Half each triangle, have to check for longest side.
 void GeoClipMap::_subdivide_half(PackedVector3Array &vertices, PackedInt32Array &indices) {
-
-	// Hash for map for quick vertex search, for loop was very very slow!
-	struct Vector3Hash {
-		std::size_t operator()(const Vector3 &v) const {
-			std::size_t h1 = std::hash<float>()(v.x);
-			std::size_t h2 = std::hash<float>()(v.y);
-			std::size_t h3 = std::hash<float>()(v.z);
-			return h1 ^ (h2 << 1) ^ (h3 << 2);
-		}
-	};
-
 	PackedVector3Array new_vertices;
 	PackedInt32Array new_indices;
 

--- a/src/register_types.cpp
+++ b/src/register_types.cpp
@@ -21,12 +21,12 @@ void initialize_terrain_3d(ModuleInitializationLevel p_level) {
 	ClassDB::register_class<Terrain3DInstancer>();
 	ClassDB::register_class<Terrain3DMaterial>();
 	ClassDB::register_class<Terrain3DMeshAsset>();
-	ClassDB::register_class<Terrain3DStorage>(); // Deprecated 0.9.3 - Remove 0.9.4+
+	ClassDB::register_class<Terrain3DStorage>(); // Deprecated 0.9.3 - Remove 1.0
 	ClassDB::register_class<Terrain3DRegion>();
 	ClassDB::register_class<Terrain3DTextureAsset>();
 	ClassDB::register_class<Terrain3DUtil>();
-	ClassDB::register_class<Terrain3DTexture>(); // Deprecated 0.9.2 - Remove 0.9.3+
-	ClassDB::register_class<Terrain3DTextureList>(); // Deprecated 0.9.2 - Remove 0.9.3+
+	ClassDB::register_class<Terrain3DTexture>(); // Deprecated 0.9.2 - Remove 1.0
+	ClassDB::register_class<Terrain3DTextureList>(); // Deprecated 0.9.2 - Remove 1.0
 }
 
 void uninitialize_terrain_3d(ModuleInitializationLevel p_level) {

--- a/src/shaders/debug_views.glsl
+++ b/src/shaders/debug_views.glsl
@@ -133,8 +133,8 @@ R"(
 //INSERT: DEBUG_REGION_GRID
 	// Show region grid
 	vec3 __pixel_pos1 = (INV_VIEW_MATRIX * vec4(VERTEX,1.0)).xyz;
-	float __region_line = 0.5;		// Region line thickness
-	__region_line = .1*sqrt(length(v_camera_pos - __pixel_pos1));
+	float __region_line = 1.0;		// Region line thickness
+	__region_line *= .1*sqrt(length(v_camera_pos - __pixel_pos1));
 	if (mod(__pixel_pos1.x * _vertex_density + __region_line*.5, _region_size) <= __region_line || 
 		mod(__pixel_pos1.z * _vertex_density + __region_line*.5, _region_size) <= __region_line ) {
 		ALBEDO = vec3(1.);
@@ -161,5 +161,16 @@ R"(
 		__vertex_add = vec3(0.15) * __distance_factor;
 	}
 	ALBEDO = fma(ALBEDO, 1.-__vertex_mul, __vertex_add);
+
+//INSERT: DEBUG_INSTANCER_GRID
+	// Show region grid
+	vec3 __pixel_pos3 = (INV_VIEW_MATRIX * vec4(VERTEX,1.0)).xyz;
+	float __cell_line = 0.5;		// Cell line thickness
+	__cell_line *= .1*sqrt(length(v_camera_pos - __pixel_pos3));
+	#define CELL_SIZE 32
+	if (mod(__pixel_pos3.x * _vertex_density + __cell_line*.5, CELL_SIZE) <= __cell_line || 
+		mod(__pixel_pos3.z * _vertex_density + __cell_line*.5, CELL_SIZE) <= __cell_line ) {
+		ALBEDO = vec3(.033);
+	}
 
 )"

--- a/src/terrain_3d.cpp
+++ b/src/terrain_3d.cpp
@@ -984,7 +984,6 @@ void Terrain3D::set_mesh_size(const int p_size) {
 void Terrain3D::set_vertex_spacing(const real_t p_spacing) {
 	real_t spacing = CLAMP(p_spacing, 0.25f, 100.0f);
 	if (_vertex_spacing != spacing) {
-		real_t scale = spacing / _vertex_spacing;
 		_vertex_spacing = spacing;
 		LOG(INFO, "Setting vertex spacing: ", _vertex_spacing);
 		_clear_meshes();
@@ -992,15 +991,8 @@ void Terrain3D::set_vertex_spacing(const real_t p_spacing) {
 		_destroy_instancer();
 		_initialize();
 		_data->_vertex_spacing = _vertex_spacing;
-		Dictionary mmis = _instancer->get_mmis();
-		Array keys = mmis.keys();
-		for (int i = 0; i < keys.size(); i++) {
-			MultiMeshInstance3D *mmi = cast_to<MultiMeshInstance3D>(mmis[keys[i]]);
-			if (mmi != nullptr) {
-				mmi->set_scale(Vector3(_vertex_spacing, 1.f, _vertex_spacing));
-			}
-		}
 		update_region_labels();
+		_instancer->_update_vertex_spacing(_vertex_spacing);
 	}
 	if (IS_EDITOR && _plugin != nullptr) {
 		_plugin->call("update_region_grid");

--- a/src/terrain_3d.cpp
+++ b/src/terrain_3d.cpp
@@ -223,7 +223,7 @@ void Terrain3D::_update_collision() {
 	int time = Time::get_singleton()->get_ticks_msec();
 	int shape_size = _region_size + 1;
 	float hole_const = NAN;
-	// DEPRECATED - Jolt v0.12 supports NAN. Remove check when it's old.
+	// DEPRECATED - Jolt v0.12 supports NAN. Remove 1.0. Jolt 0.13 supports 4.3.
 	if (ProjectSettings::get_singleton()->get_setting("physics/3d/physics_engine") == "JoltPhysics3D") {
 		hole_const = FLT_MAX;
 	}
@@ -1573,12 +1573,12 @@ void Terrain3D::_bind_methods() {
 	ADD_SIGNAL(MethodInfo("material_changed"));
 	ADD_SIGNAL(MethodInfo("assets_changed"));
 
-	// DEPRECATED 0.9.2 - Remove 0.9.3+
+	// DEPRECATED 0.9.2 - Remove 1.0
 	ClassDB::bind_method(D_METHOD("set_texture_list", "texture_list"), &Terrain3D::set_texture_list);
 	ClassDB::bind_method(D_METHOD("get_texture_list"), &Terrain3D::get_texture_list);
 	ADD_PROPERTY(PropertyInfo(Variant::OBJECT, "texture_list", PROPERTY_HINT_RESOURCE_TYPE, "Terrain3DTextureList", PROPERTY_USAGE_NONE), "set_texture_list", "get_texture_list");
 
-	// DEPRECATED 0.9.3 - Remove 0.9.4+
+	// DEPRECATED 0.9.3 - Remove 1.0
 	ClassDB::bind_method(D_METHOD("set_storage", "storage"), &Terrain3D::set_storage);
 	ClassDB::bind_method(D_METHOD("get_storage"), &Terrain3D::get_storage);
 	ClassDB::bind_method(D_METHOD("split_storage"), &Terrain3D::split_storage);
@@ -1589,7 +1589,7 @@ void Terrain3D::_bind_methods() {
 // DEPRECATED Functions
 ///////////////////////////
 
-// DEPRECATED 0.9.2 - Remove 0.9.3+
+// DEPRECATED 0.9.2 - Remove 1.0
 void Terrain3D::set_texture_list(const Ref<Terrain3DTextureList> &p_texture_list) {
 	if (p_texture_list.is_null()) {
 		LOG(ERROR, "Attempted to upgrade Terrain3DTextureList, but received null (perhaps already a Terrain3DAssets). Reconnect manually and save.");
@@ -1603,7 +1603,7 @@ void Terrain3D::set_texture_list(const Ref<Terrain3DTextureList> &p_texture_list
 	set_assets(assets);
 }
 
-// DEPRECATED 0.9.3 - Remove 0.9.4+
+// DEPRECATED 0.9.3 - Remove 1.0
 void Terrain3D::set_storage(const Ref<Terrain3DStorage> &p_storage) {
 	_storage = p_storage;
 	if (p_storage.is_valid()) {

--- a/src/terrain_3d.cpp
+++ b/src/terrain_3d.cpp
@@ -1632,7 +1632,7 @@ void Terrain3D::split_storage() {
 		region->set_height_map(hmaps[i]);
 		region->set_control_map(ctlmaps[i]);
 		region->set_color_map(clrmaps[i]);
-		region->set_multimeshes(mms[locations[i]]);
+		region->set_multimeshes(mms[locations[i]]); // TODO BROKEN
 		_data->add_region(region, false);
 		LOG(INFO, "Splicing region ", locations[i]);
 	}

--- a/src/terrain_3d.cpp
+++ b/src/terrain_3d.cpp
@@ -1632,7 +1632,7 @@ void Terrain3D::split_storage() {
 		region->set_height_map(hmaps[i]);
 		region->set_control_map(ctlmaps[i]);
 		region->set_color_map(clrmaps[i]);
-		region->set_multimeshes(mms[locations[i]]); // TODO BROKEN
+		region->set_instances(mms[locations[i]]); // TODO BROKEN - upgrade from 0.9.2
 		_data->add_region(region, false);
 		LOG(INFO, "Splicing region ", locations[i]);
 	}

--- a/src/terrain_3d.cpp
+++ b/src/terrain_3d.cpp
@@ -147,21 +147,21 @@ void Terrain3D::_grab_camera() {
 }
 
 void Terrain3D::_build_containers() {
-	_label_nodes = memnew(Node);
-	_label_nodes->set_name("Labels");
-	add_child(_label_nodes, true);
-	_mmi_nodes = memnew(Node);
-	_mmi_nodes->set_name("MMI");
-	add_child(_mmi_nodes, true);
+	_label_parent = memnew(Node3D);
+	_label_parent->set_name("Labels");
+	add_child(_label_parent, true);
+	_mmi_parent = memnew(Node3D);
+	_mmi_parent->set_name("MMI");
+	add_child(_mmi_parent, true);
 }
 
 void Terrain3D::_destroy_containers() {
-	memdelete_safely(_label_nodes);
-	memdelete_safely(_mmi_nodes);
+	memdelete_safely(_label_parent);
+	memdelete_safely(_mmi_parent);
 }
 
 void Terrain3D::_destroy_labels() {
-	Array labels = _label_nodes->get_children();
+	Array labels = _label_parent->get_children();
 	LOG(DEBUG, "Destroying ", labels.size(), " region labels");
 	for (int i = 0; i < labels.size(); i++) {
 		Node *label = cast_to<Node>(labels[i]);
@@ -879,7 +879,7 @@ void Terrain3D::update_region_labels() {
 			label->set_visibility_range_end(_label_distance);
 			label->set_visibility_range_end_margin(_label_distance / 10.f);
 			label->set_visibility_range_fade_mode(GeometryInstance3D::VISIBILITY_RANGE_FADE_SELF);
-			_label_nodes->add_child(label, true);
+			_label_parent->add_child(label, true);
 			Vector2i loc = region_locations[i];
 			Vector3 pos = Vector3(real_t(loc.x) + .5f, 0.f, real_t(loc.y) + .5f) * _region_size * _vertex_spacing;
 			real_t height = _data->get_height(pos);

--- a/src/terrain_3d.cpp
+++ b/src/terrain_3d.cpp
@@ -151,7 +151,7 @@ void Terrain3D::_build_containers() {
 	_label_nodes->set_name("Labels");
 	add_child(_label_nodes, true);
 	_mmi_nodes = memnew(Node);
-	_mmi_nodes->set_name("MMIs");
+	_mmi_nodes->set_name("MMI");
 	add_child(_mmi_nodes, true);
 }
 

--- a/src/terrain_3d.h
+++ b/src/terrain_3d.h
@@ -105,8 +105,8 @@ private:
 	uint32_t _mouse_layer = 32;
 
 	// Parent containers for child nodes
-	Node *_label_nodes;
-	Node *_mmi_nodes;
+	Node3D *_label_parent;
+	Node3D *_mmi_parent;
 
 	void _initialize();
 	void __process(const double p_delta);
@@ -155,7 +155,7 @@ public:
 	void set_assets(const Ref<Terrain3DAssets> &p_assets);
 	Ref<Terrain3DAssets> get_assets() const { return _assets; }
 	Terrain3DInstancer *get_instancer() const { return _instancer; }
-	Node *get_mmi_parent() const { return _mmi_nodes; }
+	Node *get_mmi_parent() const { return _mmi_parent; }
 	void set_editor(Terrain3DEditor *p_editor);
 	Terrain3DEditor *get_editor() const { return _editor; }
 	void set_plugin(EditorPlugin *p_plugin);

--- a/src/terrain_3d.h
+++ b/src/terrain_3d.h
@@ -228,11 +228,11 @@ protected:
 	static void _bind_methods();
 
 public:
-	// DEPRECATED 0.9.2 - Remove 0.9.3+
+	// DEPRECATED 0.9.2 - Remove 1.0
 	void set_texture_list(const Ref<Terrain3DTextureList> &p_texture_list);
 	Ref<Terrain3DTextureList> get_texture_list() const { return Ref<Terrain3DTextureList>(); }
 
-	// DEPRECATED 0.9.3 - Remove 0.9.4+
+	// DEPRECATED 0.9.3 - Remove 1.0
 	Ref<Terrain3DStorage> _storage;
 	void set_storage(const Ref<Terrain3DStorage> &p_storage);
 	Ref<Terrain3DStorage> get_storage() const { return _storage; }

--- a/src/terrain_3d_assets.cpp
+++ b/src/terrain_3d_assets.cpp
@@ -451,7 +451,7 @@ void Terrain3DAssets::create_mesh_thumbnails(const int p_id, const Vector2i &p_s
 			LOG(WARN, i, ": Terrain3DMeshAsset is null");
 			continue;
 		}
-		LOG(DEBUG, i, ": Getting Terrain3DMeshAsset: ", tmesh->get_instance_id());
+		LOG(DEBUG, i, ": Getting Terrain3DMeshAsset: ", String::num_uint64(tmesh->get_instance_id()));
 		Ref<Mesh> mesh = tmesh->get_mesh(0);
 		LOG(DEBUG, i, ": Getting Mesh 0: ", mesh);
 		if (mesh.is_null()) {

--- a/src/terrain_3d_assets.cpp
+++ b/src/terrain_3d_assets.cpp
@@ -608,7 +608,7 @@ void Terrain3DAssets::_bind_methods() {
 	ADD_SIGNAL(MethodInfo("textures_changed"));
 }
 
-// Deprecated 0.9.2 - Remove 0.9.3+
+// Deprecated 0.9.2 - Remove 1.0
 void Terrain3DTextureList::set_textures(const TypedArray<Terrain3DTexture> &p_textures) {
 	LOG(WARN, "Terrain3DTextureList: Converting Terrain3DTextures to Terrain3DTextureAssets. Save to complete.");
 	for (int i = 0; i < p_textures.size(); i++) {

--- a/src/terrain_3d_assets.cpp
+++ b/src/terrain_3d_assets.cpp
@@ -515,6 +515,10 @@ void Terrain3DAssets::update_mesh_list() {
 			LOG(ERROR, "Terrain3DMeshAsset id ", i, " is null, but shouldn't be.");
 			continue;
 		}
+		if (mesh_asset->get_mesh().is_null()) {
+			LOG(DEBUG, "Terrain3DMeshAsset has no mesh, adding a default");
+			mesh_asset->set_generated_type(Terrain3DMeshAsset::TYPE_TEXTURE_CARD);
+		}
 		if (!mesh_asset->is_connected("file_changed", callable_mp(this, &Terrain3DAssets::update_mesh_list))) {
 			LOG(DEBUG, "Connecting file_changed signal to self");
 			mesh_asset->connect("file_changed", callable_mp(this, &Terrain3DAssets::update_mesh_list));
@@ -522,10 +526,6 @@ void Terrain3DAssets::update_mesh_list() {
 		if (!mesh_asset->is_connected("setting_changed", callable_mp(this, &Terrain3DAssets::update_mesh_list))) {
 			LOG(DEBUG, "Connecting setting_changed signal to self");
 			mesh_asset->connect("setting_changed", callable_mp(this, &Terrain3DAssets::update_mesh_list));
-		}
-		if (mesh_asset->get_mesh().is_null()) {
-			LOG(DEBUG, "Terrain3DMeshAsset has no mesh, adding a default");
-			mesh_asset->set_generated_type(Terrain3DMeshAsset::TYPE_TEXTURE_CARD);
 		}
 		if (!mesh_asset->is_connected("file_changed", callable_mp(this, &Terrain3DAssets::_update_thumbnail).bind(mesh_asset))) {
 			LOG(DEBUG, "Connecting file_changed signal to _update_thumbnail");
@@ -535,9 +535,9 @@ void Terrain3DAssets::update_mesh_list() {
 			LOG(DEBUG, "Connecting setting_changed signal to _update_thumbnail");
 			mesh_asset->connect("setting_changed", callable_mp(this, &Terrain3DAssets::_update_thumbnail).bind(mesh_asset));
 		}
-		if (!mesh_asset->is_connected("cast_shadows_changed", callable_mp(_terrain->get_instancer(), &Terrain3DInstancer::set_cast_shadows))) {
-			LOG(DEBUG, "Connecting cast_shadows_changed signal to set_cast_shadows");
-			mesh_asset->connect("cast_shadows_changed", callable_mp(_terrain->get_instancer(), &Terrain3DInstancer::set_cast_shadows));
+		if (!mesh_asset->is_connected("instancer_setting_changed", callable_mp(_terrain->get_instancer(), &Terrain3DInstancer::force_update_mmis))) {
+			LOG(DEBUG, "Connecting instancer_setting_changed signal to _update_mmis");
+			mesh_asset->connect("instancer_setting_changed", callable_mp(_terrain->get_instancer(), &Terrain3DInstancer::force_update_mmis));
 		}
 	}
 	LOG(DEBUG, "Emitting meshes_changed");

--- a/src/terrain_3d_assets.h
+++ b/src/terrain_3d_assets.h
@@ -89,7 +89,7 @@ protected:
 
 VARIANT_ENUM_CAST(Terrain3DAssets::AssetType);
 
-// Deprecated 0.9.2 - Remove 0.9.3+
+// Deprecated 0.9.2 - Remove 1.0
 
 class Terrain3DTexture : public Terrain3DTextureAsset {
 	GDCLASS(Terrain3DTexture, Terrain3DTextureAsset);

--- a/src/terrain_3d_data.cpp
+++ b/src/terrain_3d_data.cpp
@@ -220,6 +220,7 @@ Ref<Terrain3DRegion> Terrain3DData::add_region_blank(const Vector2i &p_region_lo
 	region.instantiate();
 	region->set_location(p_region_loc);
 	region->set_region_size(_region_size);
+	region->set_vertex_spacing(_vertex_spacing);
 	if (add_region(region, p_update) == OK) {
 		region->set_modified(true);
 		return region;

--- a/src/terrain_3d_data.cpp
+++ b/src/terrain_3d_data.cpp
@@ -144,6 +144,7 @@ void Terrain3DData::change_region_size(int p_new_size) {
 		new_region.instantiate();
 		new_region->set_location(loc);
 		new_region->set_region_size(p_new_size);
+		new_region->set_vertex_spacing(_vertex_spacing);
 		new_region->set_modified(true);
 		new_region->sanitize_maps();
 

--- a/src/terrain_3d_data.cpp
+++ b/src/terrain_3d_data.cpp
@@ -801,7 +801,7 @@ void Terrain3DData::add_edited_area(const AABB &p_area) {
 	} else {
 		_edited_area = p_area;
 	}
-	emit_signal("maps_edited", _edited_area);
+	emit_signal("maps_edited", p_area);
 }
 
 // Recalculates master height range from all active regions current height ranges

--- a/src/terrain_3d_data.cpp
+++ b/src/terrain_3d_data.cpp
@@ -587,7 +587,11 @@ void Terrain3DData::set_pixel(const MapType p_map_type, const Vector3 &p_global_
 	Vector2i region_loc = get_region_location(p_global_position);
 	Ref<Terrain3DRegion> region = get_region(region_loc);
 	if (region.is_null()) {
-		LOG(ERROR, "No region found at: ", p_global_position);
+		LOG(ERROR, "No active region found at: ", p_global_position);
+		return;
+	}
+	if (region->is_deleted()) {
+		LOG(ERROR, "No active region found at: ", p_global_position);
 		return;
 	}
 	Vector2i global_offset = region_loc * _region_size;
@@ -607,6 +611,9 @@ Color Terrain3DData::get_pixel(const MapType p_map_type, const Vector3 &p_global
 	Vector2i region_loc = get_region_location(p_global_position);
 	Ref<Terrain3DRegion> region = get_region(region_loc);
 	if (region.is_null()) {
+		return COLOR_NAN;
+	}
+	if (region->is_deleted()) {
 		return COLOR_NAN;
 	}
 	Vector2i global_offset = region_loc * _region_size;

--- a/src/terrain_3d_data.cpp
+++ b/src/terrain_3d_data.cpp
@@ -257,6 +257,7 @@ Error Terrain3DData::add_region(const Ref<Terrain3DRegion> &p_region, const bool
 	LOG(DEBUG, "Storing region ", region_loc, " version ", vformat("%.3f", p_region->get_version()), " id: ", _region_locations.size());
 	if (p_update) {
 		force_update_maps();
+		_terrain->get_instancer()->force_update_mmis();
 	}
 	return OK;
 }
@@ -293,6 +294,7 @@ void Terrain3DData::remove_region(const Ref<Terrain3DRegion> &p_region, const bo
 	if (p_update) {
 		LOG(DEBUG, "Updating generated maps");
 		force_update_maps();
+		_terrain->get_instancer()->force_update_mmis();
 	}
 }
 
@@ -632,7 +634,7 @@ real_t Terrain3DData::get_height(const Vector3 &p_global_position) const {
 	const real_t &step = _vertex_spacing;
 	pos.y = 0.f;
 	// Round to nearest vertex
-	Vector3 pos_round = Vector3(round_multiple(pos.x, step), 0.f, round_multiple(pos.z, step));
+	Vector3 pos_round = pos.snapped(Vector3(step, 0.f, step));
 	// If requested position is close to a vertex, return its height
 	if ((pos - pos_round).length() < 0.01f) {
 		return get_pixel(TYPE_HEIGHT, pos).r;
@@ -679,7 +681,7 @@ bool Terrain3DData::is_in_slope(const Vector3 &p_global_position, const Vector2 
 		auto get_height = [&](Vector3 pos) -> real_t {
 			real_t step = _terrain->get_vertex_spacing();
 			// Round to nearest vertex
-			Vector3 pos_round = Vector3(round_multiple(pos.x, step), 0.f, round_multiple(pos.z, step));
+			Vector3 pos_round = pos.snapped(Vector3(step, 0.f, step));
 			real_t height = get_pixel(TYPE_HEIGHT, pos_round).r;
 			return std::isnan(height) ? 0.f : height;
 		};

--- a/src/terrain_3d_editor.cpp
+++ b/src/terrain_3d_editor.cpp
@@ -74,7 +74,6 @@ Ref<Terrain3DRegion> Terrain3DEditor::_operate_region(const Vector2i &p_region_l
 		_original_regions.push_back(region);
 		height_range = region->get_height_range();
 		_terrain->get_data()->remove_region(region);
-		_terrain->get_instancer()->force_update_mmis();
 		changed = true;
 	}
 
@@ -711,7 +710,7 @@ void Terrain3DEditor::start_operation(const Vector3 &p_global_position) {
 	_edited_regions = TypedArray<Terrain3DRegion>();
 	_added_removed_locations = TypedArray<Vector2i>();
 	// Reset counter at start to ensure first click places an instance
-	_terrain->get_instancer()->reset_instance_counter();
+	_terrain->get_instancer()->reset_density_counter();
 	_terrain->get_data()->clear_edited_area();
 	_operation_position = p_global_position;
 	_operation_movement = Vector3();

--- a/src/terrain_3d_editor.cpp
+++ b/src/terrain_3d_editor.cpp
@@ -50,9 +50,6 @@ Ref<Terrain3DRegion> Terrain3DEditor::_operate_region(const Vector2i &p_region_l
 	if (can_print) {
 		LOG(DEBUG, "Tool: ", _tool, " Op: ", _operation, " processing region ", p_region_loc, ": ",
 				region.is_valid() ? String::num_uint64(region->get_instance_id()) : "Null");
-		if (region.is_valid()) {
-			LOG(DEBUG, region->get_data());
-		}
 	}
 
 	// Create new region if location is null or deleted
@@ -573,7 +570,6 @@ void Terrain3DEditor::_apply_undo(const Dictionary &p_data) {
 			region->set_modified(true);
 			// Tell update_maps() this region has layers that can be individually updated
 			region->set_edited(true);
-			LOG(DEBUG, "Edited: ", region->get_data());
 		}
 	}
 
@@ -765,7 +761,6 @@ void Terrain3DEditor::stop_operation() {
 		for (int i = 0; i < _edited_regions.size(); i++) {
 			Ref<Terrain3DRegion> region = _edited_regions[i];
 			region->set_edited(false);
-			LOG(DEBUG, "Edited region: ", region->get_data());
 			// Make duplicate for redo backup
 			_edited_regions[i] = region->duplicate(true);
 		}

--- a/src/terrain_3d_editor.cpp
+++ b/src/terrain_3d_editor.cpp
@@ -543,18 +543,10 @@ void Terrain3DEditor::_store_undo() {
 	undo_redo->create_action(action_name, UndoRedo::MERGE_DISABLE, _terrain);
 
 	LOG(DEBUG, "Storing undo snapshot: ", _undo_data);
-	undo_redo->add_undo_method(this, "apply_undo", _undo_data);
-	for (int i = 0; i < _original_regions.size(); i++) {
-		Ref<Terrain3DRegion> region = _original_regions[i];
-		LOG(DEBUG, "Original Region: ", region->get_data());
-	}
+	undo_redo->add_undo_method(this, "apply_undo", _undo_data.duplicate());
 
 	LOG(DEBUG, "Storing redo snapshot: ", redo_data);
 	undo_redo->add_do_method(this, "apply_undo", redo_data);
-	for (int i = 0; i < _edited_regions.size(); i++) {
-		Ref<Terrain3DRegion> region = _edited_regions[i];
-		LOG(DEBUG, "Edited Region: ", region->get_data());
-	}
 
 	LOG(DEBUG, "Committing undo action");
 	undo_redo->commit_action(false);
@@ -711,8 +703,8 @@ void Terrain3DEditor::set_tool(const Tool p_tool) {
 // Called on mouse click
 void Terrain3DEditor::start_operation(const Vector3 &p_global_position) {
 	IS_DATA_INIT_MESG("Terrain isn't initialized", VOID);
-	LOG(INFO, "Setting up undo snapshot...");
-	_undo_data = Dictionary(); // New pointer instead of clear
+	LOG(INFO, "Setting up undo snapshot");
+	_undo_data.clear();
 	_undo_data["region_locations"] = _terrain->get_data()->get_region_locations().duplicate();
 	_is_operating = true;
 	_original_regions = TypedArray<Terrain3DRegion>(); // New pointers instead of clear
@@ -780,6 +772,7 @@ void Terrain3DEditor::stop_operation() {
 		}
 		_store_undo();
 	}
+	_undo_data.clear();
 	_original_regions = TypedArray<Terrain3DRegion>(); //New pointers instead of clear
 	_edited_regions = TypedArray<Terrain3DRegion>();
 	_added_removed_locations = TypedArray<Vector2i>();

--- a/src/terrain_3d_editor.cpp
+++ b/src/terrain_3d_editor.cpp
@@ -532,8 +532,8 @@ void Terrain3DEditor::_store_undo() {
 	}
 
 	// Store data in Godot's Undo/Redo Manager
-	LOG(INFO, "Storing undo snapshot...");
 	EditorUndoRedoManager *undo_redo = _terrain->get_plugin()->get_undo_redo();
+	LOG(INFO, "Storing undo snapshot");
 	String action_name = String("Terrain3D ") + OPNAME[_operation] + String(" ") + TOOLNAME[_tool];
 	LOG(DEBUG, "Creating undo action: '", action_name, "'");
 	undo_redo->create_action(action_name, UndoRedo::MERGE_DISABLE, _terrain);

--- a/src/terrain_3d_instancer.cpp
+++ b/src/terrain_3d_instancer.cpp
@@ -554,15 +554,20 @@ void Terrain3DInstancer::remove_instances(const Vector3 &p_global_position, cons
 		Vector2 localised_ring_center = Vector2(p_global_position.x - global_local_offset.x, p_global_position.z - global_local_offset.z);
 		// For this mesh id, or all mesh ids
 		for (int m = (modifier_shift ? 0 : mesh_id); m <= (modifier_shift ? mesh_count - 1 : mesh_id); m++) {
-			// Check potential cells rather than searching the entire region, whilst marginally
-			// slower if there are very few cells for the given mesh present it is significantly
-			// faster when a very large number of cells are present.
-			int mesh_id = mesh_types[m];
-			Dictionary cell_inst_dict = mesh_inst_dict[mesh_id];
-			Array cell_locations = cell_inst_dict.keys();
-			if (cell_locations.size() == 0) {
+			// Ensure this region has this mesh
+			if (!mesh_inst_dict.has(m)) {
 				continue;
 			}
+			Dictionary cell_inst_dict = mesh_inst_dict[m];
+			Array cell_locations = cell_inst_dict.keys();
+			// This shouldnt be empty.
+			if (cell_locations.size() == 0) {
+				LOG(WARN, "Region at: ", region_loc, " has instance dictionary for mesh id: ", m, " but has no cells.")
+				continue;
+			}
+			// Check potential cells rather than searching the entire region, whilst marginally
+			// slower if there are very few cells for the given mesh present. It is significantly
+			// faster when a large number of cells are present.
 			Dictionary c_locs;
 			// Calculate step distance to ensure every cell is checked inside the bounds of brush size.
 			real_t cell_step = brush_size / ceil(brush_size / real_t(CELL_SIZE) / vertex_spacing);

--- a/src/terrain_3d_instancer.cpp
+++ b/src/terrain_3d_instancer.cpp
@@ -315,6 +315,30 @@ void Terrain3DInstancer::initialize(Terrain3D *p_terrain) {
 	}
 	IS_DATA_INIT_MESG("Terrain or storage not ready yet", VOID);
 	LOG(INFO, "Initializing Instancer");
+
+	{ // DEPRECATED 0.9.3 - Remove 1.0
+		// This block upgrades 0.9.3-dev multimeshes to _instances
+		bool upgraded = false;
+		TypedArray<Terrain3DRegion> regions = _terrain->get_data()->get_regions_active();
+		for (int i = 0; i < regions.size(); i++) {
+			Ref<Terrain3DRegion> region = regions[i];
+			if (!region->get_multimeshes().is_empty()) {
+				Dictionary mesh_dict = region->get_multimeshes();
+				// Dictionary[mesh_id:int] -> MultiMesh
+				Array mkeys = mesh_dict.keys();
+				for (int j = 0; j < mkeys.size(); j++) {
+					int mesh_id = mkeys[j];
+					add_multimesh(mesh_id, mesh_dict[mesh_id], Transform3D(), false);
+					upgraded = true;
+				}
+				mesh_dict.clear();
+			}
+		}
+		if (upgraded) {
+			LOG(WARN, "Upgrading v0.9.3-dev instancer data. Save to write changes to disk.");
+		}
+	}
+
 	_update_mmis();
 }
 

--- a/src/terrain_3d_instancer.cpp
+++ b/src/terrain_3d_instancer.cpp
@@ -166,6 +166,9 @@ void Terrain3DInstancer::_update_mmis(const Vector2i &p_region_loc, const int p_
 					String cstring = "_C" + Util::location_to_string(cell).trim_prefix("_");
 					mmi->set_name("MMI3D" + cstring + "_M" + String::num_int64(mesh_id));
 					mmi->set_as_top_level(true);
+					mmi->set_cast_shadows_setting(ma->get_cast_shadows());
+					mmi->set_visibility_range_end(ma->get_visibility_range());
+					//mmi->set_visibility_range_end_margin(ma->get_visibility_margin());
 					cell_mmi_dict[cell] = mmi;
 					//Attach to tree
 					Node *node_container = _terrain->get_mmi_parent()->get_node_internal(rname);
@@ -182,13 +185,9 @@ void Terrain3DInstancer::_update_mmis(const Vector2i &p_region_loc, const int p_
 					continue;
 				}
 
-				mmi = cell_mmi_dict[cell];
-				//dump_mmis();
-
 				// Create MM and assign to MMI
-				Ref<MultiMesh> mm = _create_multimesh(mesh_id, xforms, colors);
-				mmi->set_multimesh(mm);
-				mmi->set_cast_shadows_setting(ma->get_cast_shadows());
+				mmi = cell_mmi_dict[cell];
+				mmi->set_multimesh(_create_multimesh(mesh_id, xforms, colors));
 
 				// Reposition the MMIs to their region location
 				Transform3D t = Transform3D();
@@ -1031,24 +1030,6 @@ MultiMeshInstance3D *Terrain3DInstancer::get_multimesh_instance(const Vector2i &
 	//return mmi;
 }
 
-void Terrain3DInstancer::set_cast_shadows(const int p_mesh_id, const GeometryInstance3D::ShadowCastingSetting p_cast_shadows) {
-	LOG(INFO, "Setting shadow casting on MMIS with mesh: ", p_mesh_id, " to mode: ", p_cast_shadows);
-	for (auto &region_pair : _mmi_nodes) {
-		MeshMMIDict &mesh_mmi_dict = region_pair.second;
-		Vector2i mesh_key(p_mesh_id, 0);
-		if (mesh_mmi_dict.count(mesh_key) == 0) {
-			continue;
-		}
-		CellMMIDict &cell_mmi_dict = mesh_mmi_dict[mesh_key];
-		for (auto &cell_pair : cell_mmi_dict) {
-			MultiMeshInstance3D *mmi = cell_pair.second;
-			if (mmi) {
-				mmi->set_cast_shadows_setting(p_cast_shadows);
-			}
-		}
-	}
-}
-
 void Terrain3DInstancer::force_update_mmis() {
 	destroy();
 	_update_mmis();
@@ -1105,6 +1086,5 @@ void Terrain3DInstancer::_bind_methods() {
 
 	ClassDB::bind_method(D_METHOD("swap_ids", "src_id", "dest_id"), &Terrain3DInstancer::swap_ids);
 	//ClassDB::bind_method(D_METHOD("get_mmis"), &Terrain3DInstancer::get_mmis);
-	ClassDB::bind_method(D_METHOD("set_cast_shadows", "mesh_id", "mode"), &Terrain3DInstancer::set_cast_shadows);
 	ClassDB::bind_method(D_METHOD("force_update_mmis"), &Terrain3DInstancer::force_update_mmis);
 }

--- a/src/terrain_3d_instancer.cpp
+++ b/src/terrain_3d_instancer.cpp
@@ -239,6 +239,15 @@ Ref<MultiMesh> Terrain3DInstancer::_create_multimesh(const int p_mesh_id, const 
 	return mm;
 }
 
+Vector2i Terrain3DInstancer::_get_cell(const Vector3 &p_global_position) {
+	int region_size = _terrain->get_region_size();
+	real_t vertex_spacing = _terrain->get_vertex_spacing();
+	Vector2i cell;
+	cell.x = (UtilityFunctions::floori(p_global_position.x / vertex_spacing) % region_size) / CELL_SIZE;
+	cell.y = (UtilityFunctions::floori(p_global_position.z / vertex_spacing) % region_size) / CELL_SIZE;
+	return cell;
+}
+
 ///////////////////////////
 // Public Functions
 ///////////////////////////

--- a/src/terrain_3d_instancer.h
+++ b/src/terrain_3d_instancer.h
@@ -31,10 +31,10 @@ class Terrain3DInstancer : public Object {
 	// Dictionary[mesh_id:int] -> MultiMesh
 	// MMI Objects attached to tree, freed in destructor, stored as
 	// Dictionary[Vector3i(region_location.x, region_location.y, mesh_id)] -> MultiMeshInstance3D
-	Dictionary _mmis;
+	Dictionary _mmi_nodes;
 
-	uint32_t _instance_counter = 0;
-	uint32_t _get_instace_count(const real_t p_density);
+	uint32_t _density_counter = 0;
+	uint32_t _get_density_count(const real_t p_density);
 
 	void _update_mmis(const Vector2i &p_region_loc = V2I_MAX, const int p_mesh_id = -1);
 	void _destroy_mmi_by_location(const Vector2i &p_region_loc, const int p_mesh_id);
@@ -69,11 +69,11 @@ public:
 	Ref<MultiMesh> get_multimesh(const Vector2i &p_region_loc, const int p_mesh_id) const;
 	MultiMeshInstance3D *get_multimesh_instancep(const Vector3 &p_global_position, const int p_mesh_id) const;
 	MultiMeshInstance3D *get_multimesh_instance(const Vector2i &p_region_loc, const int p_mesh_id) const;
-	Dictionary get_mmis() const { return _mmis; }
+	Dictionary get_mmis() const { return _mmi_nodes; }
 	void set_cast_shadows(const int p_mesh_id, const GeometryInstance3D::ShadowCastingSetting p_cast_shadows);
 	void force_update_mmis();
 
-	void reset_instance_counter() { _instance_counter = 0; }
+	void reset_density_counter() { _density_counter = 0; }
 	void print_multimesh_buffer(MultiMeshInstance3D *p_mmi) const;
 
 protected:
@@ -81,10 +81,10 @@ protected:
 };
 
 // Allows us to instance every X function calls for sparse placement
-// Modifies _instance_counter, not const!
-inline uint32_t Terrain3DInstancer::_get_instace_count(const real_t p_density) {
+// Modifies _density_counter, not const!
+inline uint32_t Terrain3DInstancer::_get_density_count(const real_t p_density) {
 	uint32_t count = 0;
-	if (p_density < 1.f && _instance_counter++ % uint32_t(1.f / p_density) == 0) {
+	if (p_density < 1.f && _density_counter++ % uint32_t(1.f / p_density) == 0) {
 		count = 1;
 	} else if (p_density >= 1.f) {
 		count = uint32_t(p_density);

--- a/src/terrain_3d_instancer.h
+++ b/src/terrain_3d_instancer.h
@@ -25,16 +25,11 @@ private:
 	Terrain3D *_terrain = nullptr;
 
 	// MM Resources stored in Terrain3DRegion::_instances as
-	// _instances{mesh_id:int} -> cell{v2i} -> [ TypedArray<Transform3D>, PackedColorArray ]
+	// _instances{mesh_id:int} -> cell{v2i} -> [ TypedArray<Transform3D>, PackedColorArray, Modified<bool> ]
 
 	// MMI Objects attached to tree, freed in destructor, stored as
 	// _mmi_nodes{region_loc} -> mesh{v2i(mesh_id,lod)} -> cell{v2i} -> MultiMeshInstance3D
 
-	//old:
-	// MM Resources stored in Terrain3DRegion::_multimeshes as
-	// Dictionary[mesh_id:int] -> MultiMesh
-	// MMI Objects attached to tree, freed in destructor, stored as
-	// Dictionary[Vector3i(region_location.x, region_location.y, mesh_id)] -> MultiMeshInstance3D
 	Dictionary _mmi_nodes;
 	Dictionary _mmi_containers; // { region_loc -> Node }
 

--- a/src/terrain_3d_instancer.h
+++ b/src/terrain_3d_instancer.h
@@ -38,6 +38,7 @@ class Terrain3DInstancer : public Object {
 	uint32_t _get_density_count(const real_t p_density);
 
 	void _update_mmis(const Vector2i &p_region_loc = V2I_MAX, const int p_mesh_id = -1);
+	void _update_vertex_spacing(const real_t p_vertex_spacing);
 	void _destroy_mmi_by_location(const Vector2i &p_region_loc, const int p_mesh_id);
 	void _backup_regionl(const Vector2i &p_region_loc);
 	void _backup_region(const Ref<Terrain3DRegion> &p_region);

--- a/src/terrain_3d_instancer.h
+++ b/src/terrain_3d_instancer.h
@@ -5,6 +5,7 @@
 
 #include <godot_cpp/classes/multi_mesh.hpp>
 #include <godot_cpp/classes/multi_mesh_instance3d.hpp>
+#include <unordered_map>
 
 #include "constants.h"
 
@@ -29,7 +30,9 @@ private:
 
 	// MMI Objects attached to tree, freed in destructor, stored as
 	// _mmi_nodes{region_loc} -> mesh{v2i(mesh_id,lod)} -> cell{v2i} -> MultiMeshInstance3D
-	Dictionary _mmi_nodes;
+	typedef std::unordered_map<Vector2i, MultiMeshInstance3D *, Vector2iHash> CellMMIDict;
+	typedef std::unordered_map<Vector2i, CellMMIDict, Vector2iHash> MeshMMIDict;
+	std::unordered_map<Vector2i, MeshMMIDict, Vector2iHash> _mmi_nodes;
 
 	// Region MMI containers named Terrain3D/MMI/Region* are stored here as
 	// _mmi_containers{region_loc} -> Node
@@ -40,6 +43,7 @@ private:
 
 	void _update_mmis(const Vector2i &p_region_loc = V2I_MAX, const int p_mesh_id = -1);
 	void _update_vertex_spacing(const real_t p_vertex_spacing);
+	void _destroy_mmi_by_cell(const Vector2i &p_region_loc, const int p_mesh_id, const Vector2i p_cell);
 	void _destroy_mmi_by_location(const Vector2i &p_region_loc, const int p_mesh_id);
 	void _backup_regionl(const Vector2i &p_region_loc);
 	void _backup_region(const Ref<Terrain3DRegion> &p_region);
@@ -73,12 +77,13 @@ public:
 	Ref<MultiMesh> get_multimesh(const Vector2i &p_region_loc, const int p_mesh_id) const;
 	MultiMeshInstance3D *get_multimesh_instancep(const Vector3 &p_global_position, const int p_mesh_id) const;
 	MultiMeshInstance3D *get_multimesh_instance(const Vector2i &p_region_loc, const int p_mesh_id) const;
-	Dictionary get_mmis() const { return _mmi_nodes; }
+	//std:: get_mmis() const { return _mmi_nodes; }
 	void set_cast_shadows(const int p_mesh_id, const GeometryInstance3D::ShadowCastingSetting p_cast_shadows);
 	void force_update_mmis();
 
 	void reset_density_counter() { _density_counter = 0; }
 	void print_multimesh_buffer(MultiMeshInstance3D *p_mmi) const;
+	void dump_mmis();
 
 protected:
 	static void _bind_methods();

--- a/src/terrain_3d_instancer.h
+++ b/src/terrain_3d_instancer.h
@@ -26,7 +26,7 @@ private:
 	Terrain3D *_terrain = nullptr;
 
 	// MM Resources stored in Terrain3DRegion::_instances as
-	// _instances{mesh_id:int} -> cell{v2i} -> [ TypedArray<Transform3D>, PackedColorArray, modified:bool ]
+	// Region::_instances{mesh_id:int} -> cell{v2i} -> [ TypedArray<Transform3D>, PackedColorArray, modified:bool ]
 
 	// MMI Objects attached to tree, freed in destructor, stored as
 	// _mmi_nodes{region_loc} -> mesh{v2i(mesh_id,lod)} -> cell{v2i} -> MultiMeshInstance3D
@@ -35,8 +35,8 @@ private:
 	std::unordered_map<Vector2i, MeshMMIDict, Vector2iHash> _mmi_nodes;
 
 	// Region MMI containers named Terrain3D/MMI/Region* are stored here as
-	// _mmi_containers{region_loc} -> Node
-	Dictionary _mmi_containers;
+	// _mmi_containers{region_loc} -> Node3D
+	std::unordered_map<Vector2i, Node3D *, Vector2iHash> _mmi_containers;
 
 	uint32_t _density_counter = 0;
 	uint32_t _get_density_count(const real_t p_density);
@@ -77,11 +77,11 @@ public:
 	Ref<MultiMesh> get_multimesh(const Vector2i &p_region_loc, const int p_mesh_id) const;
 	MultiMeshInstance3D *get_multimesh_instancep(const Vector3 &p_global_position, const int p_mesh_id) const;
 	MultiMeshInstance3D *get_multimesh_instance(const Vector2i &p_region_loc, const int p_mesh_id) const;
-	//std:: get_mmis() const { return _mmi_nodes; }
 	void force_update_mmis();
 
 	void reset_density_counter() { _density_counter = 0; }
 	void print_multimesh_buffer(MultiMeshInstance3D *p_mmi) const;
+	void dump_data();
 	void dump_mmis();
 
 protected:

--- a/src/terrain_3d_instancer.h
+++ b/src/terrain_3d_instancer.h
@@ -63,12 +63,12 @@ public:
 
 	void add_instances(const Vector3 &p_global_position, const Dictionary &p_params);
 	void remove_instances(const Vector3 &p_global_position, const Dictionary &p_params);
-	void add_multimesh(const int p_mesh_id, const Ref<MultiMesh> &p_multimesh, const Transform3D &p_xform = Transform3D());
-	void add_transforms(const int p_mesh_id, const TypedArray<Transform3D> &p_xforms, const PackedColorArray &p_colors = PackedColorArray());
+	void add_multimesh(const int p_mesh_id, const Ref<MultiMesh> &p_multimesh, const Transform3D &p_xform = Transform3D(), const bool p_update = true);
+	void add_transforms(const int p_mesh_id, const TypedArray<Transform3D> &p_xforms, const PackedColorArray &p_colors = PackedColorArray(), const bool p_update = true);
 	void append_location(const Vector2i &p_region_loc, const int p_mesh_id, const TypedArray<Transform3D> &p_xforms,
-			const PackedColorArray &p_colors, const bool p_clear = false, const bool p_update = true);
+			const PackedColorArray &p_colors, const bool p_update = true);
 	void append_region(const Ref<Terrain3DRegion> &p_region, const int p_mesh_id, const TypedArray<Transform3D> &p_xforms,
-			const PackedColorArray &p_colors, const bool p_clear = false, const bool p_update = true);
+			const PackedColorArray &p_colors, const bool p_update = true);
 	void update_transforms(const AABB &p_aabb);
 	void copy_paste_dfr(const Terrain3DRegion *p_src_region, const Rect2i &p_src_rect, const Terrain3DRegion *p_dst_region);
 

--- a/src/terrain_3d_instancer.h
+++ b/src/terrain_3d_instancer.h
@@ -18,13 +18,17 @@ class Terrain3DInstancer : public Object {
 	CLASS_NAME();
 	friend Terrain3D;
 
+public: // Constants
+	static inline const int CELL_SIZE = 32;
+
+private:
 	Terrain3D *_terrain = nullptr;
 
 	// MM Resources stored in Terrain3DRegion::_instances as
-	// _instances{mesh_id:int} -> Location{v2i} -> [ TypedArray<Transform3D>, PackedColorArray ]
+	// _instances{mesh_id:int} -> cell{v2i} -> [ TypedArray<Transform3D>, PackedColorArray ]
 
 	// MMI Objects attached to tree, freed in destructor, stored as
-	// _mmi_nodes{region_loc} -> mesh{v2i(mesh_id,lod)} -> grid_loc{v2i} -> MultiMeshInstance3D
+	// _mmi_nodes{region_loc} -> mesh{v2i(mesh_id,lod)} -> cell{v2i} -> MultiMeshInstance3D
 
 	//old:
 	// MM Resources stored in Terrain3DRegion::_multimeshes as
@@ -43,6 +47,7 @@ class Terrain3DInstancer : public Object {
 	void _backup_regionl(const Vector2i &p_region_loc);
 	void _backup_region(const Ref<Terrain3DRegion> &p_region);
 	Ref<MultiMesh> _create_multimesh(const int p_mesh_id, const TypedArray<Transform3D> &p_xforms = TypedArray<Transform3D>(), const PackedColorArray &p_colors = PackedColorArray()) const;
+	Vector2i _get_cell(const Vector3 &p_global_position);
 
 public:
 	Terrain3DInstancer() {}

--- a/src/terrain_3d_instancer.h
+++ b/src/terrain_3d_instancer.h
@@ -44,7 +44,7 @@ private:
 	void _backup_regionl(const Vector2i &p_region_loc);
 	void _backup_region(const Ref<Terrain3DRegion> &p_region);
 	Ref<MultiMesh> _create_multimesh(const int p_mesh_id, const TypedArray<Transform3D> &p_xforms = TypedArray<Transform3D>(), const PackedColorArray &p_colors = PackedColorArray()) const;
-	Vector2i _get_cell(const Vector3 &p_global_position);
+	Vector2i _get_cell(const Vector3 &p_global_position, const int p_region_size);
 
 public:
 	Terrain3DInstancer() {}
@@ -66,7 +66,7 @@ public:
 	void append_region(const Ref<Terrain3DRegion> &p_region, const int p_mesh_id, const TypedArray<Transform3D> &p_xforms,
 			const PackedColorArray &p_colors, const bool p_clear = false, const bool p_update = true);
 	void update_transforms(const AABB &p_aabb);
-	void copy_paste_dfr(const Terrain3DRegion *p_src_region, const Rect2 &p_src_rect, const Terrain3DRegion *p_dst_region);
+	void copy_paste_dfr(const Terrain3DRegion *p_src_region, const Rect2i &p_src_rect, const Terrain3DRegion *p_dst_region);
 
 	void swap_ids(const int p_src_id, const int p_dst_id);
 	Ref<MultiMesh> get_multimeshp(const Vector3 &p_global_position, const int p_mesh_id) const;

--- a/src/terrain_3d_instancer.h
+++ b/src/terrain_3d_instancer.h
@@ -32,6 +32,7 @@ class Terrain3DInstancer : public Object {
 	// MMI Objects attached to tree, freed in destructor, stored as
 	// Dictionary[Vector3i(region_location.x, region_location.y, mesh_id)] -> MultiMeshInstance3D
 	Dictionary _mmi_nodes;
+	Dictionary _mmi_containers; // { region_loc -> Node }
 
 	uint32_t _density_counter = 0;
 	uint32_t _get_density_count(const real_t p_density);

--- a/src/terrain_3d_instancer.h
+++ b/src/terrain_3d_instancer.h
@@ -20,6 +20,13 @@ class Terrain3DInstancer : public Object {
 
 	Terrain3D *_terrain = nullptr;
 
+	// MM Resources stored in Terrain3DRegion::_instances as
+	// _instances{mesh_id:int} -> Location{v2i} -> [ TypedArray<Transform3D>, PackedColorArray ]
+
+	// MMI Objects attached to tree, freed in destructor, stored as
+	// _mmi_nodes{region_loc} -> mesh{v2i(mesh_id,lod)} -> grid_loc{v2i} -> MultiMeshInstance3D
+
+	//old:
 	// MM Resources stored in Terrain3DRegion::_multimeshes as
 	// Dictionary[mesh_id:int] -> MultiMesh
 	// MMI Objects attached to tree, freed in destructor, stored as
@@ -33,7 +40,7 @@ class Terrain3DInstancer : public Object {
 	void _destroy_mmi_by_location(const Vector2i &p_region_loc, const int p_mesh_id);
 	void _backup_regionl(const Vector2i &p_region_loc);
 	void _backup_region(const Ref<Terrain3DRegion> &p_region);
-	Ref<MultiMesh> _create_multimesh(const int p_mesh_id, const TypedArray<Transform3D> &p_xforms = TypedArray<Transform3D>(), const TypedArray<Color> &p_colors = TypedArray<Color>()) const;
+	Ref<MultiMesh> _create_multimesh(const int p_mesh_id, const TypedArray<Transform3D> &p_xforms = TypedArray<Transform3D>(), const PackedColorArray &p_colors = PackedColorArray()) const;
 
 public:
 	Terrain3DInstancer() {}
@@ -49,11 +56,11 @@ public:
 	void add_instances(const Vector3 &p_global_position, const Dictionary &p_params);
 	void remove_instances(const Vector3 &p_global_position, const Dictionary &p_params);
 	void add_multimesh(const int p_mesh_id, const Ref<MultiMesh> &p_multimesh, const Transform3D &p_xform = Transform3D());
-	void add_transforms(const int p_mesh_id, const TypedArray<Transform3D> &p_xforms, const TypedArray<Color> &p_colors = TypedArray<Color>());
+	void add_transforms(const int p_mesh_id, const TypedArray<Transform3D> &p_xforms, const PackedColorArray &p_colors = PackedColorArray());
 	void append_location(const Vector2i &p_region_loc, const int p_mesh_id, const TypedArray<Transform3D> &p_xforms,
-			const TypedArray<Color> &p_colors, const bool p_clear = false, const bool p_update = true);
+			const PackedColorArray &p_colors, const bool p_clear = false, const bool p_update = true);
 	void append_region(const Ref<Terrain3DRegion> &p_region, const int p_mesh_id, const TypedArray<Transform3D> &p_xforms,
-			const TypedArray<Color> &p_colors, const bool p_clear = false, const bool p_update = true);
+			const PackedColorArray &p_colors, const bool p_clear = false, const bool p_update = true);
 	void update_transforms(const AABB &p_aabb);
 	void copy_paste_dfr(const Terrain3DRegion *p_src_region, const Rect2 &p_src_rect, const Terrain3DRegion *p_dst_region);
 

--- a/src/terrain_3d_instancer.h
+++ b/src/terrain_3d_instancer.h
@@ -25,7 +25,7 @@ private:
 	Terrain3D *_terrain = nullptr;
 
 	// MM Resources stored in Terrain3DRegion::_instances as
-	// _instances{mesh_id:int} -> cell{v2i} -> [ TypedArray<Transform3D>, PackedColorArray, Modified<bool> ]
+	// _instances{mesh_id:int} -> cell{v2i} -> [ TypedArray<Transform3D>, PackedColorArray, modified:bool ]
 
 	// MMI Objects attached to tree, freed in destructor, stored as
 	// _mmi_nodes{region_loc} -> mesh{v2i(mesh_id,lod)} -> cell{v2i} -> MultiMeshInstance3D

--- a/src/terrain_3d_instancer.h
+++ b/src/terrain_3d_instancer.h
@@ -78,7 +78,6 @@ public:
 	MultiMeshInstance3D *get_multimesh_instancep(const Vector3 &p_global_position, const int p_mesh_id) const;
 	MultiMeshInstance3D *get_multimesh_instance(const Vector2i &p_region_loc, const int p_mesh_id) const;
 	//std:: get_mmis() const { return _mmi_nodes; }
-	void set_cast_shadows(const int p_mesh_id, const GeometryInstance3D::ShadowCastingSetting p_cast_shadows);
 	void force_update_mmis();
 
 	void reset_density_counter() { _density_counter = 0; }

--- a/src/terrain_3d_instancer.h
+++ b/src/terrain_3d_instancer.h
@@ -29,9 +29,11 @@ private:
 
 	// MMI Objects attached to tree, freed in destructor, stored as
 	// _mmi_nodes{region_loc} -> mesh{v2i(mesh_id,lod)} -> cell{v2i} -> MultiMeshInstance3D
-
 	Dictionary _mmi_nodes;
-	Dictionary _mmi_containers; // { region_loc -> Node }
+
+	// Region MMI containers named Terrain3D/MMI/Region* are stored here as
+	// _mmi_containers{region_loc} -> Node
+	Dictionary _mmi_containers;
 
 	uint32_t _density_counter = 0;
 	uint32_t _get_density_count(const real_t p_density);

--- a/src/terrain_3d_instancer.h
+++ b/src/terrain_3d_instancer.h
@@ -73,14 +73,9 @@ public:
 	void copy_paste_dfr(const Terrain3DRegion *p_src_region, const Rect2i &p_src_rect, const Terrain3DRegion *p_dst_region);
 
 	void swap_ids(const int p_src_id, const int p_dst_id);
-	Ref<MultiMesh> get_multimeshp(const Vector3 &p_global_position, const int p_mesh_id) const;
-	Ref<MultiMesh> get_multimesh(const Vector2i &p_region_loc, const int p_mesh_id) const;
-	MultiMeshInstance3D *get_multimesh_instancep(const Vector3 &p_global_position, const int p_mesh_id) const;
-	MultiMeshInstance3D *get_multimesh_instance(const Vector2i &p_region_loc, const int p_mesh_id) const;
 	void force_update_mmis();
 
 	void reset_density_counter() { _density_counter = 0; }
-	void print_multimesh_buffer(MultiMeshInstance3D *p_mmi) const;
 	void dump_data();
 	void dump_mmis();
 

--- a/src/terrain_3d_material.cpp
+++ b/src/terrain_3d_material.cpp
@@ -244,6 +244,9 @@ String Terrain3DMaterial::_inject_editor_code(const String &p_shader) const {
 	if (_debug_view_vertex_grid) {
 		insert_names.push_back("DEBUG_VERTEX_GRID");
 	}
+	if (_debug_view_instancer_grid) {
+		insert_names.push_back("DEBUG_INSTANCER_GRID");
+	}
 	if (_show_navigation || (IS_EDITOR && _terrain && _terrain->get_editor() && _terrain->get_editor()->get_tool() == Terrain3DEditor::NAVIGATION)) {
 		insert_names.push_back("EDITOR_NAVIGATION");
 	}
@@ -643,6 +646,12 @@ void Terrain3DMaterial::set_show_vertex_grid(const bool p_enabled) {
 	_update_shader();
 }
 
+void Terrain3DMaterial::set_show_instancer_grid(const bool p_enabled) {
+	LOG(INFO, "Enable show_vertex_grid: ", p_enabled);
+	_debug_view_instancer_grid = p_enabled;
+	_update_shader();
+}
+
 Error Terrain3DMaterial::save(const String &p_path) {
 	if (p_path.is_empty() && get_path().is_empty()) {
 		LOG(ERROR, "No valid path provided");
@@ -870,6 +879,8 @@ void Terrain3DMaterial::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("get_show_region_grid"), &Terrain3DMaterial::get_show_region_grid);
 	ClassDB::bind_method(D_METHOD("set_show_vertex_grid", "enabled"), &Terrain3DMaterial::set_show_vertex_grid);
 	ClassDB::bind_method(D_METHOD("get_show_vertex_grid"), &Terrain3DMaterial::get_show_vertex_grid);
+	ClassDB::bind_method(D_METHOD("set_show_instancer_grid", "enabled"), &Terrain3DMaterial::set_show_instancer_grid);
+	ClassDB::bind_method(D_METHOD("get_show_instancer_grid"), &Terrain3DMaterial::get_show_instancer_grid);
 
 	ClassDB::bind_method(D_METHOD("save", "path"), &Terrain3DMaterial::save, DEFVAL(""));
 
@@ -898,4 +909,5 @@ void Terrain3DMaterial::_bind_methods() {
 	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "show_texture_rough", PROPERTY_HINT_NONE), "set_show_texture_rough", "get_show_texture_rough");
 	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "show_region_grid", PROPERTY_HINT_NONE), "set_show_region_grid", "get_show_region_grid");
 	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "show_vertex_grid", PROPERTY_HINT_NONE), "set_show_vertex_grid", "get_show_vertex_grid");
+	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "show_instancer_grid", PROPERTY_HINT_NONE), "set_show_instancer_grid", "get_show_instancer_grid");
 }

--- a/src/terrain_3d_material.h
+++ b/src/terrain_3d_material.h
@@ -66,6 +66,7 @@ private:
 	bool _debug_view_tex_rough = false;
 	bool _debug_view_region_grid = false;
 	bool _debug_view_vertex_grid = false;
+	bool _debug_view_instancer_grid = false;
 
 	// Functions
 	void _preload_shaders();
@@ -139,6 +140,8 @@ public:
 	bool get_show_region_grid() const { return _debug_view_region_grid; }
 	void set_show_vertex_grid(const bool p_enabled);
 	bool get_show_vertex_grid() const { return _debug_view_vertex_grid; }
+	void set_show_instancer_grid(const bool p_enabled);
+	bool get_show_instancer_grid() const { return _debug_view_instancer_grid; }
 
 	Error save(const String &p_path = "");
 

--- a/src/terrain_3d_mesh_asset.h
+++ b/src/terrain_3d_mesh_asset.h
@@ -29,6 +29,8 @@ public:
 private:
 	// Saved data
 	real_t _height_offset = 0.f;
+	real_t _visibility_range = 1024.f;
+	real_t _visibility_margin = 0.f;
 	GeometryInstance3D::ShadowCastingSetting _cast_shadows = GeometryInstance3D::SHADOW_CASTING_SETTING_ON;
 	GenType _generated_type = TYPE_NONE;
 	int _generated_faces = 2;
@@ -65,6 +67,10 @@ public:
 	void set_density(const real_t p_density);
 	real_t get_density() const;
 
+	void set_visibility_range(const real_t p_visibility_range);
+	real_t get_visibility_range() const { return _visibility_range; };
+	void set_visibility_margin(const real_t p_visibility_margin);
+	real_t get_visibility_margin() const { return _visibility_margin; };
 	void set_cast_shadows(const GeometryInstance3D::ShadowCastingSetting p_cast_shadows);
 	GeometryInstance3D::ShadowCastingSetting get_cast_shadows() const { return _cast_shadows; };
 

--- a/src/terrain_3d_region.cpp
+++ b/src/terrain_3d_region.cpp
@@ -262,7 +262,7 @@ void Terrain3DRegion::set_data(const Dictionary &p_data) {
 	SET_IF_HAS(_height_map, "height_map");
 	SET_IF_HAS(_control_map, "control_map");
 	SET_IF_HAS(_color_map, "color_map");
-	SET_IF_HAS(_multimeshes, "multimeshes");
+	SET_IF_HAS(_instances, "instances");
 }
 
 Dictionary Terrain3DRegion::get_data() const {
@@ -279,7 +279,7 @@ Dictionary Terrain3DRegion::get_data() const {
 	dict["height_map"] = _height_map;
 	dict["control_map"] = _control_map;
 	dict["color_map"] = _color_map;
-	dict["multimeshes"] = _multimeshes;
+	dict["instances"] = _instances;
 	return dict;
 }
 
@@ -302,15 +302,7 @@ Ref<Terrain3DRegion> Terrain3DRegion::duplicate(const bool p_deep) {
 		dict["height_map"] = _height_map->duplicate();
 		dict["control_map"] = _control_map->duplicate();
 		dict["color_map"] = _color_map->duplicate();
-		Dictionary mms;
-		Array keys = _multimeshes.keys();
-		for (int i = 0; i < keys.size(); i++) {
-			int mesh_id = keys[i];
-			Ref<MultiMesh> mm = _multimeshes[mesh_id];
-			mm->duplicate();
-			mms[mesh_id] = mm;
-		}
-		dict["multimeshes"] = mms;
+		dict["instances"] = _instances.duplicate(true); // TODO test this
 		region->set_data(dict);
 	}
 	return region;

--- a/src/terrain_3d_region.cpp
+++ b/src/terrain_3d_region.cpp
@@ -313,6 +313,16 @@ Ref<Terrain3DRegion> Terrain3DRegion::duplicate(const bool p_deep) {
 	return region;
 }
 
+// DEPRECATED 0.9.3-dev - Remove 1.0
+void Terrain3DRegion::set_multimeshes(const Dictionary &p_multimeshes) {
+	// TODO
+	// This function will upgrade 0.9.3-dev users to _instances
+	// Drop _multimeshes
+	// Translate p_multimeshes into _instances
+	// Consider changing data format to 0.931
+	_multimeshes = p_multimeshes;
+}
+
 /////////////////////
 // Protected Functions
 /////////////////////
@@ -348,8 +358,8 @@ void Terrain3DRegion::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("update_heights", "low_high"), &Terrain3DRegion::update_heights);
 	ClassDB::bind_method(D_METHOD("calc_height_range"), &Terrain3DRegion::calc_height_range);
 
-	ClassDB::bind_method(D_METHOD("set_multimeshes", "multimeshes"), &Terrain3DRegion::set_multimeshes);
-	ClassDB::bind_method(D_METHOD("get_multimeshes"), &Terrain3DRegion::get_multimeshes);
+	ClassDB::bind_method(D_METHOD("set_instances", "instances"), &Terrain3DRegion::set_instances);
+	ClassDB::bind_method(D_METHOD("get_instances"), &Terrain3DRegion::get_instances);
 
 	ClassDB::bind_method(D_METHOD("save", "path", "16-bit"), &Terrain3DRegion::save, DEFVAL(""), DEFVAL(false));
 
@@ -373,11 +383,16 @@ void Terrain3DRegion::_bind_methods() {
 	ADD_PROPERTY(PropertyInfo(Variant::OBJECT, "height_map", PROPERTY_HINT_RESOURCE_TYPE, "Image", ro_flags), "set_height_map", "get_height_map");
 	ADD_PROPERTY(PropertyInfo(Variant::OBJECT, "control_map", PROPERTY_HINT_RESOURCE_TYPE, "Image", ro_flags), "set_control_map", "get_control_map");
 	ADD_PROPERTY(PropertyInfo(Variant::OBJECT, "color_map", PROPERTY_HINT_RESOURCE_TYPE, "Image", ro_flags), "set_color_map", "get_color_map");
-	ADD_PROPERTY(PropertyInfo(Variant::DICTIONARY, "multimeshes", PROPERTY_HINT_NONE, "", ro_flags), "set_multimeshes", "get_multimeshes");
+	ADD_PROPERTY(PropertyInfo(Variant::DICTIONARY, "instances", PROPERTY_HINT_NONE, "", ro_flags), "set_instances", "get_instances");
 
 	// Double-clicking a region .res file shows what's on disk, the defaults, not in memory. So these are hidden
 	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "edited", PROPERTY_HINT_NONE, "", PROPERTY_USAGE_NONE), "set_edited", "is_edited");
 	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "deleted", PROPERTY_HINT_NONE, "", PROPERTY_USAGE_NONE), "set_deleted", "is_deleted");
 	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "modified", PROPERTY_HINT_NONE, "", PROPERTY_USAGE_NONE), "set_modified", "is_modified");
 	ADD_PROPERTY(PropertyInfo(Variant::VECTOR2I, "location", PROPERTY_HINT_NONE, "", PROPERTY_USAGE_NONE), "set_location", "get_location");
+
+	// DEPRECATED 0.9.3-dev - Remove 1.0
+	ClassDB::bind_method(D_METHOD("set_multimeshes", "multimeshes"), &Terrain3DRegion::set_multimeshes);
+	ClassDB::bind_method(D_METHOD("get_multimeshes"), &Terrain3DRegion::get_multimeshes);
+	ADD_PROPERTY(PropertyInfo(Variant::DICTIONARY, "multimeshes", PROPERTY_HINT_NONE, "", ro_flags), "set_multimeshes", "get_multimeshes");
 }

--- a/src/terrain_3d_region.cpp
+++ b/src/terrain_3d_region.cpp
@@ -271,7 +271,6 @@ Dictionary Terrain3DRegion::get_data() const {
 	dict["deleted"] = _deleted;
 	dict["edited"] = _edited;
 	dict["modified"] = _modified;
-	dict["instance_id"] = String::num_uint64(get_instance_id()); // don't commit
 	dict["version"] = _version;
 	dict["region_size"] = _region_size;
 	dict["vertex_spacing"] = _vertex_spacing;
@@ -302,7 +301,7 @@ Ref<Terrain3DRegion> Terrain3DRegion::duplicate(const bool p_deep) {
 		dict["height_map"] = _height_map->duplicate();
 		dict["control_map"] = _control_map->duplicate();
 		dict["color_map"] = _color_map->duplicate();
-		dict["instances"] = _instances.duplicate(true); // TODO test this
+		dict["instances"] = _instances.duplicate(true);
 		region->set_data(dict);
 	}
 	return region;

--- a/src/terrain_3d_region.cpp
+++ b/src/terrain_3d_region.cpp
@@ -309,11 +309,6 @@ Ref<Terrain3DRegion> Terrain3DRegion::duplicate(const bool p_deep) {
 
 // DEPRECATED 0.9.3-dev - Remove 1.0
 void Terrain3DRegion::set_multimeshes(const Dictionary &p_multimeshes) {
-	// TODO
-	// This function will upgrade 0.9.3-dev users to _instances
-	// Drop _multimeshes
-	// Translate p_multimeshes into _instances
-	// Consider changing data format to 0.931
 	_multimeshes = p_multimeshes;
 }
 

--- a/src/terrain_3d_region.cpp
+++ b/src/terrain_3d_region.cpp
@@ -257,6 +257,7 @@ void Terrain3DRegion::set_data(const Dictionary &p_data) {
 	SET_IF_HAS(_modified, "modified");
 	SET_IF_HAS(_version, "version");
 	SET_IF_HAS(_region_size, "region_size");
+	SET_IF_HAS(_vertex_spacing, "vertex_spacing");
 	SET_IF_HAS(_height_range, "height_range");
 	SET_IF_HAS(_height_map, "height_map");
 	SET_IF_HAS(_control_map, "control_map");
@@ -273,6 +274,7 @@ Dictionary Terrain3DRegion::get_data() const {
 	dict["instance_id"] = String::num_uint64(get_instance_id()); // don't commit
 	dict["version"] = _version;
 	dict["region_size"] = _region_size;
+	dict["vertex_spacing"] = _vertex_spacing;
 	dict["height_range"] = _height_range;
 	dict["height_map"] = _height_map;
 	dict["control_map"] = _control_map;
@@ -291,6 +293,7 @@ Ref<Terrain3DRegion> Terrain3DRegion::duplicate(const bool p_deep) {
 		// Native type copies
 		dict["version"] = _version;
 		dict["region_size"] = _region_size;
+		dict["vertex_spacing"] = _vertex_spacing;
 		dict["height_range"] = _height_range;
 		dict["modified"] = _modified;
 		dict["deleted"] = _deleted;
@@ -337,6 +340,8 @@ void Terrain3DRegion::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("get_version"), &Terrain3DRegion::get_version);
 	ClassDB::bind_method(D_METHOD("set_region_size", "region_size"), &Terrain3DRegion::set_region_size);
 	ClassDB::bind_method(D_METHOD("get_region_size"), &Terrain3DRegion::get_region_size);
+	ClassDB::bind_method(D_METHOD("set_vertex_spacing", "vertex_spacing"), &Terrain3DRegion::set_vertex_spacing);
+	ClassDB::bind_method(D_METHOD("get_vertex_spacing"), &Terrain3DRegion::get_vertex_spacing);
 
 	ClassDB::bind_method(D_METHOD("set_map", "map_type", "map"), &Terrain3DRegion::set_map);
 	ClassDB::bind_method(D_METHOD("get_map", "map_type"), &Terrain3DRegion::get_map);
@@ -379,6 +384,7 @@ void Terrain3DRegion::_bind_methods() {
 	int ro_flags = PROPERTY_USAGE_STORAGE | PROPERTY_USAGE_EDITOR | PROPERTY_USAGE_READ_ONLY;
 	ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "version", PROPERTY_HINT_NONE, "", ro_flags), "set_version", "get_version");
 	ADD_PROPERTY(PropertyInfo(Variant::INT, "region_size", PROPERTY_HINT_NONE, "", ro_flags), "set_region_size", "get_region_size");
+	ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "vertex_spacing", PROPERTY_HINT_NONE, "", ro_flags), "set_vertex_spacing", "get_vertex_spacing");
 	ADD_PROPERTY(PropertyInfo(Variant::VECTOR2, "height_range", PROPERTY_HINT_NONE, "", ro_flags), "set_height_range", "get_height_range");
 	ADD_PROPERTY(PropertyInfo(Variant::OBJECT, "height_map", PROPERTY_HINT_RESOURCE_TYPE, "Image", ro_flags), "set_height_map", "get_height_map");
 	ADD_PROPERTY(PropertyInfo(Variant::OBJECT, "control_map", PROPERTY_HINT_RESOURCE_TYPE, "Image", ro_flags), "set_control_map", "get_control_map");

--- a/src/terrain_3d_region.h
+++ b/src/terrain_3d_region.h
@@ -51,13 +51,16 @@ private:
 	Ref<Image> _control_map;
 	Ref<Image> _color_map;
 	// Instancer
-	Dictionary _multimeshes; // Dictionary[mesh_id:int] -> MultiMesh
+	Dictionary _instances; // Dict{mesh_id:int} -> Location{v2i} -> [ Transform3D, Color ]
 
 	// Working data not saved to disk
 	bool _deleted = false; // Marked for deletion on save
 	bool _edited = false; // Marked for undo/redo storage
 	bool _modified = false; // Marked for saving
 	Vector2i _location = V2I_MAX;
+
+	// DEPRECATED 0.9.3-dev - Remove 1.0
+	Dictionary _multimeshes; // Dictionary[mesh_id:int] -> MultiMesh
 
 public:
 	Terrain3DRegion() {}
@@ -90,8 +93,8 @@ public:
 	void calc_height_range();
 
 	// Instancer
-	void set_multimeshes(const Dictionary &p_multimeshes) { _multimeshes = p_multimeshes; }
-	Dictionary get_multimeshes() const { return _multimeshes; }
+	void set_instances(const Dictionary &p_instances) { _instances = p_instances; }
+	Dictionary get_instances() const { return _instances; }
 
 	// File I/O
 	Error save(const String &p_path = "", const bool p_16_bit = false);
@@ -110,6 +113,11 @@ public:
 	void set_data(const Dictionary &p_data);
 	Dictionary get_data() const;
 	Ref<Terrain3DRegion> duplicate(const bool p_deep = false);
+
+	// DEPRECATED 0.9.3-dev - Remove 1.0
+	void set_multimeshes(const Dictionary &p_multimeshes);
+	// TODO Drop this
+	Dictionary get_multimeshes() const { return _multimeshes; }
 
 protected:
 	static void _bind_methods();

--- a/src/terrain_3d_region.h
+++ b/src/terrain_3d_region.h
@@ -52,6 +52,7 @@ private:
 	Ref<Image> _color_map;
 	// Instancer
 	Dictionary _instances; // Dict{mesh_id:int} -> Location{v2i} -> [ Transform3D, Color ]
+	real_t _vertex_spacing = 1.f; // Vertex Spacing value that transforms are currently scaled.
 
 	// Working data not saved to disk
 	bool _deleted = false; // Marked for deletion on save
@@ -95,6 +96,8 @@ public:
 	// Instancer
 	void set_instances(const Dictionary &p_instances) { _instances = p_instances; }
 	Dictionary get_instances() const { return _instances; }
+	void set_vertex_spacing(const real_t p_vertex_spacing) { _vertex_spacing = CLAMP(p_vertex_spacing, 0.25f, 10.f); }
+	real_t get_vertex_spacing() const { return _vertex_spacing; }
 
 	// File I/O
 	Error save(const String &p_path = "", const bool p_16_bit = false);

--- a/src/terrain_3d_region.h
+++ b/src/terrain_3d_region.h
@@ -51,7 +51,7 @@ private:
 	Ref<Image> _control_map;
 	Ref<Image> _color_map;
 	// Instancer
-	Dictionary _instances; // Meshes{int} -> Cells{v2i} -> [ Transform3D, Color ]
+	Dictionary _instances; // Meshes{int} -> Cells{v2i} -> [ Transform3D, Color, Modified ]
 	real_t _vertex_spacing = 1.f; // Vertex Spacing value that transforms are currently scaled.
 
 	// Working data not saved to disk

--- a/src/terrain_3d_region.h
+++ b/src/terrain_3d_region.h
@@ -51,7 +51,7 @@ private:
 	Ref<Image> _control_map;
 	Ref<Image> _color_map;
 	// Instancer
-	Dictionary _instances; // Dict{mesh_id:int} -> Location{v2i} -> [ Transform3D, Color ]
+	Dictionary _instances; // Meshes{int} -> Cells{v2i} -> [ Transform3D, Color ]
 	real_t _vertex_spacing = 1.f; // Vertex Spacing value that transforms are currently scaled.
 
 	// Working data not saved to disk

--- a/src/terrain_3d_region.h
+++ b/src/terrain_3d_region.h
@@ -119,7 +119,6 @@ public:
 
 	// DEPRECATED 0.9.3-dev - Remove 1.0
 	void set_multimeshes(const Dictionary &p_multimeshes);
-	// TODO Drop this
 	Dictionary get_multimeshes() const { return _multimeshes; }
 
 protected:

--- a/src/terrain_3d_region.h
+++ b/src/terrain_3d_region.h
@@ -96,7 +96,7 @@ public:
 	// Instancer
 	void set_instances(const Dictionary &p_instances) { _instances = p_instances; }
 	Dictionary get_instances() const { return _instances; }
-	void set_vertex_spacing(const real_t p_vertex_spacing) { _vertex_spacing = CLAMP(p_vertex_spacing, 0.25f, 10.f); }
+	void set_vertex_spacing(const real_t p_vertex_spacing) { _vertex_spacing = CLAMP(p_vertex_spacing, 0.25f, 100.f); }
 	real_t get_vertex_spacing() const { return _vertex_spacing; }
 
 	// File I/O

--- a/src/terrain_3d_util.cpp
+++ b/src/terrain_3d_util.cpp
@@ -77,24 +77,34 @@ void Terrain3DUtil::dump_maps(const TypedArray<Image> &p_maps, const String &p_n
 
 // Expects a filename in a String like: "terrain3d-01_02.res" which returns (-1, 2)
 Vector2i Terrain3DUtil::filename_to_location(const String &p_filename) {
-	String working_string = p_filename.trim_suffix(".res");
-	String y_str = working_string.right(3).replace("_", "");
-	working_string = working_string.erase(working_string.length() - 3, 3);
-	String x_str = working_string.right(3).replace("_", "");
+	String location_string = p_filename.trim_prefix("terrain3d").trim_suffix(".res");
+	return string_to_location(location_string);
+}
+
+// Expects a string formatted as: "±##±##" which returns (##,##)
+Vector2i Terrain3DUtil::string_to_location(const String &p_string) {
+	String x_str = p_string.left(3).replace("_", "");
+	String y_str = p_string.right(3).replace("_", "");
 	if (!x_str.is_valid_int() || !y_str.is_valid_int()) {
-		LOG(ERROR, "Malformed filename at ", p_filename, ": got x ", x_str, " y ", y_str);
+		LOG(ERROR, "Malformed string '", p_string, "'. Result: ", x_str, ", ", y_str);
 		return V2I_MAX;
 	}
 	return Vector2i(x_str.to_int(), y_str.to_int());
 }
 
+// Expects a v2i(-1,2) and returns terrain3d-01_02.res
 String Terrain3DUtil::location_to_filename(const Vector2i &p_region_loc) {
+	return "terrain3d" + location_to_string(p_region_loc) + ".res";
+}
+
+// Expects a v2i(-1,2) and returns -01_02
+String Terrain3DUtil::location_to_string(const Vector2i &p_region_loc) {
 	const String POS_REGION_FORMAT = "_%02d";
 	const String NEG_REGION_FORMAT = "%03d";
 	String x_str, y_str;
 	x_str = vformat((p_region_loc.x >= 0) ? POS_REGION_FORMAT : NEG_REGION_FORMAT, p_region_loc.x);
 	y_str = vformat((p_region_loc.y >= 0) ? POS_REGION_FORMAT : NEG_REGION_FORMAT, p_region_loc.y);
-	return "terrain3d" + x_str + y_str + ".res";
+	return x_str + y_str;
 }
 
 Ref<Image> Terrain3DUtil::black_to_alpha(const Ref<Image> &p_image) {

--- a/src/terrain_3d_util.cpp
+++ b/src/terrain_3d_util.cpp
@@ -43,11 +43,11 @@ void Terrain3DUtil::print_dict(const String &p_name, const Dictionary &p_dict, c
 		Variant var = p_dict[keys[i]];
 		switch (var.get_type()) {
 			case Variant::ARRAY: {
-				print_arr(p_name + String::num_int64(i), var, p_level);
+				print_arr(String(keys[i]), var, p_level);
 				break;
 			}
 			case Variant::DICTIONARY: {
-				print_dict(p_name + String::num_int64(i), var, p_level);
+				print_dict(String(keys[i]), var, p_level);
 				break;
 			}
 			case Variant::OBJECT: {

--- a/src/terrain_3d_util.h
+++ b/src/terrain_3d_util.h
@@ -29,7 +29,9 @@ public:
 
 	// String functions
 	static Vector2i filename_to_location(const String &p_filename);
+	static Vector2i string_to_location(const String &p_string);
 	static String location_to_filename(const Vector2i &p_region_loc);
+	static String location_to_string(const Vector2i &p_region_loc);
 
 	// Image operations
 	static Ref<Image> black_to_alpha(const Ref<Image> &p_image);
@@ -59,15 +61,6 @@ typedef Terrain3DUtil Util;
 ///////////////////////////
 // Math
 ///////////////////////////
-
-// Rounds a decimal to the nearest multiple eg round_multiple(2.7, 4) -> 4
-template <typename T>
-T round_multiple(const T p_value, const T p_multiple) {
-	if (p_multiple == 0) {
-		return p_value;
-	}
-	return static_cast<T>(std::round(static_cast<double>(p_value) / static_cast<double>(p_multiple)) * static_cast<double>(p_multiple));
-}
 
 inline bool is_power_of_2(const int p_n) {
 	return p_n && !(p_n & (p_n - 1));


### PR DESCRIPTION
Fixes #479 

Implements region localised storage of instancer transforms.

See discussion
https://github.com/TokisanGames/Terrain3D/discussions/524

- [x] 1. Embed vertex_spacing in transforms, relative to local region.
Add vertex_spacing to Terrain3DRegion.
Only change vertex_spacing of transforms on load/set_vs().

- [x] 2. Split MM data down to 32x32 storage
append_location -> append_region -> append_cell -> storage in 32x32

- [x] 3. Change MM/MMI generation off of new data structure

- [x] 4. Add region container in tree / instancer

- [x] 5. Support changing region size

- [x] 6. Upgrade old data from 0.9.2 and 0.9.3

Bug squash and misc:
- [x] Hand removing instances doesn't fully delete regions from tree.
- [x] Update transforms isn't accurate at 0.5 vertex spacing.
- [x] Changing region size twice (1024-512-1024) broken.
- [x] Remove_instances operates much faster than add_instances now - should be same speed, and not "blocky".
- [x] Naming convention as per https://github.com/TokisanGames/Terrain3D/pull/523#discussion_r1802691896
- [x] Expose visibility distance for each mesh asset
- [x] Fix visibility ranges on MMIs
- [x] Dictionary issues, test std::unordered_map
- [x] Crash changing vertex spacing
- [x] Removal slope filter being smaller than the add slope filter is an annoyance
- [x] Swap_ids() and other functions haven't been touched yet (comment out region::get_multimeshes() to reveal all)
- [x] Remove_instances: Crash in w/ remove_all
- [x] Remove instances: remove not completely filtered by mesh_id
- [x] Remove instances: warning - not erasing _instances[mesh_id]
- [x] Crashes on close pretty frequently, after backup_region() runs. Potentially corrupts data
- [x] Transfer data buffers directly into Multimesh rather than per instance - unnecessary set_buffer has a memcpy
- [x] Remove_instances: Sparse removal of instances shows the cell grid
