### PR TITLE
Fix PhysicsServer now returns Terrain3D instead of Terrain3DCollision

### DIFF
--- a/doc/api/class_terrain3d.rst
+++ b/doc/api/class_terrain3d.rst
@@ -132,7 +132,7 @@ Methods
    :widths: auto
 
    +-----------------------------------------------+-------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
-   | ``Mesh``                                      | :ref:`bake_mesh<class_Terrain3D_method_bake_mesh>`\ (\ lod\: ``int``, filter\: :ref:`HeightFilter<enum_Terrain3DData_HeightFilter>`\ ) |const|                          |
+   | ``Mesh``                                      | :ref:`bake_mesh<class_Terrain3D_method_bake_mesh>`\ (\ lod\: ``int``, filter\: :ref:`HeightFilter<enum_Terrain3DData_HeightFilter>` = 0\ ) |const|                      |
    +-----------------------------------------------+-------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
    | ``PackedVector3Array``                        | :ref:`generate_nav_mesh_source_geometry<class_Terrain3D_method_generate_nav_mesh_source_geometry>`\ (\ global_aabb\: ``AABB``, require_nav\: ``bool`` = true\ ) |const| |
    +-----------------------------------------------+-------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
@@ -1057,7 +1057,7 @@ Method Descriptions
 
 .. rst-class:: classref-method
 
-``Mesh`` **bake_mesh**\ (\ lod\: ``int``, filter\: :ref:`HeightFilter<enum_Terrain3DData_HeightFilter>`\ ) |const| :ref:`🔗<class_Terrain3D_method_bake_mesh>`
+``Mesh`` **bake_mesh**\ (\ lod\: ``int``, filter\: :ref:`HeightFilter<enum_Terrain3DData_HeightFilter>` = 0\ ) |const| :ref:`🔗<class_Terrain3D_method_bake_mesh>`
 
 Generates a static ArrayMesh for the terrain.
 

--- a/doc/api/class_terrain3dcollision.rst
+++ b/doc/api/class_terrain3dcollision.rst
@@ -51,23 +51,21 @@ Methods
 .. table::
    :widths: auto
 
-   +-----------------------------------+---------------------------------------------------------------------------------------+
-   | |void|                            | :ref:`build<class_Terrain3DCollision_method_build>`\ (\ )                             |
-   +-----------------------------------+---------------------------------------------------------------------------------------+
-   | |void|                            | :ref:`destroy<class_Terrain3DCollision_method_destroy>`\ (\ )                         |
-   +-----------------------------------+---------------------------------------------------------------------------------------+
-   | ``RID``                           | :ref:`get_rid<class_Terrain3DCollision_method_get_rid>`\ (\ ) |const|                 |
-   +-----------------------------------+---------------------------------------------------------------------------------------+
-   | :ref:`Terrain3D<class_Terrain3D>` | :ref:`get_terrain<class_Terrain3DCollision_method_get_terrain>`\ (\ )                 |
-   +-----------------------------------+---------------------------------------------------------------------------------------+
-   | ``bool``                          | :ref:`is_dynamic_mode<class_Terrain3DCollision_method_is_dynamic_mode>`\ (\ ) |const| |
-   +-----------------------------------+---------------------------------------------------------------------------------------+
-   | ``bool``                          | :ref:`is_editor_mode<class_Terrain3DCollision_method_is_editor_mode>`\ (\ ) |const|   |
-   +-----------------------------------+---------------------------------------------------------------------------------------+
-   | ``bool``                          | :ref:`is_enabled<class_Terrain3DCollision_method_is_enabled>`\ (\ ) |const|           |
-   +-----------------------------------+---------------------------------------------------------------------------------------+
-   | |void|                            | :ref:`update<class_Terrain3DCollision_method_update>`\ (\ force\: ``bool`` = false\ ) |
-   +-----------------------------------+---------------------------------------------------------------------------------------+
+   +----------+---------------------------------------------------------------------------------------+
+   | |void|   | :ref:`build<class_Terrain3DCollision_method_build>`\ (\ )                             |
+   +----------+---------------------------------------------------------------------------------------+
+   | |void|   | :ref:`destroy<class_Terrain3DCollision_method_destroy>`\ (\ )                         |
+   +----------+---------------------------------------------------------------------------------------+
+   | ``RID``  | :ref:`get_rid<class_Terrain3DCollision_method_get_rid>`\ (\ ) |const|                 |
+   +----------+---------------------------------------------------------------------------------------+
+   | ``bool`` | :ref:`is_dynamic_mode<class_Terrain3DCollision_method_is_dynamic_mode>`\ (\ ) |const| |
+   +----------+---------------------------------------------------------------------------------------+
+   | ``bool`` | :ref:`is_editor_mode<class_Terrain3DCollision_method_is_editor_mode>`\ (\ ) |const|   |
+   +----------+---------------------------------------------------------------------------------------+
+   | ``bool`` | :ref:`is_enabled<class_Terrain3DCollision_method_is_enabled>`\ (\ ) |const|           |
+   +----------+---------------------------------------------------------------------------------------+
+   | |void|   | :ref:`update<class_Terrain3DCollision_method_update>`\ (\ force\: ``bool`` = false\ ) |
+   +----------+---------------------------------------------------------------------------------------+
 
 .. rst-class:: classref-section-separator
 
@@ -290,18 +288,6 @@ Removes all collision shapes and frees any memory used.
 ``RID`` **get_rid**\ (\ ) |const| :ref:`🔗<class_Terrain3DCollision_method_get_rid>`
 
 Returns the RID of the active StaticBody.
-
-.. rst-class:: classref-item-separator
-
-----
-
-.. _class_Terrain3DCollision_method_get_terrain:
-
-.. rst-class:: classref-method
-
-:ref:`Terrain3D<class_Terrain3D>` **get_terrain**\ (\ ) :ref:`🔗<class_Terrain3DCollision_method_get_terrain>`
-
-Returns the Terrain3D node this object is connected to. Since raycasts return this object, this function allows you to retreive the Terrain3D node.
 
 .. rst-class:: classref-item-separator
 

--- a/doc/api/class_terrain3dmeshasset.rst
+++ b/doc/api/class_terrain3dmeshasset.rst
@@ -92,7 +92,7 @@ Properties
    +-------------------------------------------------+-------------------------------------------------------------------------------+-------------------+
    | ``int``                                         | :ref:`shadow_impostor<class_Terrain3DMeshAsset_property_shadow_impostor>`     | ``0``             |
    +-------------------------------------------------+-------------------------------------------------------------------------------+-------------------+
-   | ``float``                                       | :ref:`visibility_range<class_Terrain3DMeshAsset_property_visibility_range>`   | ``32.0``          |
+   | ``float``                                       | :ref:`visibility_range<class_Terrain3DMeshAsset_property_visibility_range>`   |                   |
    +-------------------------------------------------+-------------------------------------------------------------------------------+-------------------+
 
 .. rst-class:: classref-reftable-group
@@ -694,7 +694,7 @@ Shadow impostors are disabled if this is set to 0 or if :ref:`cast_shadows<class
 
 .. rst-class:: classref-property
 
-``float`` **visibility_range** = ``32.0`` :ref:`🔗<class_Terrain3DMeshAsset_property_visibility_range>`
+``float`` **visibility_range** :ref:`🔗<class_Terrain3DMeshAsset_property_visibility_range>`
 
 .. rst-class:: classref-property-setget
 

--- a/doc/doc_classes/Terrain3D.xml
+++ b/doc/doc_classes/Terrain3D.xml
@@ -12,7 +12,7 @@
 		<method name="bake_mesh" qualifiers="const">
 			<return type="Mesh" />
 			<param index="0" name="lod" type="int" />
-			<param index="1" name="filter" type="int" enum="Terrain3DData.HeightFilter" />
+			<param index="1" name="filter" type="int" enum="Terrain3DData.HeightFilter" default="0" />
 			<description>
 				Generates a static ArrayMesh for the terrain.
 				[code skip-lint]lod[/code] - Determines the granularity of the generated mesh. The range is 0-8. 4 is recommended.

--- a/doc/doc_classes/Terrain3DCollision.xml
+++ b/doc/doc_classes/Terrain3DCollision.xml
@@ -26,12 +26,6 @@
 				Returns the RID of the active StaticBody.
 			</description>
 		</method>
-		<method name="get_terrain">
-			<return type="Terrain3D" />
-			<description>
-				Returns the Terrain3D node this object is connected to. Since raycasts return this object, this function allows you to retreive the Terrain3D node.
-			</description>
-		</method>
 		<method name="is_dynamic_mode" qualifiers="const">
 			<return type="bool" />
 			<description>

--- a/doc/doc_classes/Terrain3DMeshAsset.xml
+++ b/doc/doc_classes/Terrain3DMeshAsset.xml
@@ -138,7 +138,7 @@
 			Increase to improve performance by lowering shadow quality.
 			Shadow impostors are disabled if this is set to 0 or if [member cast_shadows] is set to shadows only.
 		</member>
-		<member name="visibility_range" type="float" setter="set_visibility_range" getter="get_lod0_range" default="32.0">
+		<member name="visibility_range" type="float" setter="set_visibility_range" getter="get_lod0_range">
 			Deprecated, see [member lod0_range].
 		</member>
 	</members>

--- a/src/terrain_3d_collision.cpp
+++ b/src/terrain_3d_collision.cpp
@@ -228,7 +228,7 @@ void Terrain3DCollision::build() {
 		_static_body_rid = PS->body_create();
 		PS->body_set_mode(_static_body_rid, PhysicsServer3D::BODY_MODE_STATIC);
 		PS->body_set_space(_static_body_rid, _terrain->get_world_3d()->get_space());
-		PS->body_attach_object_instance_id(_static_body_rid, get_instance_id());
+		PS->body_attach_object_instance_id(_static_body_rid, _terrain->get_instance_id());
 		PS->body_set_collision_mask(_static_body_rid, _mask);
 		PS->body_set_collision_layer(_static_body_rid, _layer);
 		PS->body_set_collision_priority(_static_body_rid, _priority);
@@ -562,7 +562,6 @@ void Terrain3DCollision::_bind_methods() {
 	BIND_ENUM_CONSTANT(FULL_GAME);
 	BIND_ENUM_CONSTANT(FULL_EDITOR);
 
-	ClassDB::bind_method(D_METHOD("get_terrain"), &Terrain3DCollision::get_terrain);
 	ClassDB::bind_method(D_METHOD("build"), &Terrain3DCollision::build);
 	ClassDB::bind_method(D_METHOD("update", "force"), &Terrain3DCollision::update, DEFVAL(false));
 	ClassDB::bind_method(D_METHOD("destroy"), &Terrain3DCollision::destroy);

--- a/src/terrain_3d_collision.h
+++ b/src/terrain_3d_collision.h
@@ -63,7 +63,6 @@ public:
 	Terrain3DCollision() {}
 	~Terrain3DCollision() { destroy(); }
 	void initialize(Terrain3D *p_terrain);
-	Terrain3D *get_terrain() const { return _terrain; }
 
 	void build();
 	void update(const bool p_force = false);


### PR DESCRIPTION
* Raycasts now collide with Terrain3D instead of Terrain3DCollision in game modes as it did before 
* Updated docs