### PR TITLE
Fix crash from dangling pointers in resources

### DIFF
--- a/src/terrain_3d.h
+++ b/src/terrain_3d.h
@@ -115,6 +115,7 @@ public:
 
 	Terrain3D();
 	~Terrain3D() {}
+	bool is_inside_world() { return _is_inside_world; }
 
 	// Terrain
 	String get_version() const { return _version; }

--- a/src/terrain_3d_assets.cpp
+++ b/src/terrain_3d_assets.cpp
@@ -376,7 +376,13 @@ void Terrain3DAssets::_update_thumbnail(const Ref<Terrain3DMeshAsset> &p_mesh_as
 ///////////////////////////
 
 void Terrain3DAssets::initialize(Terrain3D *p_terrain) {
-	_terrain = p_terrain;
+	if (p_terrain) {
+		_terrain = p_terrain;
+	} else {
+		LOG(ERROR, "Initialization failed, p_terrain is null");
+		return;
+	}
+	LOG(INFO, "Initializing assets");
 
 	// Setup Mesh preview environment
 	_scenario = RS->scenario_create();
@@ -411,7 +417,15 @@ void Terrain3DAssets::initialize(Terrain3D *p_terrain) {
 	update_mesh_list();
 }
 
-Terrain3DAssets::~Terrain3DAssets() {
+void Terrain3DAssets::uninitialize() {
+	LOG(INFO, "Uninitializing assets");
+	_terrain = nullptr;
+}
+
+void Terrain3DAssets::destroy() {
+	IS_INIT(VOID);
+	LOG(INFO, "Destroying assets");
+	_terrain = nullptr;
 	_generated_albedo_textures.clear();
 	_generated_normal_textures.clear();
 	RS->free_rid(_mesh_instance);

--- a/src/terrain_3d_assets.h
+++ b/src/terrain_3d_assets.h
@@ -58,8 +58,11 @@ private:
 
 public:
 	Terrain3DAssets() {}
+	~Terrain3DAssets() { destroy(); }
 	void initialize(Terrain3D *p_terrain);
-	~Terrain3DAssets();
+	bool is_initialized() { return _terrain != nullptr; }
+	void uninitialize();
+	void destroy();
 
 	void set_texture(const int p_id, const Ref<Terrain3DTextureAsset> &p_texture);
 	Ref<Terrain3DTextureAsset> get_texture(const int p_id) const { return _texture_list[p_id]; }

--- a/src/terrain_3d_collision.cpp
+++ b/src/terrain_3d_collision.cpp
@@ -198,11 +198,11 @@ void Terrain3DCollision::initialize(Terrain3D *p_terrain) {
 }
 
 void Terrain3DCollision::build() {
-	if (!_terrain) {
-		LOG(DEBUG, "Build called before terrain initialized. Returning.");
+	IS_DATA_INIT(VOID);
+	if (!_terrain->is_inside_world()) {
+		LOG(ERROR, "Terrain isn't inside world. Returning.");
 		return;
 	}
-	IS_DATA_INIT_MESG("Terrain3D not initialized.", VOID);
 
 	// Clear collision as the user might change modes in the editor
 	destroy();

--- a/src/terrain_3d_material.cpp
+++ b/src/terrain_3d_material.cpp
@@ -530,11 +530,11 @@ void Terrain3DMaterial::_update_maps() {
 
 // Called from signal connected in Terrain3D, emitted by texture_list
 void Terrain3DMaterial::_update_texture_arrays() {
-	IS_DATA_INIT_MESG("Material not initialized", VOID);
+	IS_DATA_INIT(VOID);
 	Ref<Terrain3DAssets> asset_list = _terrain->get_assets();
 	LOG(INFO, "Updating texture arrays in shader");
-	if (asset_list.is_null()) {
-		LOG(ERROR, "Asset list is null");
+	if (asset_list.is_null() || !asset_list->is_initialized()) {
+		LOG(ERROR, "Asset list is not initialized");
 		return;
 	}
 
@@ -598,9 +598,15 @@ void Terrain3DMaterial::initialize(Terrain3D *p_terrain) {
 	}
 }
 
-Terrain3DMaterial::~Terrain3DMaterial() {
+void Terrain3DMaterial::uninitialize() {
+	LOG(INFO, "Uninitializing material");
+	_terrain = nullptr;
+}
+
+void Terrain3DMaterial::destroy() {
 	IS_INIT(VOID);
 	LOG(INFO, "Destroying material");
+	_terrain = nullptr;
 	RS->free_rid(_material);
 }
 

--- a/src/terrain_3d_material.h
+++ b/src/terrain_3d_material.h
@@ -82,8 +82,11 @@ private:
 
 public:
 	Terrain3DMaterial() {}
+	~Terrain3DMaterial() { destroy(); }
 	void initialize(Terrain3D *p_terrain);
-	~Terrain3DMaterial();
+	bool is_initialized() { return _terrain != nullptr; }
+	void uninitialize();
+	void destroy();
 
 	void update();
 	RID get_material_rid() const { return _material; }

--- a/src/terrain_3d_mesher.cpp
+++ b/src/terrain_3d_mesher.cpp
@@ -42,7 +42,7 @@ RID Terrain3DMesher::_generate_mesh(const Vector2i &p_size, const bool p_standar
 	PackedVector3Array vertices;
 	PackedInt32Array indices;
 	AABB aabb = AABB(V3_ZERO, Vector3(p_size.x, 0.1f, p_size.y));
-	LOG(DEBUG, "Generating verticies and indicies for a", p_standard_grid ? " symetric ":" standard ", "grid mesh of width: ", p_size.x, " and height: ", p_size.y);
+	LOG(DEBUG, "Generating verticies and indicies for a", p_standard_grid ? " symetric " : " standard ", "grid mesh of width: ", p_size.x, " and height: ", p_size.y);
 
 	// Generate vertices
 	for (int y = 0; y <= p_size.y; ++y) {
@@ -115,7 +115,7 @@ void Terrain3DMesher::_generate_clipmap(const int p_size, const int p_lods, cons
 	_generate_mesh_types(p_size);
 	_generate_offset_data(p_size);
 	LOG(DEBUG, "Creating instances for all mesh segments for clipmap of size ", p_size, " for ", p_lods, " LODs");
-	
+
 	for (int level = 0; level < p_lods; level++) {
 		Array lod;
 		// 12 Tiles LOD1+, 16 for LOD0
@@ -158,8 +158,8 @@ void Terrain3DMesher::_generate_clipmap(const int p_size, const int p_lods, cons
 				fill_b_rids.append(fill_b_rid);
 			}
 			lod.append(fill_b_rids); // index 5 FILL_B
-		// Trims only on LOD 0 These share the indicies of the fills for the offsets.
-		// When snapping LOD 0 Trim a/b positions are looked up instead of Fill a/b
+			// Trims only on LOD 0 These share the indicies of the fills for the offsets.
+			// When snapping LOD 0 Trim a/b positions are looked up instead of Fill a/b
 		} else {
 			Array trim_a_rids;
 			for (int i = 0; i < 2; i++) {
@@ -287,8 +287,8 @@ void Terrain3DMesher::initialize(Terrain3D *p_terrain) {
 	} else {
 		return;
 	}
-	if (_terrain->get_world_3d().is_null()) {
-		LOG(DEBUG, "Terrain3D's world3D is null")
+	if (!_terrain->is_inside_world()) {
+		LOG(DEBUG, "Terrain3D's world3D is null");
 		return;
 	}
 	LOG(INFO, "Initializing GeoMesh");
@@ -379,9 +379,9 @@ void Terrain3DMesher::snap(const Vector3 &p_tracked_pos) {
 				t = t.scaled(lod_scale);
 				t.origin += pos;
 				RS->instance_set_transform(mesh_array[instance], t);
-				#if GODOT_VERSION_MAJOR == 4 && GODOT_VERSION_MINOR == 4
+#if GODOT_VERSION_MAJOR == 4 && GODOT_VERSION_MINOR == 4
 				RS->instance_reset_physics_interpolation(mesh_array[instance]);
-				#endif
+#endif
 			}
 		}
 	}
@@ -391,7 +391,8 @@ void Terrain3DMesher::snap(const Vector3 &p_tracked_pos) {
 // Iterates over every instance of every mesh and updates all properties.
 void Terrain3DMesher::update() {
 	IS_INIT(VOID);
-	if (_terrain->get_world_3d().is_null()) {
+	if (!_terrain->is_inside_world()) {
+		LOG(DEBUG, "Terrain3D's world3D is null");
 		return;
 	}
 	bool baked_light;
@@ -453,4 +454,3 @@ void Terrain3DMesher::update_aabbs() {
 	}
 	return;
 }
-


### PR DESCRIPTION
free() doesn't free the Material Resource, so _material::_terrain is not null on subsequent reloads. Even if I unref() it in PRE_DELETE, it still retains the same instance ID on subsequent loads. Since it's a separate loadable resource, Godot keeps reloading it into set_material(). We need to uninitialize its `_terrain`. The same for assets.
