### PR TITLE
Expose physics material

### DIFF
--- a/doc/api/class_terrain3d.rst
+++ b/doc/api/class_terrain3d.rst
@@ -72,6 +72,8 @@ Properties
    +-------------------------------------------------------------+----------------------------------------------------------------------------+-----------------+
    | ``int``                                                     | :ref:`mouse_layer<class_Terrain3D_property_mouse_layer>`                   | ``32``          |
    +-------------------------------------------------------------+----------------------------------------------------------------------------+-----------------+
+   | ``PhysicsMaterial``                                         | :ref:`physics_material<class_Terrain3D_property_physics_material>`         |                 |
+   +-------------------------------------------------------------+----------------------------------------------------------------------------+-----------------+
    | :ref:`RegionSize<enum_Terrain3D_RegionSize>`                | :ref:`region_size<class_Terrain3D_property_region_size>`                   | ``256``         |
    +-------------------------------------------------------------+----------------------------------------------------------------------------+-----------------+
    | ``int``                                                     | :ref:`render_layers<class_Terrain3D_property_render_layers>`               | ``2147483649``  |
@@ -609,6 +611,23 @@ This variable sets the editor render layer (21-32) to be used by ``get_intersect
 You may place other objects on this layer, however ``get_intersection`` will report intersections with them. So either dedicate this layer to Terrain3D, or if you must use all 32 layers, dedicate this one during editing or when using ``get_intersection``, and then you can use it during game play.
 
 See :ref:`get_intersection<class_Terrain3D_method_get_intersection>`.
+
+.. rst-class:: classref-item-separator
+
+----
+
+.. _class_Terrain3D_property_physics_material:
+
+.. rst-class:: classref-property
+
+``PhysicsMaterial`` **physics_material** :ref:`🔗<class_Terrain3D_property_physics_material>`
+
+.. rst-class:: classref-property-setget
+
+- |void| **set_physics_material**\ (\ value\: ``PhysicsMaterial``\ )
+- ``PhysicsMaterial`` **get_physics_material**\ (\ )
+
+Alias for :ref:`Terrain3DCollision.physics_material<class_Terrain3DCollision_property_physics_material>`.
 
 .. rst-class:: classref-item-separator
 

--- a/doc/api/class_terrain3dcollision.rst
+++ b/doc/api/class_terrain3dcollision.rst
@@ -27,19 +27,21 @@ Properties
 .. table::
    :widths: auto
 
-   +-------------------------------------------------------------+-----------------------------------------------------------------+---------+
-   | ``int``                                                     | :ref:`layer<class_Terrain3DCollision_property_layer>`           | ``1``   |
-   +-------------------------------------------------------------+-----------------------------------------------------------------+---------+
-   | ``int``                                                     | :ref:`mask<class_Terrain3DCollision_property_mask>`             | ``1``   |
-   +-------------------------------------------------------------+-----------------------------------------------------------------+---------+
-   | :ref:`CollisionMode<enum_Terrain3DCollision_CollisionMode>` | :ref:`mode<class_Terrain3DCollision_property_mode>`             | ``1``   |
-   +-------------------------------------------------------------+-----------------------------------------------------------------+---------+
-   | ``float``                                                   | :ref:`priority<class_Terrain3DCollision_property_priority>`     | ``1.0`` |
-   +-------------------------------------------------------------+-----------------------------------------------------------------+---------+
-   | ``int``                                                     | :ref:`radius<class_Terrain3DCollision_property_radius>`         | ``64``  |
-   +-------------------------------------------------------------+-----------------------------------------------------------------+---------+
-   | ``int``                                                     | :ref:`shape_size<class_Terrain3DCollision_property_shape_size>` | ``16``  |
-   +-------------------------------------------------------------+-----------------------------------------------------------------+---------+
+   +-------------------------------------------------------------+-----------------------------------------------------------------------------+---------+
+   | ``int``                                                     | :ref:`layer<class_Terrain3DCollision_property_layer>`                       | ``1``   |
+   +-------------------------------------------------------------+-----------------------------------------------------------------------------+---------+
+   | ``int``                                                     | :ref:`mask<class_Terrain3DCollision_property_mask>`                         | ``1``   |
+   +-------------------------------------------------------------+-----------------------------------------------------------------------------+---------+
+   | :ref:`CollisionMode<enum_Terrain3DCollision_CollisionMode>` | :ref:`mode<class_Terrain3DCollision_property_mode>`                         | ``1``   |
+   +-------------------------------------------------------------+-----------------------------------------------------------------------------+---------+
+   | ``PhysicsMaterial``                                         | :ref:`physics_material<class_Terrain3DCollision_property_physics_material>` |         |
+   +-------------------------------------------------------------+-----------------------------------------------------------------------------+---------+
+   | ``float``                                                   | :ref:`priority<class_Terrain3DCollision_property_priority>`                 | ``1.0`` |
+   +-------------------------------------------------------------+-----------------------------------------------------------------------------+---------+
+   | ``int``                                                     | :ref:`radius<class_Terrain3DCollision_property_radius>`                     | ``64``  |
+   +-------------------------------------------------------------+-----------------------------------------------------------------------------+---------+
+   | ``int``                                                     | :ref:`shape_size<class_Terrain3DCollision_property_shape_size>`             | ``16``  |
+   +-------------------------------------------------------------+-----------------------------------------------------------------------------+---------+
 
 .. rst-class:: classref-reftable-group
 
@@ -49,21 +51,23 @@ Methods
 .. table::
    :widths: auto
 
-   +----------+---------------------------------------------------------------------------------------+
-   | |void|   | :ref:`build<class_Terrain3DCollision_method_build>`\ (\ )                             |
-   +----------+---------------------------------------------------------------------------------------+
-   | |void|   | :ref:`destroy<class_Terrain3DCollision_method_destroy>`\ (\ )                         |
-   +----------+---------------------------------------------------------------------------------------+
-   | ``RID``  | :ref:`get_rid<class_Terrain3DCollision_method_get_rid>`\ (\ ) |const|                 |
-   +----------+---------------------------------------------------------------------------------------+
-   | ``bool`` | :ref:`is_dynamic_mode<class_Terrain3DCollision_method_is_dynamic_mode>`\ (\ ) |const| |
-   +----------+---------------------------------------------------------------------------------------+
-   | ``bool`` | :ref:`is_editor_mode<class_Terrain3DCollision_method_is_editor_mode>`\ (\ ) |const|   |
-   +----------+---------------------------------------------------------------------------------------+
-   | ``bool`` | :ref:`is_enabled<class_Terrain3DCollision_method_is_enabled>`\ (\ ) |const|           |
-   +----------+---------------------------------------------------------------------------------------+
-   | |void|   | :ref:`update<class_Terrain3DCollision_method_update>`\ (\ force\: ``bool`` = false\ ) |
-   +----------+---------------------------------------------------------------------------------------+
+   +-----------------------------------+---------------------------------------------------------------------------------------+
+   | |void|                            | :ref:`build<class_Terrain3DCollision_method_build>`\ (\ )                             |
+   +-----------------------------------+---------------------------------------------------------------------------------------+
+   | |void|                            | :ref:`destroy<class_Terrain3DCollision_method_destroy>`\ (\ )                         |
+   +-----------------------------------+---------------------------------------------------------------------------------------+
+   | ``RID``                           | :ref:`get_rid<class_Terrain3DCollision_method_get_rid>`\ (\ ) |const|                 |
+   +-----------------------------------+---------------------------------------------------------------------------------------+
+   | :ref:`Terrain3D<class_Terrain3D>` | :ref:`get_terrain<class_Terrain3DCollision_method_get_terrain>`\ (\ )                 |
+   +-----------------------------------+---------------------------------------------------------------------------------------+
+   | ``bool``                          | :ref:`is_dynamic_mode<class_Terrain3DCollision_method_is_dynamic_mode>`\ (\ ) |const| |
+   +-----------------------------------+---------------------------------------------------------------------------------------+
+   | ``bool``                          | :ref:`is_editor_mode<class_Terrain3DCollision_method_is_editor_mode>`\ (\ ) |const|   |
+   +-----------------------------------+---------------------------------------------------------------------------------------+
+   | ``bool``                          | :ref:`is_enabled<class_Terrain3DCollision_method_is_enabled>`\ (\ ) |const|           |
+   +-----------------------------------+---------------------------------------------------------------------------------------+
+   | |void|                            | :ref:`update<class_Terrain3DCollision_method_update>`\ (\ force\: ``bool`` = false\ ) |
+   +-----------------------------------+---------------------------------------------------------------------------------------+
 
 .. rst-class:: classref-section-separator
 
@@ -180,6 +184,25 @@ The selected mode determines if collision is generated and how. See :ref:`Collis
 
 ----
 
+.. _class_Terrain3DCollision_property_physics_material:
+
+.. rst-class:: classref-property
+
+``PhysicsMaterial`` **physics_material** :ref:`🔗<class_Terrain3DCollision_property_physics_material>`
+
+.. rst-class:: classref-property-setget
+
+- |void| **set_physics_material**\ (\ value\: ``PhysicsMaterial``\ )
+- ``PhysicsMaterial`` **get_physics_material**\ (\ )
+
+Applies a ``PhysicsMaterial`` override to the StaticBody.
+
+There's no ability built into Godot to change physics material parameters based on texture or any other factor. However, it might be possible to extend `PhysicsMaterial` in order to inject code into the queries. It would need references to an object position and a terrain, and then it could run :ref:`Terrain3DData.get_texture_id<class_Terrain3DData_method_get_texture_id>` based on the position and return different physics settings per texture. That would change the settings for the entire terrain for that moment.
+
+.. rst-class:: classref-item-separator
+
+----
+
 .. _class_Terrain3DCollision_property_priority:
 
 .. rst-class:: classref-property
@@ -267,6 +290,18 @@ Removes all collision shapes and frees any memory used.
 ``RID`` **get_rid**\ (\ ) |const| :ref:`🔗<class_Terrain3DCollision_method_get_rid>`
 
 Returns the RID of the active StaticBody.
+
+.. rst-class:: classref-item-separator
+
+----
+
+.. _class_Terrain3DCollision_method_get_terrain:
+
+.. rst-class:: classref-method
+
+:ref:`Terrain3D<class_Terrain3D>` **get_terrain**\ (\ ) :ref:`🔗<class_Terrain3DCollision_method_get_terrain>`
+
+Returns the Terrain3D node this object is connected to. Since raycasts return this object, this function allows you to retreive the Terrain3D node.
 
 .. rst-class:: classref-item-separator
 

--- a/doc/doc_classes/Terrain3D.xml
+++ b/doc/doc_classes/Terrain3D.xml
@@ -178,6 +178,9 @@
 			You may place other objects on this layer, however [code skip-lint]get_intersection[/code] will report intersections with them. So either dedicate this layer to Terrain3D, or if you must use all 32 layers, dedicate this one during editing or when using [code skip-lint]get_intersection[/code], and then you can use it during game play.
 			See [method get_intersection].
 		</member>
+		<member name="physics_material" type="PhysicsMaterial" setter="set_physics_material" getter="get_physics_material">
+			Alias for [member Terrain3DCollision.physics_material].
+		</member>
 		<member name="region_size" type="int" setter="change_region_size" getter="get_region_size" enum="Terrain3D.RegionSize" default="256">
 			The number of vertices in each region, and the number of pixels for each map in [Terrain3DRegion]. 1 pixel always corresponds to 1 vertex. [member Terrain3D.vertex_spacing] laterally scales regions, but does not change the number of vertices or pixels in each.
 		</member>

--- a/doc/doc_classes/Terrain3DCollision.xml
+++ b/doc/doc_classes/Terrain3DCollision.xml
@@ -26,6 +26,12 @@
 				Returns the RID of the active StaticBody.
 			</description>
 		</method>
+		<method name="get_terrain">
+			<return type="Terrain3D" />
+			<description>
+				Returns the Terrain3D node this object is connected to. Since raycasts return this object, this function allows you to retreive the Terrain3D node.
+			</description>
+		</method>
 		<method name="is_dynamic_mode" qualifiers="const">
 			<return type="bool" />
 			<description>
@@ -62,6 +68,10 @@
 		</member>
 		<member name="mode" type="int" setter="set_mode" getter="get_mode" enum="Terrain3DCollision.CollisionMode" default="1">
 			The selected mode determines if collision is generated and how. See [enum CollisionMode] for details.
+		</member>
+		<member name="physics_material" type="PhysicsMaterial" setter="set_physics_material" getter="get_physics_material">
+			Applies a [code skip-lint]PhysicsMaterial[/code] override to the StaticBody.
+			There's no ability built into Godot to change physics material parameters based on texture or any other factor. However, it might be possible to extend `PhysicsMaterial` in order to inject code into the queries. It would need references to an object position and a terrain, and then it could run [method Terrain3DData.get_texture_id] based on the position and return different physics settings per texture. That would change the settings for the entire terrain for that moment.
 		</member>
 		<member name="priority" type="float" setter="set_priority" getter="get_priority" default="1.0">
 			The priority with which the physics server uses to solve collisions. The higher the priority, the lower the penetration of a colliding object. Sets [code skip-lint]CollisionObject3D.collision_priority[/code].

--- a/doc/docs/collision.md
+++ b/doc/docs/collision.md
@@ -8,28 +8,40 @@ You should use raycasting only when you don't already know the X, Z of the colli
 
 ## Physics Based Collision & Raycasting
 
-Collision is generated at runtime using the physics server. Regular PhysicsBodies will interact with this collision as expected. To detect ground height, use a [ray cast](https://docs.godotengine.org/en/stable/tutorials/physics/ray-casting.html). There is no collision outside of regions, so raycasts won't hit.
+Collision is generated at runtime using the physics server. Regular PhysicsBodies will interact with this collision as expected. 
 
-Normally the editor doesn't generate collision, but some addons or other activities do need editor collision. To generate it, set `Terrain3D/Collision/Collision Mode`, or `Terrain3D.collision.mode`, to `Full / Editor` or `Dynamic / Editor`. You can run in game with this enabled.
+To detect ground height with this method, use a [ray cast](https://docs.godotengine.org/en/stable/tutorials/physics/ray-casting.html). Below is an example. The colliding object will be a [Terrain3DCollision](../api/class_terrain3dcollision.rst) object, which contains but is not a StaticBody. Run `get_terrain()` to get the Terrain3D node, or `get_rid()` to retreive the StaticBody RID. See that link for other functions to configure other properties like layers, mask, priority, and physics material.
 
-Full mode will generate collision for all regions when enabled or at startup. It's a bit slow due to the amount of data. Dynamic mode will generate a small area around the camera and can be updated on the fly.
+```gdscript
+    var space_state: PhysicsDirectSpaceState3D = get_world_3d().direct_space_state
+    var query := PhysicsRayQueryParameters3D.create(position, position + Vector3(0, -500, 0))
+    query.exclude = [ self ]
+    var result: Dictionary = space_state.intersect_ray(query)
+    if result and result["collider"] is Terrain3DCollision:
+        print("Found Terrain3DCollision")
+        var terrain: Terrain3D = result["collider"].get_terrain()
+        if terrain:
+            print("Found Terrain3D")
+```
 
-See the [Terrain3DCollision API](../api/class_terrain3dcollision.rst) for various functions to configure other properties like layers, mask, and priority.
+Raycasts won't hit the terrain where no collision shapes are generated. This occurs outside of regions and may also depend on your collision mode setting. Read about `Terrain3D/Collision/Collision Mode`, or `Terrain3D.collision.mode` in the API above. 
+
+Normally, collision mode is set `Dynamic / Game`, which only generates around the player while in game. Some addons or other activities need collision in the editor, so you can set the mode to `Full / Editor` or `Dynamic / Editor`. Full mode will generate collision for all regions when enabled or at startup. It's a bit slow due to the amount of data. You can run in game with these other modes enabled, but the default is recommended for the best performance.
 
 Finally, Godot Physics is far from perfect. If you have issues with raycasts or other physics calculations, try switching to Jolt. Also if your raycast is perfectly vertical, you can try angling it ever so slightly, or use an option below.
 
 
 ## Raycasting Without Physics
 
-It is possible to cast a ray from any position and direction to detect the collision point on the terrain without using the physics engine. We have two methods for that: raymarching and using the GPU.
+It is possible to cast a ray from any position and direction to detect the collision point on the terrain without using the physics engine. We have two methods for that: raymarching and "looking" at it with the GPU.
 
 Sending the source point and ray direction to [Terrain3D.get_intersection()](../api/class_terrain3d.rst#class-terrain3d-method-get-intersection) will return the intersection point. This function has two modes:
 
-In raymarching mode it iterates over get_height() until an intersection is reached. This only works within regions, and is a bit heavy compared to the other modes.
+In raymarching mode it iterates over get_height() until an intersection is reached. This only works within regions, and is a bit heavy compared to the other mode.
 
-In GPU mode, it "looks" at the terrain using the GPU depth texture. This works outside of regions, even on the WorldNoise. However there are caveats. It returns values for the previous frame, so can only used continuously or used with `await`, and no more than once per frame.
+In GPU mode, it "looks" at the terrain using a camera and the GPU depth texture. This works outside of regions, even on the WorldNoise. However there are caveats. It returns values for the previous frame, so can only used continuously or used with `await`, and no more than once per frame.
 
-Be sure to read the link above to understand all caveats. Review [editor_plugin.gd](https://github.com/TokisanGames/Terrain3D/blob/main/project/addons/terrain_3d/src/editor_plugin.gd#L184-L188) to see an example of using this function to project the mouse position onto the terrain.
+Be sure to read the link above to understand all caveats. Review [editor_plugin.gd:_forward_3d_gui_input](https://github.com/TokisanGames/Terrain3D/blob/main/project/addons/terrain_3d/src/editor_plugin.gd) to see an example of using this function to project the mouse position onto the terrain.
 
 
 ## Query Height At Any Position
@@ -89,7 +101,9 @@ A better alternative is to use physics collision only for the player, and use ra
 
 However both methods above require collision shapes where the enemy is. What if you want to have enemies stay on the ground when far from the camera, while using a dynamic collision mode?
 
-Have each enemy query `Terrain3DData.get_height()`, either in conjunction with checking height with a raycast or physics, or in place of. It could come right after applying gravity so it will snap back to the surface if it dips below.
+For one, you could disable all enemy processing when away from the camera. Do you really need them moving, playing animations, and applying gravity if they aren't even on screen?
+
+If so, you can have each enemy query `Terrain3DData.get_height()`, either in conjunction with checking height with a raycast or physics, or in place of. It could come right after applying gravity so it will snap back to the surface if it dips below.
 
 e.g.
 ```

--- a/doc/docs/programming_languages.md
+++ b/doc/docs/programming_languages.md
@@ -57,7 +57,7 @@ You can instantiate through ClassDB, set variables and call it.
 ```c#
      var terrain = ClassDB.Instantiate("Terrain3D");
      terrain.AsGodotObject().Set("assets", ClassDB.Instantiate("Terrain3DAssets"));
-     terrain.AsGodotObject().Call("set_collision_enabled", true);
+     terrain.AsGodotObject().Call("set_show_region_grid", true);
 ```
 
 You can also check if a node is a Terrain3D object:
@@ -73,7 +73,7 @@ You can also check if a node is a Terrain3D object:
 ```c#
 private bool CheckTerrain3D(Node myNode) {
         if (myNode.IsClass("Terrain3D")) {
-            var collisionEnabled = myNode.Call("get_collision_enabled").AsInt32();
+            var collisionMode = myNode.Call("get_collision_mode").AsInt32();
 ```
 
 For more information on C# and other languages, read [Cross-language scripting](https://docs.godotengine.org/en/stable/tutorials/scripting/cross_language_scripting.html) in the Godot docs.

--- a/src/terrain_3d.cpp
+++ b/src/terrain_3d.cpp
@@ -142,7 +142,7 @@ void Terrain3D::_grab_camera() {
 	} else {
 		_camera_instance_id = 0;
 		set_physics_process(false); // disable snapping
-		LOG(ERROR, "Cannot find the active camera. Set it manually with Terrain3D.set_camera(). Stopping _process()");
+		LOG(ERROR, "Cannot find the active camera. Set it manually with Terrain3D.set_camera(). Stopping _physics_process()");
 	}
 }
 
@@ -1293,6 +1293,8 @@ void Terrain3D::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("get_collision_mask"), &Terrain3D::get_collision_mask);
 	ClassDB::bind_method(D_METHOD("set_collision_priority", "priority"), &Terrain3D::set_collision_priority);
 	ClassDB::bind_method(D_METHOD("get_collision_priority"), &Terrain3D::get_collision_priority);
+	ClassDB::bind_method(D_METHOD("set_physics_material", "material"), &Terrain3D::set_physics_material);
+	ClassDB::bind_method(D_METHOD("get_physics_material"), &Terrain3D::get_physics_material);
 
 	// Meshes
 	ClassDB::bind_method(D_METHOD("set_mesh_lods", "count"), &Terrain3D::set_mesh_lods);
@@ -1384,6 +1386,7 @@ void Terrain3D::_bind_methods() {
 	ADD_PROPERTY(PropertyInfo(Variant::INT, "collision_layer", PROPERTY_HINT_LAYERS_3D_PHYSICS), "set_collision_layer", "get_collision_layer");
 	ADD_PROPERTY(PropertyInfo(Variant::INT, "collision_mask", PROPERTY_HINT_LAYERS_3D_PHYSICS), "set_collision_mask", "get_collision_mask");
 	ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "collision_priority", PROPERTY_HINT_RANGE, "0.1,256,.1"), "set_collision_priority", "get_collision_priority");
+	ADD_PROPERTY(PropertyInfo(Variant::OBJECT, "physics_material", PROPERTY_HINT_RESOURCE_TYPE, "PhysicsMaterial"), "set_physics_material", "get_physics_material");
 
 	ADD_GROUP("Mesh", "");
 	ADD_PROPERTY(PropertyInfo(Variant::INT, "mesh_lods", PROPERTY_HINT_RANGE, "1,10,1"), "set_mesh_lods", "get_mesh_lods");

--- a/src/terrain_3d.h
+++ b/src/terrain_3d.h
@@ -210,6 +210,8 @@ public:
 	uint32_t get_collision_mask() const { return (_collision != nullptr) ? _collision->get_mask() : 1; }
 	void set_collision_priority(const real_t p_priority) { (_collision != nullptr) ? _collision->set_priority(p_priority) : void(); }
 	real_t get_collision_priority() const { return (_collision != nullptr) ? _collision->get_priority() : 1.f; }
+	void set_physics_material(const Ref<PhysicsMaterial> &p_mat) { (_collision != nullptr) ? _collision->set_physics_material(p_mat) : void(); }
+	Ref<PhysicsMaterial> get_physics_material() const { return (_collision != nullptr) ? _collision->get_physics_material() : Ref<PhysicsMaterial>(); }
 
 	// Debug View Aliases
 	void set_show_checkered(const bool p_enabled) { (_material != nullptr) ? _material->set_show_checkered(p_enabled) : void(); }

--- a/src/terrain_3d_collision.h
+++ b/src/terrain_3d_collision.h
@@ -4,6 +4,7 @@
 #define TERRAIN3D_COLLISION_CLASS_H
 
 #include <godot_cpp/classes/collision_shape3d.hpp>
+#include <godot_cpp/classes/physics_material.hpp>
 #include <godot_cpp/classes/static_body3d.hpp>
 #include <vector>
 
@@ -37,6 +38,7 @@ private:
 	uint32_t _layer = 1;
 	uint32_t _mask = 1;
 	real_t _priority = 1.f;
+	Ref<PhysicsMaterial> _physics_material;
 
 	// Work data
 	RID _static_body_rid; // Physics Server Static Body
@@ -55,10 +57,13 @@ private:
 	Vector3 _shape_get_position(const int p_shape_id) const;
 	void _shape_set_data(const int p_shape_id, const Dictionary &p_dict);
 
+	void _reload_physics_material();
+
 public:
 	Terrain3DCollision() {}
 	~Terrain3DCollision() { destroy(); }
 	void initialize(Terrain3D *p_terrain);
+	Terrain3D *get_terrain() const { return _terrain; }
 
 	void build();
 	void update(const bool p_force = false);
@@ -80,6 +85,8 @@ public:
 	uint32_t get_mask() const { return _mask; };
 	void set_priority(const real_t p_priority);
 	real_t get_priority() const { return _priority; }
+	void set_physics_material(const Ref<PhysicsMaterial> &p_mat);
+	Ref<PhysicsMaterial> get_physics_material() { return _physics_material; }
 	RID get_rid() const;
 
 protected:


### PR DESCRIPTION
* Exposes physics material
* Updates docs to clarify how to run raycasts, which return a Terrain3DCollision object.