### PR TITLE
Strip comments before editor shader injection

### DIFF
--- a/project/addons/terrain_3d/src/ui.gd
+++ b/project/addons/terrain_3d/src/ui.gd
@@ -436,6 +436,8 @@ func update_decal() -> void:
 func is_shader_valid() -> bool:
 	# As long as the compiled shader would contain at least 1 uniform to check against, we can
 	# check if the shader compilation has failed as this will then return an empty dictionary.
+	if not plugin.terrain:
+		return false
 	var params = RenderingServer.get_shader_parameter_list(plugin.terrain.material.get_shader_rid())
 	if params.is_empty():
 		return false

--- a/project/addons/terrain_3d/src/ui.gd
+++ b/project/addons/terrain_3d/src/ui.gd
@@ -62,7 +62,8 @@ var editor_decal_fade: float :
 		editor_decal_fade = value
 		if editor_decal_color.size() > 0:
 			editor_decal_color[0].a = value
-			RenderingServer.material_set_param(mat_rid, "_editor_decal_color", editor_decal_color)
+			if is_shader_valid():
+				RenderingServer.material_set_param(mat_rid, "_editor_decal_color", editor_decal_color)
 @onready var editor_ring_texture_rid: RID = ring_texture.get_rid()
 
 
@@ -422,19 +423,29 @@ func update_decal() -> void:
 	
 	editor_decal_fade = editor_decal_color[0].a
 	# Update Shader params
-	RenderingServer.material_set_param(mat_rid, "_editor_brush_texture", editor_brush_texture_rid)
-	RenderingServer.material_set_param(mat_rid, "_editor_ring_texture", editor_ring_texture_rid)
-	RenderingServer.material_set_param(mat_rid, "_editor_decal_position", editor_decal_position)
-	RenderingServer.material_set_param(mat_rid, "_editor_decal_rotation", editor_decal_rotation)
-	RenderingServer.material_set_param(mat_rid, "_editor_decal_size", editor_decal_size)
-	RenderingServer.material_set_param(mat_rid, "_editor_decal_color", editor_decal_color)
-	RenderingServer.material_set_param(mat_rid, "_editor_decal_visible", editor_decal_visible)
-	RenderingServer.material_set_param(mat_rid, "_editor_crosshair_threshold", brush_data["crosshair_threshold"] + 0.1)
+	if is_shader_valid():
+		RenderingServer.material_set_param(mat_rid, "_editor_brush_texture", editor_brush_texture_rid)
+		RenderingServer.material_set_param(mat_rid, "_editor_ring_texture", editor_ring_texture_rid)
+		RenderingServer.material_set_param(mat_rid, "_editor_decal_position", editor_decal_position)
+		RenderingServer.material_set_param(mat_rid, "_editor_decal_rotation", editor_decal_rotation)
+		RenderingServer.material_set_param(mat_rid, "_editor_decal_size", editor_decal_size)
+		RenderingServer.material_set_param(mat_rid, "_editor_decal_color", editor_decal_color)
+		RenderingServer.material_set_param(mat_rid, "_editor_decal_visible", editor_decal_visible)
+		RenderingServer.material_set_param(mat_rid, "_editor_crosshair_threshold", brush_data["crosshair_threshold"] + 0.1)
 
+func is_shader_valid() -> bool:
+	# As long as the compiled shader would contain at least 1 uniform to check against, we can
+	# check if the shader compilation has failed as this will then return an empty dictionary.
+	var params = RenderingServer.get_shader_parameter_list(plugin.terrain.material.get_shader_rid())
+	if params.is_empty():
+		return false
+	else:
+		return true
 
 func hide_decal() -> void:
 	editor_decal_visible = [false, false, false]
-	RenderingServer.material_set_param(mat_rid, "_editor_decal_visible", editor_decal_visible)
+	if is_shader_valid():
+		RenderingServer.material_set_param(mat_rid, "_editor_decal_visible", editor_decal_visible)
 
 
 # These array sizes are reset to 0 when closing scenes for some unknown reason, so check and reset
@@ -450,8 +461,8 @@ func reset_decal_arrays() -> void:
 
 func set_decal_rotation(p_rot: float) -> void:
 	editor_decal_rotation[0] = p_rot
-	var mat_rid: RID = plugin.terrain.material.get_material_rid()
-	RenderingServer.material_set_param(mat_rid, "_editor_decal_rotation", editor_decal_rotation)
+	if is_shader_valid():
+		RenderingServer.material_set_param(mat_rid, "_editor_decal_rotation", editor_decal_rotation)
 
 
 func _on_picking(p_type: int, p_callback: Callable) -> void:

--- a/src/shaders/main.glsl
+++ b/src/shaders/main.glsl
@@ -146,7 +146,7 @@ void vertex() {
 
 	// Show holes to all cameras except mouse camera (on exactly 1 layer)
 	if ( !(CAMERA_VISIBLE_LAYERS == _mouse_layer) && 
-			(hole || (_background_mode == 0u && v_region.z < 0))) {
+			(hole || (_background_mode == 0u && v_region.z == -1))) {
 		v_vertex.x = 0. / 0.;
 	} else {		
 		// Set final vertex height & calculate vertex normals. 3 lookups

--- a/src/terrain_3d.cpp
+++ b/src/terrain_3d.cpp
@@ -616,6 +616,7 @@ void Terrain3D::set_assets(const Ref<Terrain3DAssets> &p_assets) {
 
 void Terrain3D::set_editor(Terrain3DEditor *p_editor) {
 	_editor = p_editor;
+	_material->update();
 	LOG(DEBUG, "Received Terrain3DEditor: ", p_editor);
 }
 

--- a/src/terrain_3d_editor.cpp
+++ b/src/terrain_3d_editor.cpp
@@ -730,9 +730,11 @@ void Terrain3DEditor::set_brush_data(const Dictionary &p_data) {
 }
 
 void Terrain3DEditor::set_tool(const Tool p_tool) {
-	_tool = CLAMP(p_tool, Tool(0), TOOL_MAX);
-	if (_terrain) {
+	if (_terrain && _tool != p_tool && (_tool == Tool::NAVIGATION || p_tool == Tool::NAVIGATION)) {
+		_tool = CLAMP(p_tool, Tool(0), TOOL_MAX);
 		_terrain->get_material()->update();
+	} else {
+		_tool = p_tool;
 	}
 }
 

--- a/src/terrain_3d_material.h
+++ b/src/terrain_3d_material.h
@@ -72,6 +72,7 @@ private:
 	void _parse_shader(const String &p_shader, const String &p_name);
 	String _apply_inserts(const String &p_shader, const Array &p_excludes = Array()) const;
 	String _generate_shader_code() const;
+	String _strip_comments(const String &p_shader) const;
 	String _inject_editor_code(const String &p_shader) const;
 	void _update_shader();
 	void _update_maps();

--- a/src/terrain_3d_mesh_asset.cpp
+++ b/src/terrain_3d_mesh_asset.cpp
@@ -260,6 +260,7 @@ void Terrain3DMeshAsset::set_generated_type(const GenType p_type) {
 			_material_override = _get_material();
 		}
 		_density = 10.f;
+		_height_offset = 0.5f;
 		_last_lod = 0;
 		_last_shadow_lod = 0;
 		_shadow_impostor = 0;


### PR DESCRIPTION
Admin update:
* Strips comments from shader before injection to fix commented braces
* Verifies shader has been compiled before decal use in UI.gd
* Reduce shader recompilation on tool changes; only navigation now
* Implement region decal, partially working on #100 
* Fix default texture card offset

-----
Fixes issues with comments being incorrectly picked up as places to inject code.

Expand decal to include region tool