### PR TITLE
Color map fix region edges

### DIFF
--- a/project/addons/terrain_3d/extras/lowpoly_colormap.gdshader
+++ b/project/addons/terrain_3d/extras/lowpoly_colormap.gdshader
@@ -62,8 +62,7 @@ ivec3 get_region_uv(const vec2 uv, const int search) {
 // XY: (0 to 1) coordinates within a region
 // Z: layer index used for texturearrays, -1 if not in a region
 vec3 get_region_uv2(const vec2 uv2) {
-	// Remove texel offset to ensure correct region index
-	ivec2 pos = ivec2(floor(uv2 - vec2(_region_texel_size * 0.5))) + (_region_map_size / 2);
+	ivec2 pos = ivec2(floor(uv2)) + (_region_map_size / 2);
 	int bounds = int(uint(pos.x | pos.y) < uint(_region_map_size));
 	int layer_index = _region_map[ pos.y * _region_map_size + pos.x ] * bounds - 1;
 	return vec3(uv2 - _region_locations[layer_index], float(layer_index));
@@ -119,7 +118,9 @@ void fragment() {
 	vec2 uv2 = UV2 + v_uv2_offset;
 	
 	// Apply terrain normals
-	NORMAL = normalize(cross(dFdyCoarse(VERTEX),dFdxCoarse(VERTEX)));
+	vec3 ddx = dFdxCoarse(VERTEX);
+	vec3 ddy = dFdyCoarse(VERTEX);
+	NORMAL = normalize(cross(ddy, ddx));
 	TANGENT = normalize(cross(NORMAL, vec3(0.0, 0.0, 1.0)));
 	BINORMAL = normalize(cross(NORMAL, TANGENT));
 	
@@ -127,11 +128,9 @@ void fragment() {
 	vec3 region_uv = get_region_uv2(uv2);
 	
 	// Colormap. 1 lookup
-	vec4 color_map = vec4(1., 1., 1., .5);
-	if (region_uv.z >= 0.) {
-		float lod = textureQueryLod(_color_maps, uv2.xy).y;
-		color_map = textureLod(_color_maps, region_uv, lod);
-	}
+	float lod = log2(max(length(ddx.xz), length(ddy.xz)) * _vertex_density);
+	vec4 color_map = region_uv.z > -1.0 ?
+		textureLod(_color_maps, region_uv, lod) : vec4(1., 1., 1., .5);
 	
 	// Wetness/roughness modifier, converting 0 - 1 range to -1 to 1 range
 	float roughness = fma(color_map.a - 0.5, 2.0, default_roughness);

--- a/project/addons/terrain_3d/extras/minimum.gdshader
+++ b/project/addons/terrain_3d/extras/minimum.gdshader
@@ -134,10 +134,10 @@ void fragment() {
 	vec3 base_ddx = dFdxCoarse(v_vertex);
 	vec3 base_ddy = dFdyCoarse(v_vertex);
 	vec4 base_derivatives = vec4(base_ddx.xz, base_ddy.xz);
-	// When this exceeds 2.0, as derivatives are across 2x2 fragments it means that 
-	// each control map texel is less than 1 pixel in screen space as such we can 
+	// Calculate the effective mipmap for regionspace, and if less than 0,
 	// skip all extra lookups required for bilinear blend.
-	bool bilerp = length(base_derivatives  * _vertex_density) <= 2.0;
+	float region_mip = log2(max(length(base_ddx.xz), length(base_ddy.xz)) * _vertex_density);
+	bool bilerp = region_mip < 0.0;
 
 	ivec3 indexUV[4];
 	// control map lookups, used for some normal lookups as well

--- a/src/shaders/main.glsl
+++ b/src/shaders/main.glsl
@@ -116,8 +116,7 @@ ivec3 get_region_uv(const vec2 uv, const int search) {
 // XY: (0 to 1) coordinates within a region
 // Z: layer index used for texturearrays, -1 if not in a region
 vec3 get_region_uv2(const vec2 uv2) {
-	// Remove texel offset to ensure correct region index
-	ivec2 pos = ivec2(floor(uv2 - vec2(_region_texel_size * 0.5))) + (_region_map_size / 2);
+	ivec2 pos = ivec2(floor(uv2)) + (_region_map_size / 2);
 	int bounds = int(uint(pos.x | pos.y) < uint(_region_map_size));
 	int layer_index = _region_map[ pos.y * _region_map_size + pos.x ] * bounds - 1;
 	return vec3(uv2 - _region_locations[layer_index], float(layer_index));

--- a/src/shaders/uniforms.glsl
+++ b/src/shaders/uniforms.glsl
@@ -3,6 +3,7 @@
 R"(
 
 //INSERT: TEXTURE_SAMPLERS_LINEAR
+#define FILTER_LINEAR 
 uniform highp sampler2DArray _color_maps : source_color, filter_linear_mipmap_anisotropic, repeat_disable;
 uniform highp sampler2DArray _texture_array_albedo : source_color, filter_linear_mipmap_anisotropic, repeat_enable;
 uniform highp sampler2DArray _texture_array_normal : hint_normal, filter_linear_mipmap_anisotropic, repeat_enable;


### PR DESCRIPTION
Before:
![image](https://github.com/user-attachments/assets/1d6833c4-fad4-40cb-ba33-18582ab1bcbf)

After:
![image](https://github.com/user-attachments/assets/f6258153-2edf-44be-92b3-f6825e4f1445)

~~Also dropping mipmaps for the color maps, as texelfetch wont access them.~~

~~Also, this was the last use of uv2 - it is no longer used. making get_region_uv2 redundant as well...~~