### PR TITLE
Multiple fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,6 @@ Developed for the Godot community by:
 
 And other contributors displayed on the right of the github page and in [AUTHORS.md](https://terrain3d.readthedocs.io/en/stable/docs/authors.html).
 
-Geometry clipmap mesh code created by [Mike J. Savage](https://mikejsavage.co.uk/blog/geometry-clipmaps.html). Blog and repository code released under the MIT license per email communication with Mike.
 
 ## Contributing
 

--- a/doc/api/class_terrain3d.rst
+++ b/doc/api/class_terrain3d.rst
@@ -421,7 +421,7 @@ Alias for :ref:`Terrain3DCollision.shape_size<class_Terrain3DCollision_property_
 - |void| **set_cull_margin**\ (\ value\: ``float``\ )
 - ``float`` **get_cull_margin**\ (\ )
 
-This margin is added to the vertical component of the terrain bounding box (AABB). The terrain already sets its AABB from :ref:`Terrain3DData.get_height_range<class_Terrain3DData_method_get_height_range>`, which is calculated while sculpting. This setting only needs to be used if the shader has expanded the terrain beyond the AABB and the terrain meshes are being culled at certain viewing angles. This might happen from using :ref:`Terrain3DMaterial.world_background<class_Terrain3DMaterial_property_world_background>` with NOISE and a height value larger than the terrain heights. This setting is similar to ``GeometryInstance3D.extra_cull_margin``, but it only affects the Y axis.
+This margin is added to the vertical component of the terrain bounding box (AABB). The terrain already sets its AABB from :ref:`Terrain3DData.get_height_range()<class_Terrain3DData_method_get_height_range>`, which is calculated while sculpting. This setting only needs to be used if the shader has expanded the terrain beyond the AABB and the terrain meshes are being culled at certain viewing angles. This might happen from using :ref:`Terrain3DMaterial.world_background<class_Terrain3DMaterial_property_world_background>` with NOISE and a height value larger than the terrain heights. This setting is similar to ``GeometryInstance3D.extra_cull_margin``, but it only affects the Y axis.
 
 .. rst-class:: classref-item-separator
 
@@ -488,7 +488,7 @@ The verbosity of debug messages printed to the console. Errors and warnings are 
 - |void| **set_free_editor_textures**\ (\ value\: ``bool``\ )
 - ``bool`` **get_free_editor_textures**\ (\ )
 
-Frees ground textures used for editing at the start of the game. These textures are used to generate the TextureArrays, so if you don't change any :ref:`Terrain3DTextureAsset<class_Terrain3DTextureAsset>` settings in game, this can be enabled. Calls :ref:`Terrain3DAssets.clear_textures<class_Terrain3DAssets_method_clear_textures>`.
+Frees ground textures used for editing at the start of the game. These textures are used to generate the TextureArrays, so if you don't change any :ref:`Terrain3DTextureAsset<class_Terrain3DTextureAsset>` settings in game, this can be enabled. Calls :ref:`Terrain3DAssets.clear_textures()<class_Terrain3DAssets_method_clear_textures>`.
 
 .. rst-class:: classref-item-separator
 
@@ -629,7 +629,7 @@ This variable sets the editor render layer (21-32) to be used by ``get_intersect
 
 You may place other objects on this layer, however ``get_intersection`` will report intersections with them. So either dedicate this layer to Terrain3D, or if you must use all 32 layers, dedicate this one during editing or when using ``get_intersection``, and then you can use it during game play.
 
-See :ref:`get_intersection<class_Terrain3D_method_get_intersection>`.
+See :ref:`get_intersection()<class_Terrain3D_method_get_intersection>`.
 
 .. rst-class:: classref-item-separator
 
@@ -664,6 +664,8 @@ Alias for :ref:`Terrain3DCollision.physics_material<class_Terrain3DCollision_pro
 - :ref:`RegionSize<enum_Terrain3D_RegionSize>` **get_region_size**\ (\ )
 
 The number of vertices in each region, and the number of pixels for each map in :ref:`Terrain3DRegion<class_Terrain3DRegion>`. 1 pixel always corresponds to 1 vertex. :ref:`vertex_spacing<class_Terrain3D_property_vertex_spacing>` laterally scales regions, but does not change the number of vertices or pixels in each.
+
+There is no undo for this operation. However you can apply it again to reslice, as long as your data doesn't hit the maximum boundaries.
 
 .. rst-class:: classref-item-separator
 
@@ -1059,7 +1061,7 @@ The distance between vertices. Godot units are typically considered to be meters
 
 This variable changes the global position of landscape features. A mountain peak might be at (512, 512), but with a vertex spacing of 2.0 it is now located at (1024, 1024).
 
-All Terrain3D functions with a global_position expect an absolute global value. If you would normally use :ref:`Terrain3DData.import_images<class_Terrain3DData_method_import_images>` to import an image in the region at (-1024, -1024), with a vertex_spacing of 2, you'll need to import that image at (-2048, -2048) to place it in the same region.
+All Terrain3D functions with a global_position expect an absolute global value. If you would normally use :ref:`Terrain3DData.import_images()<class_Terrain3DData_method_import_images>` to import an image in the region at (-1024, -1024), with a vertex_spacing of 2, you'll need to import that image at (-2048, -2048) to place it in the same region.
 
 To scale heights, export the height map and reimport it with a new height scale.
 

--- a/doc/api/class_terrain3dassets.rst
+++ b/doc/api/class_terrain3dassets.rst
@@ -364,7 +364,7 @@ path - specifies a directory and file name to use from now on.
 
 |void| **set_mesh_asset**\ (\ id\: ``int``, mesh\: :ref:`Terrain3DMeshAsset<class_Terrain3DMeshAsset>`\ ) :ref:`🔗<class_Terrain3DAssets_method_set_mesh_asset>`
 
-Assigns the Terrain3DMeshAsset to the specified ID slot. It can be null to clear the slot. See :ref:`set_texture<class_Terrain3DAssets_method_set_texture>`.
+Assigns the Terrain3DMeshAsset to the specified ID slot. It can be null to clear the slot. See :ref:`set_texture()<class_Terrain3DAssets_method_set_texture>`.
 
 .. rst-class:: classref-item-separator
 

--- a/doc/api/class_terrain3dcollision.rst
+++ b/doc/api/class_terrain3dcollision.rst
@@ -195,7 +195,7 @@ The selected mode determines if collision is generated and how. See :ref:`Collis
 
 Applies a ``PhysicsMaterial`` override to the StaticBody.
 
-There's no ability built into Godot to change physics material parameters based on texture or any other factor. However, it might be possible to extend `PhysicsMaterial` in order to inject code into the queries. It would need references to an object position and a terrain, and then it could run :ref:`Terrain3DData.get_texture_id<class_Terrain3DData_method_get_texture_id>` based on the position and return different physics settings per texture. That would change the settings for the entire terrain for that moment.
+There's no ability built into Godot to change physics material parameters based on texture or any other factor. However, it might be possible to extend `PhysicsMaterial` in order to inject code into the queries. It would need references to an object position and a terrain, and then it could run :ref:`Terrain3DData.get_texture_id()<class_Terrain3DData_method_get_texture_id>` based on the position and return different physics settings per texture. That would change the settings for the entire terrain for that moment.
 
 .. rst-class:: classref-item-separator
 
@@ -263,7 +263,7 @@ Method Descriptions
 
 |void| **build**\ (\ ) :ref:`🔗<class_Terrain3DCollision_method_build>`
 
-Creates collision shapes and calls :ref:`update<class_Terrain3DCollision_method_update>` to shape them. Calls :ref:`destroy<class_Terrain3DCollision_method_destroy>` first, so it is safe to call this to fully rebuild collision any time.
+Creates collision shapes and calls :ref:`update()<class_Terrain3DCollision_method_update>` to shape them. Calls :ref:`destroy()<class_Terrain3DCollision_method_destroy>` first, so it is safe to call this to fully rebuild collision any time.
 
 .. rst-class:: classref-item-separator
 
@@ -335,7 +335,7 @@ Returns true if :ref:`mode<class_Terrain3DCollision_property_mode>` is not ``Dis
 
 |void| **update**\ (\ force\: ``bool`` = false\ ) :ref:`🔗<class_Terrain3DCollision_method_update>`
 
-- If :ref:`mode<class_Terrain3DCollision_property_mode>` is Full, updates the existing collision shapes. If regions have been added or removed, set ``force`` to true or call :ref:`build<class_Terrain3DCollision_method_build>` instead. Can be slow.
+- If :ref:`mode<class_Terrain3DCollision_property_mode>` is Full, updates the existing collision shapes. If regions have been added or removed, set ``force`` to true or call :ref:`build()<class_Terrain3DCollision_method_build>` instead. Can be slow.
 
 - If :ref:`mode<class_Terrain3DCollision_property_mode>` is Dynamic, repositions collision shapes around the camera and recalculated ones not already in place, skipping those that are. Set ``force`` to true to recalculate all shapes. This is very fast, and can be updated at 60fps for little cost.
 

--- a/doc/api/class_terrain3ddata.rst
+++ b/doc/api/class_terrain3ddata.rst
@@ -407,7 +407,7 @@ The region should already be configured with the desired location and maps befor
 
 Upon saving, this region will be written to a data file stored in :ref:`Terrain3D.data_directory<class_Terrain3D_property_data_directory>`.
 
-- update - regenerates the texture arrays if true. Set to false if bulk adding many regions, then true on the last one or use :ref:`force_update_maps<class_Terrain3DData_method_force_update_maps>`.
+- update - regenerates the texture arrays if true. Set to false if bulk adding many regions, then true on the last one or use :ref:`force_update_maps()<class_Terrain3DData_method_force_update_maps>`.
 
 .. rst-class:: classref-item-separator
 
@@ -419,7 +419,7 @@ Upon saving, this region will be written to a data file stored in :ref:`Terrain3
 
 :ref:`Terrain3DRegion<class_Terrain3DRegion>` **add_region_blank**\ (\ region_location\: ``Vector2i``, update\: ``bool`` = true\ ) :ref:`🔗<class_Terrain3DData_method_add_region_blank>`
 
-Creates and adds a blank region at the specified location. See :ref:`add_region<class_Terrain3DData_method_add_region>`.
+Creates and adds a blank region at the specified location. See :ref:`add_region()<class_Terrain3DData_method_add_region>`.
 
 .. rst-class:: classref-item-separator
 
@@ -431,7 +431,7 @@ Creates and adds a blank region at the specified location. See :ref:`add_region<
 
 :ref:`Terrain3DRegion<class_Terrain3DRegion>` **add_region_blankp**\ (\ global_position\: ``Vector3``, update\: ``bool`` = true\ ) :ref:`🔗<class_Terrain3DData_method_add_region_blankp>`
 
-Creates and adds a blank region at a region location encompassing the specified global position. See :ref:`add_region<class_Terrain3DData_method_add_region>`.
+Creates and adds a blank region at a region location encompassing the specified global position. See :ref:`add_region()<class_Terrain3DData_method_add_region>`.
 
 .. rst-class:: classref-item-separator
 
@@ -445,7 +445,7 @@ Creates and adds a blank region at a region location encompassing the specified 
 
 Recalculates the master height range for the whole terrain by summing the height ranges of all active regions.
 
-Recursive mode does the same, but has each region recalculate heights from each heightmap pixel. See :ref:`Terrain3DRegion.calc_height_range<class_Terrain3DRegion_method_calc_height_range>`.
+Recursive mode does the same, but has each region recalculate heights from each heightmap pixel. See :ref:`Terrain3DRegion.calc_height_range()<class_Terrain3DRegion_method_calc_height_range>`.
 
 .. rst-class:: classref-item-separator
 
@@ -709,7 +709,7 @@ Returns the resource ID of the generated height map texture array sent to the sh
 
 ``Vector2`` **get_height_range**\ (\ ) |const| :ref:`🔗<class_Terrain3DData_method_get_height_range>`
 
-Returns the highest and lowest heights for the sculpted terrain used to set the world AABB. See :ref:`calc_height_range<class_Terrain3DData_method_calc_height_range>`.
+Returns the highest and lowest heights for the sculpted terrain used to set the world AABB. See :ref:`calc_height_range()<class_Terrain3DData_method_calc_height_range>`.
 
 Any :ref:`Terrain3DMaterial.world_background<class_Terrain3DMaterial_property_world_background>` used that extends the mesh outside of this range will not change this variable. You need to set :ref:`Terrain3D.cull_margin<class_Terrain3D_property_cull_margin>` or the renderer will clip meshes.
 
@@ -753,7 +753,7 @@ Returns the position of a terrain vertex at a certain LOD. If the position is ou
 
 ``Vector3`` **get_normal**\ (\ global_position\: ``Vector3``\ ) |const| :ref:`🔗<class_Terrain3DData_method_get_normal>`
 
-Returns the terrain normal at the specified position. This function uses :ref:`get_height<class_Terrain3DData_method_get_height>`.
+Returns the terrain normal at the specified position. This function uses :ref:`get_height()<class_Terrain3DData_method_get_height>`.
 
 Returns ``Vector3(NAN, NAN, NAN)`` if the requested position is a hole or outside of defined regions.
 
@@ -819,7 +819,7 @@ The region_id is the index into the TextureArrays sent to the shader, and can ch
 
 ``int`` **get_region_idp**\ (\ global_position\: ``Vector3``\ ) |const| :ref:`🔗<class_Terrain3DData_method_get_region_idp>`
 
-Returns the region id at a global position. See :ref:`get_region_id<class_Terrain3DData_method_get_region_id>`.
+Returns the region id at a global position. See :ref:`get_region_id()<class_Terrain3DData_method_get_region_id>`.
 
 .. rst-class:: classref-item-separator
 
@@ -831,7 +831,7 @@ Returns the region id at a global position. See :ref:`get_region_id<class_Terrai
 
 ``Vector2i`` **get_region_location**\ (\ global_position\: ``Vector3``\ ) |const| :ref:`🔗<class_Terrain3DData_method_get_region_location>`
 
-Returns the calculated region location for the given global position. This is just a calculation and does no bounds checking or verification that a region exists. See :ref:`get_region_map_index<class_Terrain3DData_method_get_region_map_index>` for bounds checking, or :ref:`has_region<class_Terrain3DData_method_has_region>` for checking existance.
+Returns the calculated region location for the given global position. This is just a calculation and does no bounds checking or verification that a region exists. See :ref:`get_region_map_index()<class_Terrain3DData_method_get_region_map_index>` for bounds checking, or :ref:`has_region()<class_Terrain3DData_method_has_region>` for checking existance.
 
 .. rst-class:: classref-item-separator
 
@@ -845,7 +845,7 @@ Returns the calculated region location for the given global position. This is ju
 
 Returns a fully populated 32 x 32 array. The array location contains the region id + 1, or 0, which means no region.
 
-See :ref:`get_region_map_index<class_Terrain3DData_method_get_region_map_index>`.
+See :ref:`get_region_map_index()<class_Terrain3DData_method_get_region_map_index>`.
 
 .. rst-class:: classref-item-separator
 
@@ -857,7 +857,7 @@ See :ref:`get_region_map_index<class_Terrain3DData_method_get_region_map_index>`
 
 ``int`` **get_region_map_index**\ (\ region_location\: ``Vector2i``\ ) |static| :ref:`🔗<class_Terrain3DData_method_get_region_map_index>`
 
-Given a region location, returns the index into the region map array. See :ref:`get_region_map<class_Terrain3DData_method_get_region_map>`.
+Given a region location, returns the index into the region map array. See :ref:`get_region_map()<class_Terrain3DData_method_get_region_map>`.
 
 You can use this function to quickly determine if a location is within the greater world bounds (-16,-16) to (15, 15). It returns -1 if not.
 
@@ -1075,7 +1075,7 @@ Marks the specified region as deleted. This deactivates it so it won't render it
 
 |void| **remove_regionl**\ (\ region_location\: ``Vector2i``, update\: ``bool`` = true\ ) :ref:`🔗<class_Terrain3DData_method_remove_regionl>`
 
-Removes the region at the specified location. See :ref:`remove_region<class_Terrain3DData_method_remove_region>`.
+Removes the region at the specified location. See :ref:`remove_region()<class_Terrain3DData_method_remove_region>`.
 
 .. rst-class:: classref-item-separator
 
@@ -1087,7 +1087,7 @@ Removes the region at the specified location. See :ref:`remove_region<class_Terr
 
 |void| **remove_regionp**\ (\ global_position\: ``Vector3``, update\: ``bool`` = true\ ) :ref:`🔗<class_Terrain3DData_method_remove_regionp>`
 
-Removes the region at the specified global_position. See :ref:`remove_region<class_Terrain3DData_method_remove_region>`.
+Removes the region at the specified global_position. See :ref:`remove_region()<class_Terrain3DData_method_remove_region>`.
 
 .. rst-class:: classref-item-separator
 
@@ -1111,7 +1111,7 @@ This saves all active regions into the specified directory.
 
 |void| **save_region**\ (\ region_location\: ``Vector2i``, directory\: ``String``, 16_bit\: ``bool`` = false\ ) :ref:`🔗<class_Terrain3DData_method_save_region>`
 
-Saves the specified active region to the directory. See :ref:`Terrain3DRegion.save<class_Terrain3DRegion_method_save>`.
+Saves the specified active region to the directory. See :ref:`Terrain3DRegion.save()<class_Terrain3DRegion_method_save>`.
 
 - region_location - the region to save.
 
@@ -1127,7 +1127,7 @@ Saves the specified active region to the directory. See :ref:`Terrain3DRegion.sa
 
 |void| **set_color**\ (\ global_position\: ``Vector3``, color\: ``Color``\ ) :ref:`🔗<class_Terrain3DData_method_set_color>`
 
-Sets the color on the color map pixel associated with the specified position. See :ref:`set_pixel<class_Terrain3DData_method_set_pixel>` for important information.
+Sets the color on the color map pixel associated with the specified position. See :ref:`set_pixel()<class_Terrain3DData_method_set_pixel>` for important information.
 
 .. rst-class:: classref-item-separator
 
@@ -1139,7 +1139,7 @@ Sets the color on the color map pixel associated with the specified position. Se
 
 |void| **set_control**\ (\ global_position\: ``Vector3``, control\: ``int``\ ) :ref:`🔗<class_Terrain3DData_method_set_control>`
 
-Sets the value on the control map pixel associated with the specified position. See :ref:`set_pixel<class_Terrain3DData_method_set_pixel>` for important information.
+Sets the value on the control map pixel associated with the specified position. See :ref:`set_pixel()<class_Terrain3DData_method_set_pixel>` for important information.
 
 .. rst-class:: classref-item-separator
 
@@ -1153,7 +1153,7 @@ Sets the value on the control map pixel associated with the specified position. 
 
 Sets the angle, aka uv rotation, on the control map at the requested position. Values are rounded to the nearest 22.5 degree interval, for a maximum of 16 angles. 360 / 16 = 22.5.
 
-See :ref:`set_pixel<class_Terrain3DData_method_set_pixel>` for important information.
+See :ref:`set_pixel()<class_Terrain3DData_method_set_pixel>` for important information.
 
 .. rst-class:: classref-item-separator
 
@@ -1167,7 +1167,7 @@ See :ref:`set_pixel<class_Terrain3DData_method_set_pixel>` for important informa
 
 Sets if the material should render the autoshader or manual texturing on the control map at the requested position.
 
-See :ref:`set_pixel<class_Terrain3DData_method_set_pixel>` for important information.
+See :ref:`set_pixel()<class_Terrain3DData_method_set_pixel>` for important information.
 
 .. rst-class:: classref-item-separator
 
@@ -1181,7 +1181,7 @@ See :ref:`set_pixel<class_Terrain3DData_method_set_pixel>` for important informa
 
 Sets the base texture ID on the control map at the requested position. Values are clamped to 0 - 31, matching the ID of the texture asset in the asset dock.
 
-See :ref:`set_pixel<class_Terrain3DData_method_set_pixel>` for important information.
+See :ref:`set_pixel()<class_Terrain3DData_method_set_pixel>` for important information.
 
 .. rst-class:: classref-item-separator
 
@@ -1195,7 +1195,7 @@ See :ref:`set_pixel<class_Terrain3DData_method_set_pixel>` for important informa
 
 Sets the blend value between the base texture ID, and the overlay texture ID. The value is clamped between 0.0 - 1.0 where 0.0 shows only the base texture, and 1.0 shows only the overlay texture.
 
-See :ref:`set_pixel<class_Terrain3DData_method_set_pixel>` for important information.
+See :ref:`set_pixel()<class_Terrain3DData_method_set_pixel>` for important information.
 
 .. rst-class:: classref-item-separator
 
@@ -1207,7 +1207,7 @@ See :ref:`set_pixel<class_Terrain3DData_method_set_pixel>` for important informa
 
 |void| **set_control_hole**\ (\ global_position\: ``Vector3``, enable\: ``bool``\ ) :ref:`🔗<class_Terrain3DData_method_set_control_hole>`
 
-Sets if a hole should be rendered on the control map at the requested position. See :ref:`set_pixel<class_Terrain3DData_method_set_pixel>` for important information.
+Sets if a hole should be rendered on the control map at the requested position. See :ref:`set_pixel()<class_Terrain3DData_method_set_pixel>` for important information.
 
 .. rst-class:: classref-item-separator
 
@@ -1219,7 +1219,7 @@ Sets if a hole should be rendered on the control map at the requested position. 
 
 |void| **set_control_navigation**\ (\ global_position\: ``Vector3``, enable\: ``bool``\ ) :ref:`🔗<class_Terrain3DData_method_set_control_navigation>`
 
-Sets if navigation generation is enabled on the control map at the requested position. See :ref:`set_pixel<class_Terrain3DData_method_set_pixel>` for important information.
+Sets if navigation generation is enabled on the control map at the requested position. See :ref:`set_pixel()<class_Terrain3DData_method_set_pixel>` for important information.
 
 .. rst-class:: classref-item-separator
 
@@ -1233,7 +1233,7 @@ Sets if navigation generation is enabled on the control map at the requested pos
 
 Sets the overlay texture ID on the control map at the requested position. Values are clamped to 0 - 31, matching the ID of the texture asset in the asset dock.
 
-See :ref:`set_pixel<class_Terrain3DData_method_set_pixel>` for important information.
+See :ref:`set_pixel()<class_Terrain3DData_method_set_pixel>` for important information.
 
 .. rst-class:: classref-item-separator
 
@@ -1247,7 +1247,7 @@ See :ref:`set_pixel<class_Terrain3DData_method_set_pixel>` for important informa
 
 Sets the uv scale on the control map at the requested position. The value is rounded to the nearest 20% difference from 100%, ranging between -60% to +80%.
 
-See :ref:`set_pixel<class_Terrain3DData_method_set_pixel>` for important information.
+See :ref:`set_pixel()<class_Terrain3DData_method_set_pixel>` for important information.
 
 .. rst-class:: classref-item-separator
 
@@ -1259,9 +1259,9 @@ See :ref:`set_pixel<class_Terrain3DData_method_set_pixel>` for important informa
 
 |void| **set_height**\ (\ global_position\: ``Vector3``, height\: ``float``\ ) :ref:`🔗<class_Terrain3DData_method_set_height>`
 
-Sets the height value on the heightmap pixel associated with the specified position. See :ref:`set_pixel<class_Terrain3DData_method_set_pixel>` for important information.
+Sets the height value on the heightmap pixel associated with the specified position. See :ref:`set_pixel()<class_Terrain3DData_method_set_pixel>` for important information.
 
-Unlike :ref:`get_height<class_Terrain3DData_method_get_height>`, which interpolates between vertices, this function does not and will set the pixel at floored coordinates.
+Unlike :ref:`get_height()<class_Terrain3DData_method_get_height>`, which interpolates between vertices, this function does not and will set the pixel at floored coordinates.
 
 .. rst-class:: classref-item-separator
 
@@ -1273,9 +1273,9 @@ Unlike :ref:`get_height<class_Terrain3DData_method_get_height>`, which interpola
 
 |void| **set_pixel**\ (\ map_type\: :ref:`MapType<enum_Terrain3DRegion_MapType>`, global_position\: ``Vector3``, pixel\: ``Color``\ ) :ref:`🔗<class_Terrain3DData_method_set_pixel>`
 
-Sets the pixel for the map type associated with the specified position. This method is fine for setting a few pixels, but if you wish to modify thousands of pixels quickly, you should get the region and use :ref:`Terrain3DRegion.get_map<class_Terrain3DRegion_method_get_map>`, then edit the images directly.
+Sets the pixel for the map type associated with the specified position. This method is fine for setting a few pixels, but if you wish to modify thousands of pixels quickly, you should get the region and use :ref:`Terrain3DRegion.get_map()<class_Terrain3DRegion_method_get_map>`, then edit the images directly.
 
-After setting pixels you need to call :ref:`force_update_maps<class_Terrain3DData_method_force_update_maps>`. You may also need to regenerate collision if you don't have dynamic collision enabled.
+After setting pixels you need to call :ref:`force_update_maps()<class_Terrain3DData_method_force_update_maps>`. You may also need to regenerate collision if you don't have dynamic collision enabled.
 
 .. rst-class:: classref-item-separator
 
@@ -1311,7 +1311,7 @@ Sets the region as modified. It will be written to disk when saved. Syntactic su
 
 |void| **set_roughness**\ (\ global_position\: ``Vector3``, roughness\: ``float``\ ) :ref:`🔗<class_Terrain3DData_method_set_roughness>`
 
-Sets the roughness modifier (wetness) on the color map alpha channel associated with the specified position. See :ref:`set_pixel<class_Terrain3DData_method_set_pixel>` for important information.
+Sets the roughness modifier (wetness) on the color map alpha channel associated with the specified position. See :ref:`set_pixel()<class_Terrain3DData_method_set_pixel>` for important information.
 
 .. |virtual| replace:: :abbr:`virtual (This method should typically be overridden by the user to have any effect.)`
 .. |const| replace:: :abbr:`const (This method has no side effects. It doesn't modify any of the instance's member variables.)`

--- a/doc/api/class_terrain3deditor.rst
+++ b/doc/api/class_terrain3deditor.rst
@@ -263,7 +263,7 @@ Undo the previous changes, with the provided data. Used by Godot, not gamedevs.
 
 |void| **backup_region**\ (\ region\: :ref:`Terrain3DRegion<class_Terrain3DRegion>`\ ) :ref:`🔗<class_Terrain3DEditor_method_backup_region>`
 
-Adds a region to the currently pending operation undo snapshot. :ref:`is_operating<class_Terrain3DEditor_method_is_operating>` must be true.
+Adds a region to the currently pending operation undo snapshot. :ref:`is_operating()<class_Terrain3DEditor_method_is_operating>` must be true.
 
 .. rst-class:: classref-item-separator
 

--- a/doc/api/class_terrain3dinstancer.rst
+++ b/doc/api/class_terrain3dinstancer.rst
@@ -23,23 +23,23 @@ Data is currently stored in :ref:`Terrain3DRegion.instances<class_Terrain3DRegio
 
 \ **The methods available for adding instances are:**\ 
 
-- :ref:`add_transforms<class_Terrain3DInstancer_method_add_transforms>` - Accepts your list of transforms and parses them by region and cell location and stores in our data storage. Recommended for general API instancing.
+- :ref:`add_transforms()<class_Terrain3DInstancer_method_add_transforms>` - Accepts your list of transforms and parses them by region and cell location and stores in our data storage. Recommended for general API instancing.
 
-- :ref:`add_multimesh<class_Terrain3DInstancer_method_add_multimesh>` - Pulls the transforms out of your MultiMesh and calls add_transforms.
+- :ref:`add_multimesh()<class_Terrain3DInstancer_method_add_multimesh>` - Pulls the transforms out of your MultiMesh and calls add_transforms.
 
-- :ref:`add_instances<class_Terrain3DInstancer_method_add_instances>` - A feature rich function designed for hand editing via Terrain3DEditor.
+- :ref:`add_instances()<class_Terrain3DInstancer_method_add_instances>` - A feature rich function designed for hand editing via Terrain3DEditor.
 
 - Creating your own instance data and inserting it directly into :ref:`Terrain3DRegion.instances<class_Terrain3DRegion_property_instances>`. It's not difficult to do this in GDScript, but a thorough understanding of the C++ code in this class is recommended.
 
 \ **The methods available for removing instances are:**\ 
 
-- :ref:`remove_instances<class_Terrain3DInstancer_method_remove_instances>` - Like add_instances, this is can be used procedurally but is designed for hand editing.
+- :ref:`remove_instances()<class_Terrain3DInstancer_method_remove_instances>` - Like add_instances, this is can be used procedurally but is designed for hand editing.
 
-- :ref:`clear_by_mesh<class_Terrain3DInstancer_method_clear_by_mesh>`, :ref:`clear_by_location<class_Terrain3DInstancer_method_clear_by_location>` - To erase large sections of instances
+- :ref:`clear_by_mesh()<class_Terrain3DInstancer_method_clear_by_mesh>`, :ref:`clear_by_location()<class_Terrain3DInstancer_method_clear_by_location>` - To erase large sections of instances
 
 - Editing :ref:`Terrain3DRegion.instances<class_Terrain3DRegion_property_instances>` directly.
 
-After modifying region data, run :ref:`force_update_mmis<class_Terrain3DInstancer_method_force_update_mmis>` to rebuild the MultiMeshInstance3Ds.
+After modifying region data, run :ref:`force_update_mmis()<class_Terrain3DInstancer_method_force_update_mmis>` to rebuild the MultiMeshInstance3Ds.
 
 \ **Read More:**\ 
 
@@ -112,7 +112,7 @@ Used by Terrain3DEditor to place instances given many brush parameters. In addit
 
 |void| **add_multimesh**\ (\ mesh_id\: ``int``, multimesh\: ``MultiMesh``, transform\: ``Transform3D`` = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 0, 0, 0), update\: ``bool`` = true\ ) :ref:`🔗<class_Terrain3DInstancer_method_add_multimesh>`
 
-Allows procedural placement of meshes, or importing from another MultiMeshInstancer placement tool. The specified mesh_id should already be setup as a :ref:`Terrain3DMeshAsset<class_Terrain3DMeshAsset>` in the asset dock. This function extracts the instance transforms and colors from a multimesh and passes it to :ref:`add_transforms<class_Terrain3DInstancer_method_add_transforms>`.
+Allows procedural placement of meshes, or importing from another MultiMeshInstancer placement tool. The specified mesh_id should already be setup as a :ref:`Terrain3DMeshAsset<class_Terrain3DMeshAsset>` in the asset dock. This function extracts the instance transforms and colors from a multimesh and passes it to :ref:`add_transforms()<class_Terrain3DInstancer_method_add_transforms>`.
 
 Update will regenerate the MultiMeshInstances. Disable for bulk adding, then call at the end.
 

--- a/doc/api/class_terrain3dmaterial.rst
+++ b/doc/api/class_terrain3dmaterial.rst
@@ -36,7 +36,7 @@ Properties
    +------------------------------------------------------------------+------------------------------------------------------------------------------------------+-----------+
    | ``Dictionary``                                                   | :ref:`_shader_parameters<class_Terrain3DMaterial_property__shader_parameters>`           | ``{}``    |
    +------------------------------------------------------------------+------------------------------------------------------------------------------------------+-----------+
-   | ``bool``                                                         | :ref:`auto_shader<class_Terrain3DMaterial_property_auto_shader>`                         | ``false`` |
+   | ``bool``                                                         | :ref:`auto_shader<class_Terrain3DMaterial_property_auto_shader>`                         | ``true``  |
    +------------------------------------------------------------------+------------------------------------------------------------------------------------------+-----------+
    | ``bool``                                                         | :ref:`dual_scaling<class_Terrain3DMaterial_property_dual_scaling>`                       | ``false`` |
    +------------------------------------------------------------------+------------------------------------------------------------------------------------------+-----------+
@@ -195,7 +195,7 @@ This private dictionary stores all of the shader parameters in the resource. It 
 
 .. rst-class:: classref-property
 
-``bool`` **auto_shader** = ``false`` :ref:`🔗<class_Terrain3DMaterial_property_auto_shader>`
+``bool`` **auto_shader** = ``true`` :ref:`🔗<class_Terrain3DMaterial_property_auto_shader>`
 
 .. rst-class:: classref-property-setget
 

--- a/doc/api/class_terrain3dregion.rst
+++ b/doc/api/class_terrain3dregion.rst
@@ -202,7 +202,7 @@ However, we interpret these images as format: `RenderingDevice.DATA_FORMAT_R32_U
 - |void| **set_deleted**\ (\ value\: ``bool``\ )
 - ``bool`` **is_deleted**\ (\ )
 
-This region is marked for deletion. It won't be rendered once :ref:`Terrain3DData.force_update_maps<class_Terrain3DData_method_force_update_maps>` rebuilds the map index. The file will be deleted from disk on :ref:`save<class_Terrain3DRegion_method_save>`.
+This region is marked for deletion. It won't be rendered once :ref:`Terrain3DData.force_update_maps()<class_Terrain3DData_method_force_update_maps>` rebuilds the map index. The file will be deleted from disk on :ref:`save()<class_Terrain3DRegion_method_save>`.
 
 .. rst-class:: classref-item-separator
 
@@ -259,7 +259,7 @@ Editing is always done in 32-bit. We do provide an option to save as 16-bit, see
 - |void| **set_height_range**\ (\ value\: ``Vector2``\ )
 - ``Vector2`` **get_height_range**\ (\ )
 
-The current minimum and maximum height range for this region, used to calculate the AABB of the terrain. Update it with :ref:`update_height<class_Terrain3DRegion_method_update_height>`, and recalculate it with :ref:`calc_height_range<class_Terrain3DRegion_method_calc_height_range>`.
+The current minimum and maximum height range for this region, used to calculate the AABB of the terrain. Update it with :ref:`update_height()<class_Terrain3DRegion_method_update_height>`, and recalculate it with :ref:`calc_height_range()<class_Terrain3DRegion_method_calc_height_range>`.
 
 .. rst-class:: classref-item-separator
 
@@ -292,7 +292,7 @@ The format is instances{mesh_id:int} -> cells{grid_location:Vector2i} -> ( Array
 
 - 2: A bool that tracks if this cell has been modified
 
-After changing this data, :ref:`Terrain3DInstancer.force_update_mmis<class_Terrain3DInstancer_method_force_update_mmis>` should be called to rebuild the MMIs.
+After changing this data, :ref:`Terrain3DInstancer.force_update_mmis()<class_Terrain3DInstancer_method_force_update_mmis>` should be called to rebuild the MMIs.
 
 .. rst-class:: classref-item-separator
 
@@ -468,7 +468,7 @@ Validates and adjusts the map size and format if possible, or creates a usable b
 
 |void| **sanitize_maps**\ (\ ) :ref:`🔗<class_Terrain3DRegion_method_sanitize_maps>`
 
-Sanitizes all map types. See :ref:`sanitize_map<class_Terrain3DRegion_method_sanitize_map>`.
+Sanitizes all map types. See :ref:`sanitize_map()<class_Terrain3DRegion_method_sanitize_map>`.
 
 .. rst-class:: classref-item-separator
 

--- a/doc/api/class_terrain3dutil.rst
+++ b/doc/api/class_terrain3dutil.rst
@@ -124,7 +124,7 @@ This function does not convert integer values to float values (e.g. 4 -> 4.0). I
 
 \ ``my_float == util.as_float(util.as_uint(my_float))``\ 
 
-See :ref:`as_uint<class_Terrain3DUtil_method_as_uint>` for the opposite.
+See :ref:`as_uint()<class_Terrain3DUtil_method_as_uint>` for the opposite.
 
 .. rst-class:: classref-item-separator
 
@@ -142,7 +142,7 @@ This function does not convert float values to integer values (e.g. 4.0 -> 4). I
 
 \ ``my_int == util.as_uint(util.as_float(my_int))``\ 
 
-See :ref:`as_float<class_Terrain3DUtil_method_as_float>` for the opposite.
+See :ref:`as_float()<class_Terrain3DUtil_method_as_float>` for the opposite.
 
 .. rst-class:: classref-item-separator
 
@@ -238,7 +238,7 @@ Returns a control map uint with the overlay texture ID encoded. See the top desc
 
 ``int`` **enc_uv_rotation**\ (\ rotation\: ``int``\ ) |static| :ref:`🔗<class_Terrain3DUtil_method_enc_uv_rotation>`
 
-Returns a control map uint with the texture rotation encoded. See the top description for usage.  See :ref:`get_uv_rotation<class_Terrain3DUtil_method_get_uv_rotation>` for values.
+Returns a control map uint with the texture rotation encoded. See the top description for usage.  See :ref:`get_uv_rotation()<class_Terrain3DUtil_method_get_uv_rotation>` for values.
 
 .. rst-class:: classref-item-separator
 
@@ -250,7 +250,7 @@ Returns a control map uint with the texture rotation encoded. See the top descri
 
 ``int`` **enc_uv_scale**\ (\ scale\: ``int``\ ) |static| :ref:`🔗<class_Terrain3DUtil_method_enc_uv_scale>`
 
-Returns a control map uint with the texture scale encoded. See the top description for usage. See :ref:`get_uv_scale<class_Terrain3DUtil_method_get_uv_scale>` for values.
+Returns a control map uint with the texture scale encoded. See the top description for usage. See :ref:`get_uv_scale()<class_Terrain3DUtil_method_get_uv_scale>` for values.
 
 .. rst-class:: classref-item-separator
 

--- a/doc/doc_classes/Terrain3D.xml
+++ b/doc/doc_classes/Terrain3D.xml
@@ -186,6 +186,7 @@
 		</member>
 		<member name="region_size" type="int" setter="change_region_size" getter="get_region_size" enum="Terrain3D.RegionSize" default="256">
 			The number of vertices in each region, and the number of pixels for each map in [Terrain3DRegion]. 1 pixel always corresponds to 1 vertex. [member Terrain3D.vertex_spacing] laterally scales regions, but does not change the number of vertices or pixels in each.
+			There is no undo for this operation. However you can apply it again to reslice, as long as your data doesn't hit the maximum boundaries.
 		</member>
 		<member name="render_layers" type="int" setter="set_render_layers" getter="get_render_layers" default="2147483649">
 			The render layers the terrain is drawn on. This sets [code skip-lint]VisualInstance3D.layers[/code] in the engine. The defaults is layer 1 and 32 (for the mouse cursor). When you set this, make sure the layer for [member mouse_layer] is included, or set that variable again after this so that the mouse cursor works.

--- a/doc/doc_classes/Terrain3DMaterial.xml
+++ b/doc/doc_classes/Terrain3DMaterial.xml
@@ -57,7 +57,7 @@
 		<member name="_shader_parameters" type="Dictionary" setter="_set_shader_parameters" getter="_get_shader_parameters" default="{}">
 			This private dictionary stores all of the shader parameters in the resource. It is not a cache.
 		</member>
-		<member name="auto_shader" type="bool" setter="set_auto_shader" getter="get_auto_shader" default="false">
+		<member name="auto_shader" type="bool" setter="set_auto_shader" getter="get_auto_shader" default="true">
 			Enables selecting two texture IDs that will automatically be applied to the terrain based upon slope.
 		</member>
 		<member name="dual_scaling" type="bool" setter="set_dual_scaling" getter="get_dual_scaling" default="false">

--- a/doc/docs/games.md
+++ b/doc/docs/games.md
@@ -9,7 +9,7 @@ Terrain3D is being used in the following games. To add yours, submit it to the #
 | [Memora Wanderer](https://store.steampowered.com/app/2937690/Memora_Wanderer/) | [Maytch](https://twitter.com/Maytch) | Cute nostalgic RPG
 | [Black Pellet](https://www.kickstarter.com/projects/raiseledwards/black-pellet) | [BlackPelletGame](https://x.com/BlackPelletGame) | Claymation, Western, TPS, Open world, Action-adventure
 | [No Gasoline](https://store.steampowered.com/app/2835350/No_Gasoline/) | [Mount Retro](https://twitter.com/mountretro) | Co-Op/Solo, Adventure-Simulation-Puzzle
-| [RotorSim](https://immaculate-lift-studio.itch.io/godot-flight-simulator-alpha) | [Immaculate Lift](https://www.youtube.com/channel/UC-9JixNs1FFE6T5DGwZ6O5Q) | Retro helicopter simulation
+| [RotorSim](https://store.steampowered.com/app/3376070/RotorSim_Helicopter_Simulator/) | [Immaculate Lift](https://immaculate-lift-studio.github.io/studio-site/) | Retro helicopter simulation
 | [B&E Ski](https://www.youtube.com/watch?v=pD8Ea3utz9o) | [Penguin Milk](https://bande.ski/) | Skiing game
 | [Sacred Forest](https://store.steampowered.com/app/2864350/Sacred_Forest/) | [Blekoh](https://www.youtube.com/@sacredforestgame) | Open world 3D pixel art RPG
 | [Pest Apocalypse](https://store.steampowered.com/app/2506810/Pest_Apocalypse/) | [Kikimora Games](https://x.com/KikimoraGames) | Post-apocalyptic pizza delivery

--- a/doc/docs/system_architecture.md
+++ b/doc/docs/system_architecture.md
@@ -4,13 +4,13 @@ System Architecture
 ## Geometry Clipmap Terrain
 Some terrain systems generate a grid of mesh chunks, centered around the camera. As the camera moves forward, old meshes far behind are destroyed and new meshes in front are created.
 
-Like The Witcher 3, this system uses a geometry clipmap, where the mesh components are generated once, and at periodic intervals are centered on the camera location. On each update, the vertex heights of the mesh components are adjusted by the GPU in the vertex shader, by reading from the terrain heightmap. Levels of Detail (LODs) are built into the mesh generated on startup, so don't require any additional consideration once placed. Lower detail levels are automatically placed far away once all mesh components are recentered on the camera. See Mike Savage's blog for visual examples.
+Like The Witcher 3, this system uses a geometry clipmap, where the mesh components are generated once, and at periodic intervals are centered on the camera location. On each update, the vertex heights of the mesh components are adjusted by the GPU in the vertex shader, by reading from the terrain heightmap. Levels of Detail (LODs) are built into the mesh generated on startup, so don't require any additional consideration once placed. Lower detail levels are automatically placed far away once all mesh components are recentered on the camera. See Mike Savage's excellent blog below for visual examples and further explanations on the technique.
 
 We provide a system where one can allocate regions for sculpting and texturing and only pay the VRAM and storage costs for only the areas used. Think of a world that takes up 16k x 16k, but has multiple small islands. Rather than pay for 16k, our system requires only allocates memory for the regions that contain the islands. The space in between can be flat, hidden, or have collision-less shader generated noise.
 
 
 ### Reference Material
-* Mike J. Savage: [Geometry clipmaps: simple terrain rendering with level of detail](https://mikejsavage.co.uk/blog/geometry-clipmaps.html)
+* Mike J. Savage: [Geometry clipmaps: simple terrain rendering with level of detail](https://mikejsavage.co.uk/blog/geometry-clipmaps.html). Earlier versions of Terrain3D used Mike's implementation. Blog and repository code released under the MIT license per email communication with Mike. 
 
 * NVidia GPU Gems 2: [Terrain Rendering Using GPU-Based Geometry Clipmaps](https://developer.nvidia.com/gpugems/gpugems2/part-i-geometric-complexity/chapter-2-terrain-rendering-using-gpu-based-geometry)
 

--- a/project/addons/terrain_3d/src/editor_plugin.gd
+++ b/project/addons/terrain_3d/src/editor_plugin.gd
@@ -186,7 +186,7 @@ func _forward_3d_gui_input(p_viewport_camera: Camera3D, p_event: InputEvent) -> 
 	#Else look for intersection with terrain
 		var intersection_point: Vector3 = terrain.get_intersection(camera_pos, camera_dir, true)
 		if intersection_point.z > 3.4e38 or is_nan(intersection_point.y): # max double or nan
-			return AFTER_GUI_INPUT_STOP
+			return AFTER_GUI_INPUT_PASS
 		mouse_global_position = intersection_point
 	
 	## Handle mouse movement

--- a/src/terrain_3d.cpp
+++ b/src/terrain_3d.cpp
@@ -435,13 +435,17 @@ void Terrain3D::set_debug_level(const int p_level) {
 void Terrain3D::set_data_directory(String p_dir) {
 	LOG(INFO, "Setting data directory to ", p_dir);
 	if (_data_directory != p_dir) {
-		_initialized = false;
-		_destroy_labels();
-		_destroy_collision();
-		_destroy_instancer();
-		memdelete_safely(_data);
-		_data_directory = p_dir;
-		_initialize();
+		if (_data_directory.is_empty()) {
+			_data_directory = p_dir;
+		} else {
+			_initialized = false;
+			_destroy_labels();
+			_destroy_collision();
+			_destroy_instancer();
+			memdelete_safely(_data);
+			_data_directory = p_dir;
+			_initialize();
+		}
 	}
 	update_configuration_warnings();
 }

--- a/src/terrain_3d_collision.cpp
+++ b/src/terrain_3d_collision.cpp
@@ -416,9 +416,10 @@ void Terrain3DCollision::destroy() {
 
 	// Physics Server
 	if (_static_body_rid.is_valid()) {
-		for (int i = 0; i < PS->body_get_shape_count(_static_body_rid); i++) {
-			RID rid = PS->body_get_shape(_static_body_rid, i);
-			LOG(DEBUG, "Freeing CollisionShape RID ", i);
+		// Shape IDs change as they are freed, so it's not safe to iterate over them while freeing.
+		while (PS->body_get_shape_count(_static_body_rid) > 0) {
+			RID rid = PS->body_get_shape(_static_body_rid, 0);
+			LOG(DEBUG, "Freeing CollisionShape RID ", rid);
 			PS->free_rid(rid);
 		}
 

--- a/src/terrain_3d_material.h
+++ b/src/terrain_3d_material.h
@@ -44,8 +44,8 @@ private:
 	// Material Features
 	WorldBackground _world_background = FLAT;
 	TextureFiltering _texture_filtering = LINEAR;
-	bool _auto_shader = false;
 	bool _dual_scaling = false;
+	bool _auto_shader = true;
 
 	// Editor Functions / Debug views
 	bool _show_navigation = false;


### PR DESCRIPTION
Fixes the following:
* If you sculpt into the camera, you can no longer move the camera.
* Material autoshader/~~dual scaling~~ disabled by default
* Make a new terrain, Sculpt data, then specify a dir and it erases what you've sculpted.
* Some Collision shape RIDs weren't freed because its not safe to iterate over them while freeing.
* Updates docs

Fixes #638 