### PR TITLE
fix region edge behaviour

### DIFF
--- a/project/demo/CodeGeneratedDemo.tscn
+++ b/project/demo/CodeGeneratedDemo.tscn
@@ -18,10 +18,10 @@ script = ExtResource("1_h7vyv")
 [node name="Environment" parent="." instance=ExtResource("3_71ikj")]
 
 [node name="Player" parent="." instance=ExtResource("2_3v2uf")]
-transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 0, 200, 0)
+transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 0, 50, 0)
 
 [node name="Enemy" parent="." node_paths=PackedStringArray("target") instance=ExtResource("4_p8qry")]
-transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 10, 200, -10)
+transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 10, 50, -10)
 target = NodePath("../Player")
 
 [node name="UI" parent="." instance=ExtResource("4_x5ge4")]

--- a/project/demo/src/CodeGenerated.gd
+++ b/project/demo/src/CodeGenerated.gd
@@ -52,7 +52,7 @@ func create_terrain() -> Terrain3D:
 	var img: Image = Image.create_empty(2048, 2048, false, Image.FORMAT_RF)
 	for x in img.get_width():
 		for y in img.get_height():
-			img.set_pixel(x, y, Color(noise.get_noise_2d(x, y) + 1., 0., 0., 1.))
+			img.set_pixel(x, y, Color(noise.get_noise_2d(x, y), 0., 0., 1.))
 	terrain.region_size = 1024
 	terrain.data.import_images([img, null, null], Vector3(-1024, 0, -1024), 0.0, 150.0)
 

--- a/src/shaders/debug_views.glsl
+++ b/src/shaders/debug_views.glsl
@@ -89,7 +89,7 @@ R"(
 	NORMAL_MAP = vec3(0.5, 0.5, 1.0);
 
 //INSERT: DEBUG_CONTROL_ANGLE
-	ivec3 __auv = get_region_uv(floor(uv));
+	ivec3 __auv = get_region_uv(floor(uv), SKIP_PASS);
 	uint __a_control = texelFetch(_control_maps, __auv, 0).r;
 	uint __angle = (__a_control >>10u & 0xFu);
 	vec3 __a_colors[16] = {
@@ -104,7 +104,7 @@ R"(
 	NORMAL_MAP = vec3(0.5, 0.5, 1.0);
 
 //INSERT: DEBUG_CONTROL_SCALE
-	ivec3 __suv = get_region_uv(floor(uv));
+	ivec3 __suv = get_region_uv(floor(uv), SKIP_PASS);
 	uint __s_control = texelFetch(_control_maps, __suv, 0).r;
 	uint __scale = (__s_control >>7u & 0x7u);
 	vec3 __s_colors[8] = {
@@ -125,7 +125,7 @@ R"(
 	NORMAL_MAP = vec3(0.5, 0.5, 1.0);
 
 //INSERT: DEBUG_AUTOSHADER
-	ivec3 __ruv = get_region_uv(floor(uv));
+	ivec3 __ruv = get_region_uv(floor(uv), SKIP_PASS);
 	uint __control = texelFetch(_control_maps, __ruv, 0).r;
 	float __autoshader = float( bool(__control & 0x1u) || __ruv.z<0 );
 	ALBEDO = vec3(__autoshader);

--- a/src/shaders/editor_functions.glsl
+++ b/src/shaders/editor_functions.glsl
@@ -5,7 +5,7 @@
 R"(
 //INSERT: EDITOR_NAVIGATION
 	// Show navigation
-	if(bool(texelFetch(_control_maps, get_region_uv(floor(uv)), 0).r >>1u & 0x1u)) {
+	if(bool(texelFetch(_control_maps, get_region_uv(floor(uv), SKIP_PASS), 0).r >>1u & 0x1u)) {
 		ALBEDO *= vec3(.5, .0, .85);
 	}
 

--- a/src/terrain_3d.cpp
+++ b/src/terrain_3d.cpp
@@ -268,19 +268,19 @@ void Terrain3D::_update_collision() {
 					if (map_x.is_valid()) {
 						map_data[index] = (is_hole(cmap_x->get_pixel(0, z).r)) ? NAN : map_x->get_pixel(0, z).r;
 					} else {
-						map_data[index] = 0.0f;
+						map_data[index] = (is_hole(cmap->get_pixel(x - 1, z).r)) ? NAN : map->get_pixel(x - 1, z).r;
 					}
 				} else if (z == _region_size && x < _region_size) {
 					if (map_z.is_valid()) {
 						map_data[index] = (is_hole(cmap_z->get_pixel(x, 0).r)) ? NAN : map_z->get_pixel(x, 0).r;
 					} else {
-						map_data[index] = 0.0f;
+						map_data[index] = (is_hole(cmap->get_pixel(x, z - 1).r)) ? NAN : map->get_pixel(x, z - 1).r;
 					}
 				} else if (x == _region_size && z == _region_size) {
 					if (map_xz.is_valid()) {
 						map_data[index] = (is_hole(cmap_xz->get_pixel(0, 0).r)) ? NAN : map_xz->get_pixel(0, 0).r;
 					} else {
-						map_data[index] = 0.0f;
+						map_data[index] = (is_hole(cmap->get_pixel(x - 1, z - 1).r)) ? NAN : map->get_pixel(x - 1, z - 1).r;
 					}
 				}
 			}

--- a/src/terrain_3d_editor.cpp
+++ b/src/terrain_3d_editor.cpp
@@ -259,21 +259,22 @@ void Terrain3DEditor::_operate_map(const Vector3 &p_global_position, const real_
 						Vector3 right_position = brush_global_position + Vector3(vertex_spacing, 0.f, 0.f);
 						Vector3 down_position = brush_global_position - Vector3(0.f, 0.f, vertex_spacing);
 						Vector3 up_position = brush_global_position + Vector3(0.f, 0.f, vertex_spacing);
+						real_t bg_srcf_zero = _terrain->get_material()->get_world_background() == 0u ? srcf : 0.0;
 						real_t left = data->get_pixel(map_type, left_position).r;
 						if (std::isnan(left)) {
-							left = 0.f;
+							left = bg_srcf_zero;
 						}
 						real_t right = data->get_pixel(map_type, right_position).r;
 						if (std::isnan(right)) {
-							right = 0.f;
+							right = bg_srcf_zero;
 						}
 						real_t up = data->get_pixel(map_type, up_position).r;
 						if (std::isnan(up)) {
-							up = 0.f;
+							up = bg_srcf_zero;
 						}
 						real_t down = data->get_pixel(map_type, down_position).r;
 						if (std::isnan(down)) {
-							down = 0.f;
+							down = bg_srcf_zero;
 						}
 						real_t avg = (srcf + left + right + up + down) * 0.2f;
 						destf = Math::lerp(srcf, avg, CLAMP(brush_alpha * strength * 2.f, .02f, 1.f));


### PR DESCRIPTION
When background mode is none, get_region_uv() will return the +xz edges from 1 or 2 additional region_texels into empty regions to provide filler data for bridging vertices, and normal calculations.

Set NAN instead of 0.0 when collision reads from edge data if adjacent regions are empty

Average sculpt duplicates source entry for average instead of 0.0 at offsets along edges of regions for more intuitive bahvaior.

![image](https://github.com/user-attachments/assets/881d3168-c7e1-4d8f-9269-dfe6f7b59590)
