### PR TITLE
[4.4] Fix Physics Interpolation

### DIFF
--- a/src/terrain_3d.cpp
+++ b/src/terrain_3d.cpp
@@ -103,7 +103,7 @@ void Terrain3D::_initialize() {
  * This is a proxy for _process(delta) called by _notification() due to
  * https://github.com/godotengine/godot-cpp/issues/1022
  */
-void Terrain3D::__process(const double p_delta) {
+void Terrain3D::__physics_process(const double p_delta) {
 	if (!_initialized)
 		return;
 
@@ -140,7 +140,7 @@ void Terrain3D::_grab_camera() {
 		_camera_instance_id = _camera->get_instance_id();
 	} else {
 		_camera_instance_id = 0;
-		set_process(false); // disable snapping
+		set_physics_process(false); // disable snapping
 		LOG(ERROR, "Cannot find the active camera. Set it manually with Terrain3D.set_camera(). Stopping _process()");
 	}
 }
@@ -634,7 +634,7 @@ void Terrain3D::set_camera(Camera3D *p_camera) {
 			_camera_instance_id = _camera->get_instance_id();
 			LOG(DEBUG, "Setting camera: ", _camera);
 			_initialize();
-			set_process(true); // enable __process snapping
+			set_physics_process(true); // enable snapping
 		}
 	}
 }
@@ -1115,7 +1115,7 @@ void Terrain3D::_notification(const int p_what) {
 			set_meta("_edit_lock_", true);
 			_setup_mouse_picking();
 			_initialize(); // Rebuild anything freed: meshes, collision, instancer
-			set_process(true);
+			set_physics_process(true);
 			break;
 		}
 
@@ -1127,9 +1127,9 @@ void Terrain3D::_notification(const int p_what) {
 
 			/// Game Loop notifications
 
-		case NOTIFICATION_PROCESS: {
-			// Node is processing one frame
-			__process(get_process_delta_time());
+		case NOTIFICATION_PHYSICS_PROCESS: {
+			// Node is processing one physics frame
+			__physics_process(get_process_delta_time());
 			break;
 		}
 
@@ -1195,7 +1195,7 @@ void Terrain3D::_notification(const int p_what) {
 			// Node is about to exit a SceneTree
 			// Sent on scene changes
 			LOG(INFO, "NOTIFICATION_EXIT_TREE");
-			set_process(false);
+			set_physics_process(false);
 			_clear_meshes();
 			_destroy_mouse_picking();
 			break;

--- a/src/terrain_3d.cpp
+++ b/src/terrain_3d.cpp
@@ -16,6 +16,7 @@
 #include <godot_cpp/classes/viewport.hpp>
 #include <godot_cpp/classes/viewport_texture.hpp>
 #include <godot_cpp/classes/world3d.hpp>
+#include <godot_cpp/core/version.hpp>
 
 #include "geoclipmap.h"
 #include "logger.h"
@@ -803,6 +804,9 @@ void Terrain3D::snap(const Vector3 &p_cam_pos) {
 	Transform3D scaled_t = Transform3D().scaled(Vector3(_vertex_spacing, 1.f, _vertex_spacing));
 	scaled_t.origin = _snapped_position;
 	RS->instance_set_transform(_mesh_data.cross, scaled_t);
+#if GODOT_VERSION_MAJOR == 4 && GODOT_VERSION_MINOR == 4
+	RS->instance_reset_physics_interpolation(_mesh_data.cross);
+#endif
 
 	int edge = 0;
 	int tile = 0;
@@ -828,6 +832,9 @@ void Terrain3D::snap(const Vector3 &p_cam_pos) {
 				t.origin = tile_tl;
 
 				RS->instance_set_transform(_mesh_data.tiles[tile], t);
+#if GODOT_VERSION_MAJOR == 4 && GODOT_VERSION_MINOR == 4
+				RS->instance_reset_physics_interpolation(_mesh_data.tiles[tile]);
+#endif
 
 				tile++;
 			}
@@ -836,6 +843,9 @@ void Terrain3D::snap(const Vector3 &p_cam_pos) {
 			Transform3D t = Transform3D().scaled(Vector3(scale, 1.f, scale));
 			t.origin = snapped_pos;
 			RS->instance_set_transform(_mesh_data.fillers[l], t);
+#if GODOT_VERSION_MAJOR == 4 && GODOT_VERSION_MINOR == 4
+			RS->instance_reset_physics_interpolation(_mesh_data.fillers[l]);
+#endif
 		}
 
 		if (l != _mesh_lods - 1) {
@@ -858,6 +868,9 @@ void Terrain3D::snap(const Vector3 &p_cam_pos) {
 				t = t.scaled(Vector3(scale, 1.f, scale));
 				t.origin = tile_center;
 				RS->instance_set_transform(_mesh_data.trims[edge], t);
+#if GODOT_VERSION_MAJOR == 4 && GODOT_VERSION_MINOR == 4
+				RS->instance_reset_physics_interpolation(_mesh_data.trims[edge]);
+#endif
 			}
 
 			// Position seams
@@ -866,6 +879,9 @@ void Terrain3D::snap(const Vector3 &p_cam_pos) {
 				Transform3D t = Transform3D().scaled(Vector3(scale, 1.f, scale));
 				t.origin = next_base;
 				RS->instance_set_transform(_mesh_data.seams[edge], t);
+#if GODOT_VERSION_MAJOR == 4 && GODOT_VERSION_MINOR == 4
+				RS->instance_reset_physics_interpolation(_mesh_data.seams[edge]);
+#endif
 			}
 			edge++;
 		}

--- a/src/terrain_3d.h
+++ b/src/terrain_3d.h
@@ -96,7 +96,7 @@ private:
 	Node3D *_mmi_parent;
 
 	void _initialize();
-	void __process(const double p_delta);
+	void __physics_process(const double p_delta);
 	void _grab_camera();
 
 	void _build_containers();


### PR DESCRIPTION
* Moves all snapping to the physics frame (no apparent effect, but handling it in process isn't necessary)
* Fixes physics interpolation by resetting it on the meshes

This fix requires a version of Terrain3D built against godot-cpp 4.4 and Godot Engine 4.4. The artifact in this build will work in 4.4 while its available. However, once this PR is merged into main, which is still running on godot-cpp 4.3, devs will have to build Terrain3D from source against godot-cpp 4.4 in order to use Physics Interpolation in 4.4. This will remain the case until we stop supporting 4.3.

Fixes #470