### PR TITLE
Small fix to terrain_3d_objects.gd

### DIFF
--- a/project/addons/terrain_3d/utils/terrain_3d_objects.gd
+++ b/project/addons/terrain_3d/utils/terrain_3d_objects.gd
@@ -97,7 +97,8 @@ func _on_child_exiting_tree(p_node: Node) -> void:
 	
 	var helper: TransformChangedNotifier = p_node.get_node_or_null(CHILD_HELPER_PATH)
 	if helper:
-		helper.transform_changed.disconnect(_on_child_transform_changed)
+		if helper.transform_changed.is_connected(_on_child_transform_changed):
+			helper.transform_changed.disconnect(_on_child_transform_changed)
 		p_node.remove_child(helper)
 		helper.queue_free()
 	


### PR DESCRIPTION
Add signal connection check before attempting to disconnect. Attempting to disconnect a non-existent connection caused an error print to the console.