### PR TITLE
Fix update_transforms issues

### DIFF
--- a/doc/api/class_terrain3dmeshasset.rst
+++ b/doc/api/class_terrain3dmeshasset.rst
@@ -36,7 +36,7 @@ Properties
    +-------------------------------------------------+-------------------------------------------------------------------------------+-------------------+
    | GeometryInstance3D.ShadowCastingSetting         | :ref:`cast_shadows<class_Terrain3DMeshAsset_property_cast_shadows>`           | ``1``             |
    +-------------------------------------------------+-------------------------------------------------------------------------------+-------------------+
-   | ``float``                                       | :ref:`density<class_Terrain3DMeshAsset_property_density>`                     | ``-1.0``          |
+   | ``float``                                       | :ref:`density<class_Terrain3DMeshAsset_property_density>`                     | ``10.0``          |
    +-------------------------------------------------+-------------------------------------------------------------------------------+-------------------+
    | ``int``                                         | :ref:`generated_faces<class_Terrain3DMeshAsset_property_generated_faces>`     | ``2``             |
    +-------------------------------------------------+-------------------------------------------------------------------------------+-------------------+
@@ -205,7 +205,7 @@ Tells the renderer how to cast shadows from this mesh asset onto the terrain and
 
 .. rst-class:: classref-property
 
-``float`` **density** = ``-1.0`` :ref:`🔗<class_Terrain3DMeshAsset_property_density>`
+``float`` **density** = ``10.0`` :ref:`🔗<class_Terrain3DMeshAsset_property_density>`
 
 .. rst-class:: classref-property-setget
 

--- a/doc/doc_classes/Terrain3DMeshAsset.xml
+++ b/doc/doc_classes/Terrain3DMeshAsset.xml
@@ -41,7 +41,7 @@
 		<member name="cast_shadows" type="int" setter="set_cast_shadows" getter="get_cast_shadows" enum="GeometryInstance3D.ShadowCastingSetting" default="1">
 			Tells the renderer how to cast shadows from this mesh asset onto the terrain and other objects. This sets [code skip-lint]GeometryInstance3D.cast_shadow[/code] on all MultiMeshInstances used by this mesh.
 		</member>
-		<member name="density" type="float" setter="set_density" getter="get_density" default="-1.0">
+		<member name="density" type="float" setter="set_density" getter="get_density" default="10.0">
 			Density is used to set the approximate default spacing between instances based on the size of the mesh. When painting meshes on the terrain, mesh density is multiplied by brush strength.
 			This value is not tied to any real world unit. It is calculated as [code skip-lint]10.f / mesh-&gt;get_aabb().get_volume()[/code], then clamped to a sane range. If the calculated amount is inappropriate, increase or decrease it here.
 		</member>

--- a/project/addons/terrain_3d/src/asset_dock.gd
+++ b/project/addons/terrain_3d/src/asset_dock.gd
@@ -792,8 +792,8 @@ class ListEntry extends VBoxContainer:
 				var ma := Terrain3DMeshAsset.new()
 				if resource is Terrain3DMeshAsset:
 					ma.id = resource.id
-				ma.set_scene_file(res)
 				set_edited_resource(ma, false)
+				ma.set_scene_file(res)
 				resource = ma
 			elif res is Terrain3DMeshAsset and type == Terrain3DAssets.TYPE_MESH:
 				if resource is Terrain3DMeshAsset:

--- a/src/terrain_3d.cpp
+++ b/src/terrain_3d.cpp
@@ -71,11 +71,6 @@ void Terrain3D::_initialize() {
 		LOG(DEBUG, "Connecting _data::height_maps_changed signal to update_aabbs()");
 		_data->connect("height_maps_changed", callable_mp(this, &Terrain3D::update_aabbs));
 	}
-	// Connect height changes to update instances
-	if (!_data->is_connected("maps_edited", callable_mp(_instancer, &Terrain3DInstancer::update_transforms))) {
-		LOG(DEBUG, "Connecting maps_edited signal to update_transforms()");
-		_data->connect("maps_edited", callable_mp(_instancer, &Terrain3DInstancer::update_transforms));
-	}
 	// Texture assets changed, update material
 	if (!_assets->is_connected("textures_changed", callable_mp(_material.ptr(), &Terrain3DMaterial::_update_texture_arrays))) {
 		LOG(DEBUG, "Connecting _assets.textures_changed to _material->_update_texture_arrays()");

--- a/src/terrain_3d_editor.cpp
+++ b/src/terrain_3d_editor.cpp
@@ -222,7 +222,7 @@ void Terrain3DEditor::_operate_map(const Vector3 &p_global_position, const real_
 			if (map_type == TYPE_HEIGHT) {
 				real_t srcf = src.r;
 				// In case data in existing map has nan or inf saved, check, and reset to real number if required.
-				srcf = std::isnan(srcf) || std::isnan(srcf) ? 0.f : srcf; 
+				srcf = std::isnan(srcf) || std::isnan(srcf) ? 0.f : srcf;
 				real_t destf = srcf;
 
 				switch (_operation) {
@@ -522,6 +522,10 @@ void Terrain3DEditor::_operate_map(const Vector3 &p_global_position, const real_
 		data->force_update_maps(map_type);
 	}
 	data->add_edited_area(edited_area);
+
+	if (_tool == HOLES || _tool == HEIGHT || _tool == SCULPT) {
+		_terrain->get_instancer()->update_transforms(edited_area);
+	}
 }
 
 void Terrain3DEditor::_store_undo() {

--- a/src/terrain_3d_instancer.cpp
+++ b/src/terrain_3d_instancer.cpp
@@ -760,8 +760,7 @@ void Terrain3DInstancer::update_transforms(const AABB &p_aabb) {
 	int region_size = _terrain->get_region_size();
 	real_t vertex_spacing = _terrain->get_vertex_spacing();
 
-	// Build list of potential regions to search, rather than searching the entire terrain, calculate possible regions covered
-	// and check if they are valid; if so add that location to the dictionary keys.
+	// Build list of valid regions within AABB; add the locations as dictionary keys.
 	Dictionary r_locs;
 	// Calculate step distance to ensure every region is checked inside the bounds of brush size.
 	Vector2 step = Vector2(size.x / ceil(size.x / real_t(region_size) / vertex_spacing), size.y / ceil(size.y / real_t(region_size) / vertex_spacing));
@@ -821,7 +820,7 @@ void Terrain3DInstancer::update_transforms(const AABB &p_aabb) {
 			if (cell_queue.size() == 0) {
 				continue;
 			}
-			Ref<Terrain3DMeshAsset> mesh_asset = _terrain->get_assets()->get_mesh_asset(m);
+			Ref<Terrain3DMeshAsset> mesh_asset = _terrain->get_assets()->get_mesh_asset(mesh_types[m]);
 			real_t mesh_height_offset = mesh_asset->get_height_offset();
 			for (int c = 0; c < cell_queue.size(); c++) {
 				Vector2i cell = cell_queue[c];

--- a/src/terrain_3d_mesh_asset.cpp
+++ b/src/terrain_3d_mesh_asset.cpp
@@ -26,10 +26,6 @@ void Terrain3DMeshAsset::_set_generated_type(const GenType p_type) {
 		LOG(DEBUG, "Generating card mesh");
 		_meshes.push_back(_get_generated_mesh());
 		_set_material_override(_get_material());
-		_height_offset = 0.5f;
-		_generated_faces = 2;
-		_relative_density = 10.f;
-		_calculated_density = 10.f;
 	}
 }
 
@@ -158,8 +154,7 @@ void Terrain3DMeshAsset::clear() {
 	_cast_shadows = GeometryInstance3D::SHADOW_CASTING_SETTING_ON;
 	_generated_faces = 2.f;
 	_generated_size = Vector2(1.f, 1.f);
-	_relative_density = -1.f;
-	_calculated_density = -1.f;
+	_density = 10.f;
 	_packed_scene.unref();
 	_material_override.unref();
 	_set_generated_type(TYPE_TEXTURE_CARD);
@@ -187,19 +182,7 @@ void Terrain3DMeshAsset::set_height_offset(const real_t p_offset) {
 
 void Terrain3DMeshAsset::set_density(const real_t p_density) {
 	LOG(INFO, "Setting mesh density: ", p_density);
-	if (p_density < 0) {
-		_relative_density = _calculated_density;
-	} else {
-		_relative_density = CLAMP(p_density, 0.01f, 10.f);
-	}
-}
-
-real_t Terrain3DMeshAsset::get_density() const {
-	if (_relative_density > 0) {
-		return _relative_density;
-	} else {
-		return _calculated_density;
-	}
+	_density = CLAMP(p_density, 0.01f, 10.f);
 }
 
 void Terrain3DMeshAsset::set_visibility_range(const real_t p_visibility_range) {
@@ -260,23 +243,25 @@ void Terrain3DMeshAsset::set_scene_file(const Ref<PackedScene> &p_scene_file) {
 		}
 		if (_meshes.size() > 0) {
 			Ref<Mesh> mesh = _meshes[0];
-			_calculated_density = CLAMP(10.f / mesh->get_aabb().get_volume(), 0.01f, 10.0f);
-			_relative_density = _calculated_density;
-			LOG(DEBUG, "Emitting file_changed");
-			emit_signal("file_changed");
+			_density = CLAMP(10.f / mesh->get_aabb().get_volume(), 0.01f, 10.0f);
 		} else {
 			LOG(ERROR, "No MeshInstance3D found in scene file");
 		}
 		notify_property_list_changed();
 	} else {
 		set_generated_type(TYPE_TEXTURE_CARD);
+		_density = 10.f;
 	}
+	LOG(DEBUG, "Emitting file_changed");
+	emit_signal("file_changed");
+	emit_signal("instancer_setting_changed");
 }
 
 void Terrain3DMeshAsset::set_material_override(const Ref<Material> &p_material) {
 	_set_material_override(p_material);
 	LOG(DEBUG, "Emitting setting_changed");
 	emit_signal("setting_changed");
+	emit_signal("instancer_setting_changed");
 }
 
 void Terrain3DMeshAsset::set_generated_type(const GenType p_type) {
@@ -284,6 +269,7 @@ void Terrain3DMeshAsset::set_generated_type(const GenType p_type) {
 	LOG(DEBUG, "Emitting file_changed");
 	notify_property_list_changed();
 	emit_signal("file_changed");
+	emit_signal("instancer_setting_changed");
 }
 
 void Terrain3DMeshAsset::set_generated_faces(const int p_count) {
@@ -295,6 +281,7 @@ void Terrain3DMeshAsset::set_generated_faces(const int p_count) {
 			_set_material_override(_get_material());
 			LOG(DEBUG, "Emitting setting_changed");
 			emit_signal("setting_changed");
+			emit_signal("instancer_setting_changed");
 		}
 	}
 }
@@ -308,6 +295,7 @@ void Terrain3DMeshAsset::set_generated_size(const Vector2 &p_size) {
 			_set_material_override(_get_material());
 			LOG(DEBUG, "Emitting setting_changed");
 			emit_signal("setting_changed");
+			emit_signal("instancer_setting_changed");
 		}
 	}
 }

--- a/src/terrain_3d_mesh_asset.h
+++ b/src/terrain_3d_mesh_asset.h
@@ -37,8 +37,7 @@ private:
 	Vector2 _generated_size = Vector2(1.f, 1.f);
 	Ref<PackedScene> _packed_scene;
 	Ref<Material> _material_override;
-	real_t _relative_density = -1.f;
-	real_t _calculated_density = -1.f;
+	real_t _density = 10.f;
 
 	// Working data
 	TypedArray<Mesh> _meshes;
@@ -65,7 +64,7 @@ public:
 	void set_height_offset(const real_t p_offset);
 	real_t get_height_offset() const { return _height_offset; }
 	void set_density(const real_t p_density);
-	real_t get_density() const;
+	real_t get_density() const { return _density; }
 
 	void set_visibility_range(const real_t p_visibility_range);
 	real_t get_visibility_range() const { return _visibility_range; };


### PR DESCRIPTION
Fixes #584 
Fixes #544

Issues addressed:
* Undo not reapplying manual offset when undoing (due to update_transforms being called on the undo)
* Update_transforms called on non-sculpting brushes
* Update_transforms affecting whole cell instead of only aabb 
* update_transforms uses wrong/old height offset after swaping IDs
* Mesh assets not retaining height offset setting and other settings across restarts of the engine

Not done:
* Retaining manually painted height offset - possible future update