### PR TITLE
force decompress textures when building arrays in compatibility

### DIFF
--- a/doc/docs/platforms.md
+++ b/doc/docs/platforms.md
@@ -143,15 +143,15 @@ The Forward Vulkan Mobile renderer is fully supported in Terrain3D.
 
 The OpenGLES 3.0 Compatibility renderer is mostly supported from Terrain3D 0.9.3 though there are some caveats with Godot 4.3:
 
-* If using a custom override shader, we add a special COMPATIBILITY_DEFINES block to your shader that will allow certain features to work properly (eg the fma() function). We remove this block from your shader if you switch back to Mobile or Forward. It is normal to receive a shader dump in your console during this transition, but it should not repeat every start, once saved.
+* If using a custom override shader, we add a special COMPATIBILITY_DEFINES section to your shader that will allow certain features to work properly (eg the fma() function). We remove this block from your shader if you switch back to Mobile or Forward. It is normal to receive a shader dump in your console during this transition, but it should not repeat every start, once saved.
 
-* `IS_COMPATIBILITY` is defined in this block should you wish to check against it with your own custom preprocessor statements.
+* `IS_COMPATIBILITY` is defined in this section should you wish to check against it with your own custom preprocessor statements.
 
 * If enabling compatibility mode on the command line, we cannot detect that currently. You can tell Terrain3D with a special parameter:
 
     `Godot_v4.3-stable_win64_console.exe --rendering-driver opengl3 -e project.godot --terrain3d-renderer=compatibility`
 
-* `VRAM Compressed` is only partially supported. You can use 2 textures in the asset list. If a third is added, Godot will crash. It seems to be fixed in 4.4. The workaround for now is to select `VRAM Uncompressed` or `Lossless` on the Import tab and reimport for all of your textures.
+* Textures that are imported with `VRAM Compressed` are forced uncompressed and a warning issued. You can disable the warning by manually selecting `VRAM Uncompressed` or `Lossless` on the Import tab and reimport for all of your textures. Compression seems to be fixed in 4.4.
  
 Further reading:
 

--- a/src/terrain_3d_assets.cpp
+++ b/src/terrain_3d_assets.cpp
@@ -155,6 +155,7 @@ void Terrain3DAssets::_set_asset(const AssetType p_type, const int p_id, const R
 }
 
 void Terrain3DAssets::_update_texture_files() {
+	IS_INIT(VOID);
 	LOG(DEBUG, "Received texture_changed signal");
 	_generated_albedo_textures.clear();
 	_generated_normal_textures.clear();
@@ -173,6 +174,8 @@ void Terrain3DAssets::_update_texture_files() {
 	Image::Format normal_format = Image::FORMAT_MAX;
 	bool albedo_mipmaps = true;
 	bool normal_mipmaps = true;
+	//DEPRECATED 1.0 - remove in Godot 4.4
+	bool warn_compatibility_decompress = false;
 
 	for (int i = 0; i < _texture_list.size(); i++) {
 		Ref<Terrain3DTextureAsset> texture_set = _texture_list[i];
@@ -192,6 +195,11 @@ void Terrain3DAssets::_update_texture_files() {
 				return;
 			}
 			Ref<Image> img = albedo_tex->get_image();
+			//DEPRECATED 1.0 - remove in Godot 4.4
+			if (_terrain->is_compatibility_mode() && img->is_compressed()) {
+				warn_compatibility_decompress = true;
+				img->decompress();
+			}
 			Image::Format format = img->get_format();
 			if (albedo_format == Image::FORMAT_MAX) {
 				albedo_format = format;
@@ -210,6 +218,11 @@ void Terrain3DAssets::_update_texture_files() {
 				return;
 			}
 			Ref<Image> img = normal_tex->get_image();
+			//DEPRECATED 1.0 - remove in Godot 4.4
+			if (_terrain->is_compatibility_mode() && img->is_compressed()) {
+				warn_compatibility_decompress = true;
+				img->decompress();
+			}
 			Image::Format format = img->get_format();
 			if (normal_format == Image::FORMAT_MAX) {
 				normal_format = format;
@@ -250,6 +263,11 @@ void Terrain3DAssets::_update_texture_files() {
 				texture_set->_albedo_texture = ImageTexture::create_from_image(img);
 			} else {
 				img = tex->get_image();
+				//DEPRECATED 1.0 - remove in Godot 4.4
+				if (_terrain->is_compatibility_mode() && img->is_compressed()) {
+					warn_compatibility_decompress = true;
+					img->decompress();
+				}
 				LOG(DEBUG, "ID ", i, " albedo texture is valid. Format: ", img->get_format());
 			}
 			albedo_texture_array.push_back(img);
@@ -278,6 +296,11 @@ void Terrain3DAssets::_update_texture_files() {
 				texture_set->_normal_texture = ImageTexture::create_from_image(img);
 			} else {
 				img = tex->get_image();
+				//DEPRECATED 1.0 - remove in Godot 4.4
+				if (_terrain->is_compatibility_mode() && img->is_compressed()) {
+					warn_compatibility_decompress = true;
+					img->decompress();
+				}
 				LOG(DEBUG, "ID ", i, " Normal texture is valid. Format: ", img->get_format());
 			}
 			normal_texture_array.push_back(img);
@@ -286,7 +309,10 @@ void Terrain3DAssets::_update_texture_files() {
 			_generated_normal_textures.create(normal_texture_array);
 		}
 	}
-
+	//DEPRECATED 1.0 - remove in Godot 4.4
+	if (warn_compatibility_decompress == true) {
+		LOG(WARN, "Textures were decompressed for the Compatibility renderer. Decompress in the Import panel to remove this warning. See Supported Renderers doc.");
+	}
 	emit_signal("textures_changed");
 }
 


### PR DESCRIPTION
Fixes crashes, and removes the requirement to manually re-import textures for compatibility mode.

When the arrays are built, if in compatibility and the texture format is compressed, decompress before building the array that is sent to generated_texture.create()

Deprecated in 4.4 (hopefully)