### PR TITLE
Add config warnings for texture size/format/mipmap mismatch

### DIFF
--- a/src/constants.h
+++ b/src/constants.h
@@ -32,6 +32,12 @@ using namespace godot;
 #define V3_ZERO Vector3(0.f, 0.f, 0.f)
 #define V3_MAX Vector3(FLT_MAX, FLT_MAX, FLT_MAX)
 
+// Terrain3D::_warnings is uint8_t
+#define WARN_MISMATCHED_SIZE 0x01
+#define WARN_MISMATCHED_FORMAT 0x02
+#define WARN_MISMATCHED_MIPMAPS 0x04
+#define WARN_ALL 0xFF
+
 // Set class name for logger.h
 
 #define CLASS_NAME() const String __class__ = get_class_static() + \

--- a/src/terrain_3d.cpp
+++ b/src/terrain_3d.cpp
@@ -762,7 +762,9 @@ void Terrain3D::set_data_directory(String p_dir) {
 		_data_directory = p_dir;
 		_initialize();
 	}
+	update_configuration_warnings();
 }
+
 void Terrain3D::set_material(const Ref<Terrain3DMaterial> &p_material) {
 	if (_material != p_material) {
 		_clear_meshes();
@@ -1291,13 +1293,28 @@ PackedVector3Array Terrain3D::generate_nav_mesh_source_geometry(const AABB &p_gl
 	return faces;
 }
 
+void Terrain3D::set_warning(const uint8_t p_warning, const bool p_enabled) {
+	if (p_enabled) {
+		_warnings |= p_warning;
+	} else {
+		_warnings &= ~p_warning;
+	}
+	update_configuration_warnings();
+}
+
 PackedStringArray Terrain3D::_get_configuration_warnings() const {
 	PackedStringArray psa;
 	if (_data_directory.is_empty()) {
 		psa.push_back("No data directory specified. Select a directory then save the scene to write data.");
 	}
-	if (!psa.is_empty()) {
-		psa.push_back("To update this message, deselect and reselect Terrain3D in the Scene panel.");
+	if (_warnings & WARN_MISMATCHED_SIZE) {
+		psa.push_back("Texture dimensions don't match. Double-click a texture in the FileSystem panel to see its size. Read Texture Prep in docs.");
+	}
+	if (_warnings & WARN_MISMATCHED_FORMAT) {
+		psa.push_back("Texture formats don't match. Double-click a texture in the FileSystem panel to see its format. Check Import panel. Read Texture Prep in docs.");
+	}
+	if (_warnings & WARN_MISMATCHED_MIPMAPS) {
+		psa.push_back("Texture mipmap settings don't match. Change on the Import panel.");
 	}
 	return psa;
 }

--- a/src/terrain_3d.h
+++ b/src/terrain_3d.h
@@ -47,6 +47,7 @@ private:
 	String _data_directory;
 	bool _is_inside_world = false;
 	bool _initialized = false;
+	uint8_t _warnings = 0;
 
 	// Object references
 	Terrain3DData *_data = nullptr;
@@ -253,7 +254,9 @@ public:
 	Ref<Mesh> bake_mesh(const int p_lod, const Terrain3DData::HeightFilter p_filter = Terrain3DData::HEIGHT_FILTER_NEAREST) const;
 	PackedVector3Array generate_nav_mesh_source_geometry(const AABB &p_global_aabb, const bool p_require_nav = true) const;
 
-	// Godot Callbacks
+	// Warnings
+	void set_warning(const uint8_t p_warning, const bool p_enabled);
+	uint8_t get_warnings() const { return _warnings; }
 	PackedStringArray _get_configuration_warnings() const override;
 
 protected:

--- a/src/terrain_3d_texture_asset.cpp
+++ b/src/terrain_3d_texture_asset.cpp
@@ -66,9 +66,22 @@ void Terrain3DTextureAsset::set_albedo_texture(const Ref<Texture2D> &p_texture) 
 	LOG(INFO, "Setting albedo texture: ", p_texture);
 	if (_is_valid_format(p_texture)) {
 		_albedo_texture = p_texture;
-		if (p_texture.is_valid() && _name == "New Texture") {
-			_name = p_texture->get_path().get_file().get_basename();
-			LOG(INFO, "Naming texture based on filename: ", _name);
+		if (p_texture.is_valid()) {
+			String filename = p_texture->get_path().get_file().get_basename();
+			if (_name == "New Texture") {
+				_name = filename;
+				LOG(INFO, "Naming texture based on filename: ", _name);
+			}
+			Ref<Image> img = p_texture->get_image();
+			if (!img->has_mipmaps()) {
+				LOG(WARN, "Texture '", filename, "' has no mipmaps. Change on the Import panel if desired.");
+			}
+			if (img->get_width() != img->get_height()) {
+				LOG(WARN, "Texture '", filename, "' is not square. Mipmaps might have artifacts.");
+			}
+			if (!is_power_of_2(img->get_width()) || !is_power_of_2(img->get_height())) {
+				LOG(WARN, "Texture '", filename, "' size is not power of 2. This is sub-optimal.");
+			}
 		}
 		emit_signal("file_changed");
 	}
@@ -78,6 +91,19 @@ void Terrain3DTextureAsset::set_normal_texture(const Ref<Texture2D> &p_texture) 
 	LOG(INFO, "Setting normal texture: ", p_texture);
 	if (_is_valid_format(p_texture)) {
 		_normal_texture = p_texture;
+		if (p_texture.is_valid()) {
+			String filename = p_texture->get_path().get_file().get_basename();
+			Ref<Image> img = p_texture->get_image();
+			if (!img->has_mipmaps()) {
+				LOG(WARN, "Texture '", filename, "' has no mipmaps. Change on the Import panel if desired.");
+			}
+			if (img->get_width() != img->get_height()) {
+				LOG(WARN, "Texture '", filename, "' is not square. Not recommended. Mipmaps might have artifacts.");
+			}
+			if (!is_power_of_2(img->get_width()) || !is_power_of_2(img->get_height())) {
+				LOG(WARN, "Texture '", filename, "' dimensions are not power of 2. This is sub-optimal.");
+			}
+		}
 		emit_signal("file_changed");
 	}
 }


### PR DESCRIPTION
Fixes #542 

Add SceneTree (config) warnings for:
* Texture size mismatch
* Texture format mismatch
* Texture mipmap mismatch

Add console warnings for textures:
* No mipmaps
* Not square
* Not power of 2


@Xtarsia Would you review this please? Are there any config warnings we should add? 

Compatibility mode && albedo/normal is compressed is probably fine as a warning since it works and can be ignored. Config warnings is a nag screen, so should be considered "must dos".

