### PR TITLE
Fix region data reading for linux dedicated server export

### DIFF
--- a/src/terrain_3d_data.cpp
+++ b/src/terrain_3d_data.cpp
@@ -362,7 +362,7 @@ void Terrain3DData::load_directory(const String &p_dir) {
 	LOG(INFO, "Loading region files from ", p_dir);
 	PackedStringArray files = da->get_files();
 	for (int i = 0; i < files.size(); i++) {
-		String fname = files[i];
+		String fname = files[i].trim_suffix(".remap");
 		String path = p_dir + String("/") + fname;
 		if (!fname.begins_with("terrain3d") || !fname.ends_with(".res")) {
 			continue;


### PR DESCRIPTION
Fixes an issue with dedicated server export, where the `.res` terrain3d files end up becoming `.res.remap` files. This only seems to happen on some exports. Removing .remap from the file name lets it load properly

Tested with: Dedicated Server export, Ubuntu 22.04