### PR TITLE
Fix triangle pairs to generate edges for ArrayMesh, Navigation

### DIFF
--- a/project/demo/data/assets.tres
+++ b/project/demo/data/assets.tres
@@ -19,6 +19,7 @@ distance_fade_max_distance = 96.0
 [sub_resource type="Terrain3DMeshAsset" id="Terrain3DMeshAsset_2qf8x"]
 name = "TextureCard"
 generated_type = 1
+height_offset = 0.5
 material_override = SubResource("StandardMaterial3D_b2vqk")
 last_lod = 0
 last_shadow_lod = 0
@@ -29,6 +30,7 @@ visibility_range = 128.0
 name = "LODExample"
 id = 1
 scene_file = ExtResource("1_4jrdu")
+height_offset = 0.5
 last_lod = 3
 last_shadow_lod = 3
 

--- a/project/demo/src/Enemy.gd
+++ b/project/demo/src/Enemy.gd
@@ -47,7 +47,9 @@ func _physics_process(p_delta: float) -> void:
 
 	# Ensure enemy doesn't fall through terrain when collision absent
 	if get_parent().terrain:
-		global_position.y = maxf(global_position.y, get_parent().terrain.data.get_height(global_position))
+		var height: float = get_parent().terrain.data.get_height(global_position)
+		if not is_nan(height):
+			global_position.y = maxf(global_position.y, height)
 
 
 func _on_velocity_computed(p_safe_velocity: Vector3) -> void:

--- a/src/shaders/editor_functions.glsl
+++ b/src/shaders/editor_functions.glsl
@@ -5,7 +5,7 @@
 R"(
 //INSERT: EDITOR_NAVIGATION
 	// Show navigation
-	if(bool(texelFetch(_control_maps, get_region_uv(floor(uv), SKIP_PASS), 0).r >>1u & 0x1u)) {
+	if(bool(texelFetch(_control_maps, get_region_uv(floor(uv + 0.5), SKIP_PASS), 0).r >>1u & 0x1u)) {
 		ALBEDO *= vec3(.5, .0, .85);
 	}
 


### PR DESCRIPTION
Admin edit
* Fixes #597 extending triangle pair generation into the region edge, but not into holes. 
* Fixes navigation region edges and arraymesh edges
* Reduces lookups by 2/3rds, increasing speed by 33%.
* Related to #451

----

fixes #597 by adding a 0.5 offset to the uv when doing the control_map lookup.

Edit: And generating triangle for nav mesh if any vertex point has nav enabled.

![image](https://github.com/user-attachments/assets/32878a9b-3ffa-42fa-bd56-da071cacbf11)
