### PR TITLE
Improve spray condition check

### DIFF
--- a/project/addons/terrain_3d/src/ui.gd
+++ b/project/addons/terrain_3d/src/ui.gd
@@ -15,8 +15,8 @@ const COLOR_LIFT := Color.ORANGE
 const COLOR_FLATTEN := Color.BLUE_VIOLET
 const COLOR_HEIGHT := Color(0., 0.32, .4)
 const COLOR_SLOPE := Color.YELLOW
-const COLOR_PAINT := Color.FOREST_GREEN
-const COLOR_SPRAY := Color.SEA_GREEN
+const COLOR_PAINT := Color.DARK_GREEN
+const COLOR_SPRAY := Color.PALE_GREEN
 const COLOR_ROUGHNESS := Color.ROYAL_BLUE
 const COLOR_AUTOSHADER := Color.DODGER_BLUE
 const COLOR_HOLES := Color.BLACK
@@ -369,6 +369,9 @@ func update_decal() -> void:
 					Terrain3DEditor.REPLACE:
 						decal.modulate = COLOR_PAINT
 						decal.modulate.a = .7
+					Terrain3DEditor.SUBTRACT:
+						decal.modulate = COLOR_PAINT
+						decal.modulate.a = clamp(brush_data["strength"], .2, .5)
 					Terrain3DEditor.ADD:
 						decal.modulate = COLOR_SPRAY
 						decal.modulate.a = clamp(brush_data["strength"], .2, .5)


### PR DESCRIPTION
_Admin edit: Cherry-pick 0.9.3_


fixes use case of spraying onto freshly painted base texture, by overrwiting overlay texture when it is not visible (less than 0.5 blend)

still some undesireable edge cases can occur when intentionally "making a mess" with lots of different textures sprayed in close proximity but its not really avoidable, since these conditions are attempting to emulate the feel of using a spatmap with many channels, with the just the 2 in the index map.

Also added ~~alt~~ CTRL key modifier to invert the blend direction, which is handy for quickly un-spraying any over-shoot, also prevents any new ID changes on the control map during this so that it explicitly only effects the blend value.

modified the tool colors slightly, SEA_GREEN and FOREST_GREEN were not visually distinct to me