### PR TITLE
Free editor textures in game mode

### DIFF
--- a/doc/api/class_terrain3d.rst
+++ b/doc/api/class_terrain3d.rst
@@ -56,6 +56,8 @@ Properties
    +-------------------------------------------------------------+----------------------------------------------------------------------------+-----------------+
    | ``int``                                                     | :ref:`debug_level<class_Terrain3D_property_debug_level>`                   | ``0``           |
    +-------------------------------------------------------------+----------------------------------------------------------------------------+-----------------+
+   | ``bool``                                                    | :ref:`free_editor_textures<class_Terrain3D_property_free_editor_textures>` | ``true``        |
+   +-------------------------------------------------------------+----------------------------------------------------------------------------+-----------------+
    | GeometryInstance3D.GIMode                                   | :ref:`gi_mode<class_Terrain3D_property_gi_mode>`                           | ``1``           |
    +-------------------------------------------------------------+----------------------------------------------------------------------------+-----------------+
    | :ref:`Terrain3DInstancer<class_Terrain3DInstancer>`         | :ref:`instancer<class_Terrain3D_property_instancer>`                       |                 |
@@ -470,6 +472,23 @@ The directory where terrain data will be saved to and loaded from.
 - ``int`` **get_debug_level**\ (\ )
 
 The verbosity of debug messages printed to the console. Errors and warnings are always printed. This can also be set via command line using ``--terrain3d-debug=LEVEL`` where ``LEVEL`` is one of ``ERROR, INFO, DEBUG, EXTREME``. The last includes continuously recurring messages like position updates for the mesh as the camera moves around.
+
+.. rst-class:: classref-item-separator
+
+----
+
+.. _class_Terrain3D_property_free_editor_textures:
+
+.. rst-class:: classref-property
+
+``bool`` **free_editor_textures** = ``true`` :ref:`🔗<class_Terrain3D_property_free_editor_textures>`
+
+.. rst-class:: classref-property-setget
+
+- |void| **set_free_editor_textures**\ (\ value\: ``bool``\ )
+- ``bool`` **get_free_editor_textures**\ (\ )
+
+Frees ground textures used for editing at the start of the game. These textures are used to generate the TextureArrays, so if you don't change any :ref:`Terrain3DTextureAsset<class_Terrain3DTextureAsset>` settings in game, this can be enabled. Calls :ref:`Terrain3DAssets.clear_textures<class_Terrain3DAssets_method_clear_textures>`.
 
 .. rst-class:: classref-item-separator
 

--- a/doc/api/class_terrain3dassets.rst
+++ b/doc/api/class_terrain3dassets.rst
@@ -42,6 +42,8 @@ Methods
    :widths: auto
 
    +-----------------------------------------------------------+-------------------------------------------------------------------------------------------------------------------------------------------------------+
+   | |void|                                                    | :ref:`clear_textures<class_Terrain3DAssets_method_clear_textures>`\ (\ update\: ``bool`` = false\ )                                                   |
+   +-----------------------------------------------------------+-------------------------------------------------------------------------------------------------------------------------------------------------------+
    | |void|                                                    | :ref:`create_mesh_thumbnails<class_Terrain3DAssets_method_create_mesh_thumbnails>`\ (\ id\: ``int`` = -1, size\: ``Vector2i`` = Vector2i(128, 128)\ ) |
    +-----------------------------------------------------------+-------------------------------------------------------------------------------------------------------------------------------------------------------+
    | ``RID``                                                   | :ref:`get_albedo_array_rid<class_Terrain3DAssets_method_get_albedo_array_rid>`\ (\ ) |const|                                                          |
@@ -205,6 +207,22 @@ The list of texture assets.
 
 Method Descriptions
 -------------------
+
+.. _class_Terrain3DAssets_method_clear_textures:
+
+.. rst-class:: classref-method
+
+|void| **clear_textures**\ (\ update\: ``bool`` = false\ ) :ref:`🔗<class_Terrain3DAssets_method_clear_textures>`
+
+After textures are loaded, they are combined into a TextureArray. The originals remain in VRAM and are only used if the :ref:`Terrain3DTextureAsset<class_Terrain3DTextureAsset>` settings are changed and regenerating the TextureArrays are necessary. Use this function to clear the originals if not needed. It removes all textures from the asset list, freeing them if they are not referenced by other objects.
+
+Update will regenerate the texture arrays housing the textures drawn on the terrain. This will remove all textures and turn the terrain checkerboard.
+
+A similar ``clear_meshes`` is less useful so hasn't been included. However you can do the same thing with ``get_mesh_list().clear()``.
+
+.. rst-class:: classref-item-separator
+
+----
 
 .. _class_Terrain3DAssets_method_create_mesh_thumbnails:
 

--- a/doc/doc_classes/Terrain3D.xml
+++ b/doc/doc_classes/Terrain3D.xml
@@ -151,6 +151,9 @@
 		<member name="debug_level" type="int" setter="set_debug_level" getter="get_debug_level" default="0">
 			The verbosity of debug messages printed to the console. Errors and warnings are always printed. This can also be set via command line using [code skip-lint]--terrain3d-debug=LEVEL[/code] where [code skip-lint]LEVEL[/code] is one of [code skip-lint]ERROR, INFO, DEBUG, EXTREME[/code]. The last includes continuously recurring messages like position updates for the mesh as the camera moves around.
 		</member>
+		<member name="free_editor_textures" type="bool" setter="set_free_editor_textures" getter="get_free_editor_textures" default="true">
+			Frees ground textures used for editing at the start of the game. These textures are used to generate the TextureArrays, so if you don't change any [Terrain3DTextureAsset] settings in game, this can be enabled. Calls [method Terrain3DAssets.clear_textures].
+		</member>
 		<member name="gi_mode" type="int" setter="set_gi_mode" getter="get_gi_mode" enum="GeometryInstance3D.GIMode" default="1">
 			Tells the renderer which global illumination mode to use for Terrain3D. This sets [code skip-lint]GeometryInstance3D.gi_mode[/code] in the engine.
 		</member>

--- a/doc/doc_classes/Terrain3DAssets.xml
+++ b/doc/doc_classes/Terrain3DAssets.xml
@@ -8,6 +8,15 @@
 	<tutorials>
 	</tutorials>
 	<methods>
+		<method name="clear_textures">
+			<return type="void" />
+			<param index="0" name="update" type="bool" default="false" />
+			<description>
+				After textures are loaded, they are combined into a TextureArray. The originals remain in VRAM and are only used if the [Terrain3DTextureAsset] settings are changed and regenerating the TextureArrays are necessary. Use this function to clear the originals if not needed. It removes all textures from the asset list, freeing them if they are not referenced by other objects.
+				Update will regenerate the texture arrays housing the textures drawn on the terrain. This will remove all textures and turn the terrain checkerboard.
+				A similar [code skip-lint]clear_meshes[/code] is less useful so hasn't been included. However you can do the same thing with [code skip-lint]get_mesh_list().clear()[/code].
+			</description>
+		</method>
 		<method name="create_mesh_thumbnails">
 			<return type="void" />
 			<param index="0" name="id" type="int" default="-1" />

--- a/doc/docs/collision.md
+++ b/doc/docs/collision.md
@@ -12,7 +12,7 @@ To enable physics based collision, we must generate a StaticBody and CollisionSh
 
 Collision generation can be slow and consume a lot of memory, so we offer five options:
 * `Dynamic / Game` is the default, which only generates around the camera while in game. It is node-less and the fastest option.
-* `Dynamic / Editor` generates around the camera in editor or in game. It attaches nodes to the tree, so is slightly slower, but this allows the shapes to be [visualized](#visualize-collision).
+* `Dynamic / Editor` generates around the camera in editor or in game. It attaches nodes to the tree, so is slightly slower, but this allows the shapes to be [visualized](#visualizing-collision).
 * `Full / Game` generates collision for the entire terrain at game start, using node-less shapes. It consumes a lot of memory on large terrains.
 * `Full / Editor` does the above with viewable shapes in the editor.
 * `Disabled` is self explanatory.

--- a/src/terrain_3d.cpp
+++ b/src/terrain_3d.cpp
@@ -861,6 +861,9 @@ void Terrain3D::_notification(const int p_what) {
 		case NOTIFICATION_READY: {
 			// Node is ready
 			LOG(INFO, "NOTIFICATION_READY");
+			if (_free_editor_textures && !IS_EDITOR) {
+				_assets->clear_textures();
+			}
 			break;
 		}
 
@@ -1043,6 +1046,8 @@ void Terrain3D::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("get_gi_mode"), &Terrain3D::get_gi_mode);
 	ClassDB::bind_method(D_METHOD("set_cull_margin", "margin"), &Terrain3D::set_cull_margin);
 	ClassDB::bind_method(D_METHOD("get_cull_margin"), &Terrain3D::get_cull_margin);
+	ClassDB::bind_method(D_METHOD("set_free_editor_textures"), &Terrain3D::set_free_editor_textures);
+	ClassDB::bind_method(D_METHOD("get_free_editor_textures"), &Terrain3D::get_free_editor_textures);
 	ClassDB::bind_method(D_METHOD("set_show_instances", "visible"), &Terrain3D::set_show_instances);
 	ClassDB::bind_method(D_METHOD("get_show_instances"), &Terrain3D::get_show_instances);
 	ClassDB::bind_method(D_METHOD("is_compatibility_mode"), &Terrain3D::is_compatibility_mode);
@@ -1126,26 +1131,27 @@ void Terrain3D::_bind_methods() {
 	ADD_PROPERTY(PropertyInfo(Variant::INT, "cast_shadows", PROPERTY_HINT_ENUM, "Off,On,Double-Sided,Shadows Only"), "set_cast_shadows", "get_cast_shadows");
 	ADD_PROPERTY(PropertyInfo(Variant::INT, "gi_mode", PROPERTY_HINT_ENUM, "Disabled,Static,Dynamic"), "set_gi_mode", "get_gi_mode");
 	ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "cull_margin", PROPERTY_HINT_RANGE, "0.0,10000.0,.5,or_greater"), "set_cull_margin", "get_cull_margin");
-	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "show_instances", PROPERTY_HINT_NONE), "set_show_instances", "get_show_instances");
+	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "free_editor_textures"), "set_free_editor_textures", "get_free_editor_textures");
+	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "show_instances"), "set_show_instances", "get_show_instances");
 
 	ADD_GROUP("Debug Views", "show_");
-	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "show_checkered", PROPERTY_HINT_NONE), "set_show_checkered", "get_show_checkered");
-	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "show_grey", PROPERTY_HINT_NONE), "set_show_grey", "get_show_grey");
-	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "show_heightmap", PROPERTY_HINT_NONE), "set_show_heightmap", "get_show_heightmap");
-	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "show_colormap", PROPERTY_HINT_NONE), "set_show_colormap", "get_show_colormap");
-	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "show_roughmap", PROPERTY_HINT_NONE), "set_show_roughmap", "get_show_roughmap");
-	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "show_control_texture", PROPERTY_HINT_NONE), "set_show_control_texture", "get_show_control_texture");
-	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "show_control_angle", PROPERTY_HINT_NONE), "set_show_control_angle", "get_show_control_angle");
-	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "show_control_scale", PROPERTY_HINT_NONE), "set_show_control_scale", "get_show_control_scale");
-	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "show_control_blend", PROPERTY_HINT_NONE), "set_show_control_blend", "get_show_control_blend");
-	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "show_autoshader", PROPERTY_HINT_NONE), "set_show_autoshader", "get_show_autoshader");
-	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "show_navigation", PROPERTY_HINT_NONE), "set_show_navigation", "get_show_navigation");
-	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "show_texture_height", PROPERTY_HINT_NONE), "set_show_texture_height", "get_show_texture_height");
-	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "show_texture_normal", PROPERTY_HINT_NONE), "set_show_texture_normal", "get_show_texture_normal");
-	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "show_texture_rough", PROPERTY_HINT_NONE), "set_show_texture_rough", "get_show_texture_rough");
-	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "show_region_grid", PROPERTY_HINT_NONE), "set_show_region_grid", "get_show_region_grid");
-	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "show_instancer_grid", PROPERTY_HINT_NONE), "set_show_instancer_grid", "get_show_instancer_grid");
-	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "show_vertex_grid", PROPERTY_HINT_NONE), "set_show_vertex_grid", "get_show_vertex_grid");
+	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "show_checkered"), "set_show_checkered", "get_show_checkered");
+	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "show_grey"), "set_show_grey", "get_show_grey");
+	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "show_heightmap"), "set_show_heightmap", "get_show_heightmap");
+	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "show_colormap"), "set_show_colormap", "get_show_colormap");
+	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "show_roughmap"), "set_show_roughmap", "get_show_roughmap");
+	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "show_control_texture"), "set_show_control_texture", "get_show_control_texture");
+	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "show_control_angle"), "set_show_control_angle", "get_show_control_angle");
+	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "show_control_scale"), "set_show_control_scale", "get_show_control_scale");
+	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "show_control_blend"), "set_show_control_blend", "get_show_control_blend");
+	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "show_autoshader"), "set_show_autoshader", "get_show_autoshader");
+	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "show_navigation"), "set_show_navigation", "get_show_navigation");
+	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "show_texture_height"), "set_show_texture_height", "get_show_texture_height");
+	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "show_texture_normal"), "set_show_texture_normal", "get_show_texture_normal");
+	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "show_texture_rough"), "set_show_texture_rough", "get_show_texture_rough");
+	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "show_region_grid"), "set_show_region_grid", "get_show_region_grid");
+	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "show_instancer_grid"), "set_show_instancer_grid", "get_show_instancer_grid");
+	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "show_vertex_grid"), "set_show_vertex_grid", "get_show_vertex_grid");
 
 	ADD_SIGNAL(MethodInfo("material_changed"));
 	ADD_SIGNAL(MethodInfo("assets_changed"));

--- a/src/terrain_3d.h
+++ b/src/terrain_3d.h
@@ -76,6 +76,7 @@ private:
 	RenderingServer::ShadowCastingSetting _cast_shadows = RenderingServer::SHADOW_CASTING_SETTING_ON;
 	GeometryInstance3D::GIMode _gi_mode = GeometryInstance3D::GI_MODE_STATIC;
 	real_t _cull_margin = 0.0f;
+	bool _free_editor_textures = true;
 	bool _compatibility = false;
 
 	// Mouse cursor
@@ -170,9 +171,11 @@ public:
 	GeometryInstance3D::GIMode get_gi_mode() const { return _gi_mode; }
 	void set_cull_margin(const real_t p_margin);
 	real_t get_cull_margin() const { return _cull_margin; };
-	bool is_compatibility_mode() const { return _compatibility; };
+	void set_free_editor_textures(const bool p_free_textures) { _free_editor_textures = p_free_textures; }
+	bool get_free_editor_textures() const { return _free_editor_textures; };
 	void set_show_instances(const bool p_visible) { _mmi_parent ? _mmi_parent->set_visible(p_visible) : void(); }
 	bool get_show_instances() const { return _mmi_parent ? _mmi_parent->is_visible() : false; }
+	bool is_compatibility_mode() const { return _compatibility; };
 
 	// Utility
 	Vector3 get_intersection(const Vector3 &p_src_pos, const Vector3 &p_direction, const bool p_gpu_mode = false);

--- a/src/terrain_3d_assets.h
+++ b/src/terrain_3d_assets.h
@@ -37,16 +37,16 @@ private:
 	PackedFloat32Array _texture_uv_scales;
 	PackedFloat32Array _texture_detiles;
 
-	// Mesh previews
-	RID scenario;
-	RID viewport;
-	RID viewport_texture;
-	RID camera;
-	RID key_light;
-	RID key_light_instance;
-	RID fill_light;
-	RID fill_light_instance;
-	RID mesh_instance;
+	// Mesh Thumbnail Generation
+	RID _scenario;
+	RID _viewport;
+	RID _viewport_texture;
+	RID _camera;
+	RID _key_light;
+	RID _key_light_instance;
+	RID _fill_light;
+	RID _fill_light_instance;
+	RID _mesh_instance;
 
 	void _swap_ids(const AssetType p_type, const int p_src_id, const int p_dst_id);
 	void _set_asset_list(const AssetType p_type, const TypedArray<Terrain3DAssetResource> &p_list);
@@ -71,6 +71,7 @@ public:
 	PackedColorArray get_texture_colors() const { return _texture_colors; }
 	PackedFloat32Array get_texture_uv_scales() const { return _texture_uv_scales; }
 	PackedFloat32Array get_texture_detiles() const { return _texture_detiles; }
+	void clear_textures(const bool p_update = false);
 	void update_texture_list();
 
 	void set_mesh_asset(const int p_id, const Ref<Terrain3DMeshAsset> &p_mesh_asset);


### PR DESCRIPTION
Frees editor textures in game mode, enabled by default

Fixes #566 

@Xtarsia Would you review this please?
You can use the vram debugger, but one texture is used by borders, so delete that node.
You can test the remote scene tree and edit texture settings with this setting enabled and not.