### PR TITLE
Update Terrain3DInstancer.xml to mention the slope parameter in method remove_instances

### DIFF
--- a/doc/api/class_terrain3dinstancer.rst
+++ b/doc/api/class_terrain3dinstancer.rst
@@ -234,7 +234,7 @@ Removes and rebuilds all MultiMeshInstance3Ds attached to the tree.
 
 |void| **remove_instances**\ (\ global_position\: ``Vector3``, params\: ``Dictionary``\ ) :ref:`🔗<class_Terrain3DInstancer_method_remove_instances>`
 
-Uses parameters asset_id, size, strength, fixed_scale, random_scale, to randomly remove instances within the indicated brush position and size.
+Uses parameters asset_id, size, strength, fixed_scale, random_scale, slope (Vector2), to randomly remove instances within the indicated brush position and size.
 
 .. rst-class:: classref-item-separator
 

--- a/doc/doc_classes/Terrain3DInstancer.xml
+++ b/doc/doc_classes/Terrain3DInstancer.xml
@@ -119,7 +119,7 @@
 			<param index="0" name="global_position" type="Vector3" />
 			<param index="1" name="params" type="Dictionary" />
 			<description>
-				Uses parameters asset_id, size, strength, fixed_scale, random_scale, to randomly remove instances within the indicated brush position and size.
+				Uses parameters asset_id, size, strength, fixed_scale, random_scale, slope (Vector2), to randomly remove instances within the indicated brush position and size.
 			</description>
 		</method>
 		<method name="swap_ids">

--- a/src/terrain_3d_editor.cpp
+++ b/src/terrain_3d_editor.cpp
@@ -691,7 +691,7 @@ void Terrain3DEditor::set_brush_data(const Dictionary &p_data) {
 	_brush_data["size"] = CLAMP(real_t(p_data.get("size", 10.f)), 0.1f, 4096.f); // Diameter in meters
 	_brush_data["strength"] = CLAMP(real_t(p_data.get("strength", .1f)) * .01f, .01f, 1000.f); // 1-100k% (max of 1000m per click)
 	// mouse_pressure injected in editor.gd and sanitized in _operate_map()
-	Vector2 slope = p_data.get("slope", V2_ZERO);
+	Vector2 slope = p_data.get("slope", Vector2(0.f, 90.f));
 	slope.x = CLAMP(slope.x, 0.f, 90.f);
 	slope.y = CLAMP(slope.y, 0.f, 90.f);
 	_brush_data["slope"] = slope; // 0-90 (degrees)


### PR DESCRIPTION
By default the slope dictionary argument is Vector2(0, 0), meaning any mesh on a slope won't be affected.
Since slope isn't mentioned in the documentation, this can become a hard to solve issue when you don't understand why some or your meshes don't get removed.
There are two other arguments taken from the dictionary but not mentioned in the doc: modifier_shift and modifier_alt, but I don't really understand what they do so I didn't add them to the doc.