### PR TITLE
Consolidate force_update*, update_* and expose more options

### DIFF
--- a/doc/api/class_terrain3dcollision.rst
+++ b/doc/api/class_terrain3dcollision.rst
@@ -337,7 +337,7 @@ Returns true if :ref:`mode<class_Terrain3DCollision_property_mode>` is not ``Dis
 
 - If :ref:`mode<class_Terrain3DCollision_property_mode>` is Full, updates the existing collision shapes. If regions have been added or removed, set ``force`` to true or call :ref:`build()<class_Terrain3DCollision_method_build>` instead. Can be slow.
 
-- If :ref:`mode<class_Terrain3DCollision_property_mode>` is Dynamic, repositions collision shapes around the camera and recalculated ones not already in place, skipping those that are. Set ``force`` to true to recalculate all shapes. This is very fast, and can be updated at 60fps for little cost.
+- If :ref:`mode<class_Terrain3DCollision_property_mode>` is Dynamic, repositions collision shapes around the camera and recalculates ones that moved. Set ``force`` to true to recalculate all shapes. This is very fast, and can be updated at 60fps for little cost.
 
 .. |virtual| replace:: :abbr:`virtual (This method should typically be overridden by the user to have any effect.)`
 .. |const| replace:: :abbr:`const (This method has no side effects. It doesn't modify any of the instance's member variables.)`

--- a/doc/api/class_terrain3dcollision.rst
+++ b/doc/api/class_terrain3dcollision.rst
@@ -51,21 +51,21 @@ Methods
 .. table::
    :widths: auto
 
-   +----------+---------------------------------------------------------------------------------------+
-   | |void|   | :ref:`build<class_Terrain3DCollision_method_build>`\ (\ )                             |
-   +----------+---------------------------------------------------------------------------------------+
-   | |void|   | :ref:`destroy<class_Terrain3DCollision_method_destroy>`\ (\ )                         |
-   +----------+---------------------------------------------------------------------------------------+
-   | ``RID``  | :ref:`get_rid<class_Terrain3DCollision_method_get_rid>`\ (\ ) |const|                 |
-   +----------+---------------------------------------------------------------------------------------+
-   | ``bool`` | :ref:`is_dynamic_mode<class_Terrain3DCollision_method_is_dynamic_mode>`\ (\ ) |const| |
-   +----------+---------------------------------------------------------------------------------------+
-   | ``bool`` | :ref:`is_editor_mode<class_Terrain3DCollision_method_is_editor_mode>`\ (\ ) |const|   |
-   +----------+---------------------------------------------------------------------------------------+
-   | ``bool`` | :ref:`is_enabled<class_Terrain3DCollision_method_is_enabled>`\ (\ ) |const|           |
-   +----------+---------------------------------------------------------------------------------------+
-   | |void|   | :ref:`update<class_Terrain3DCollision_method_update>`\ (\ force\: ``bool`` = false\ ) |
-   +----------+---------------------------------------------------------------------------------------+
+   +----------+-----------------------------------------------------------------------------------------+
+   | |void|   | :ref:`build<class_Terrain3DCollision_method_build>`\ (\ )                               |
+   +----------+-----------------------------------------------------------------------------------------+
+   | |void|   | :ref:`destroy<class_Terrain3DCollision_method_destroy>`\ (\ )                           |
+   +----------+-----------------------------------------------------------------------------------------+
+   | ``RID``  | :ref:`get_rid<class_Terrain3DCollision_method_get_rid>`\ (\ ) |const|                   |
+   +----------+-----------------------------------------------------------------------------------------+
+   | ``bool`` | :ref:`is_dynamic_mode<class_Terrain3DCollision_method_is_dynamic_mode>`\ (\ ) |const|   |
+   +----------+-----------------------------------------------------------------------------------------+
+   | ``bool`` | :ref:`is_editor_mode<class_Terrain3DCollision_method_is_editor_mode>`\ (\ ) |const|     |
+   +----------+-----------------------------------------------------------------------------------------+
+   | ``bool`` | :ref:`is_enabled<class_Terrain3DCollision_method_is_enabled>`\ (\ ) |const|             |
+   +----------+-----------------------------------------------------------------------------------------+
+   | |void|   | :ref:`update<class_Terrain3DCollision_method_update>`\ (\ rebuild\: ``bool`` = false\ ) |
+   +----------+-----------------------------------------------------------------------------------------+
 
 .. rst-class:: classref-section-separator
 
@@ -333,11 +333,11 @@ Returns true if :ref:`mode<class_Terrain3DCollision_property_mode>` is not ``Dis
 
 .. rst-class:: classref-method
 
-|void| **update**\ (\ force\: ``bool`` = false\ ) :ref:`🔗<class_Terrain3DCollision_method_update>`
+|void| **update**\ (\ rebuild\: ``bool`` = false\ ) :ref:`🔗<class_Terrain3DCollision_method_update>`
 
-- If :ref:`mode<class_Terrain3DCollision_property_mode>` is Full, updates the existing collision shapes. If regions have been added or removed, set ``force`` to true or call :ref:`build()<class_Terrain3DCollision_method_build>` instead. Can be slow.
+- If :ref:`mode<class_Terrain3DCollision_property_mode>` is Full, recalculates the existing collision shapes. If regions have been added or removed, set ``rebuild`` to true or call :ref:`build()<class_Terrain3DCollision_method_build>` instead. Can be slow.
 
-- If :ref:`mode<class_Terrain3DCollision_property_mode>` is Dynamic, repositions collision shapes around the camera and recalculates ones that moved. Set ``force`` to true to recalculate all shapes. This is very fast, and can be updated at 60fps for little cost.
+- If :ref:`mode<class_Terrain3DCollision_property_mode>` is Dynamic, repositions collision shapes around the camera and recalculates ones that moved. Set ``rebuild`` to true to recalculate all shapes within :ref:`radius<class_Terrain3DCollision_property_radius>`. This is very fast, and can be updated at 60fps for little cost.
 
 .. |virtual| replace:: :abbr:`virtual (This method should typically be overridden by the user to have any effect.)`
 .. |const| replace:: :abbr:`const (This method has no side effects. It doesn't modify any of the instance's member variables.)`

--- a/doc/api/class_terrain3deditor.rst
+++ b/doc/api/class_terrain3deditor.rst
@@ -383,7 +383,7 @@ Sets the tool selected in the editor plugin.
 
 |void| **start_operation**\ (\ position\: ``Vector3``\ ) :ref:`🔗<class_Terrain3DEditor_method_start_operation>`
 
-Begin a sculpting or painting operation.
+Begin a sculpting or painting operation. Prepares to create an undo/redo commit.
 
 .. rst-class:: classref-item-separator
 
@@ -395,7 +395,7 @@ Begin a sculpting or painting operation.
 
 |void| **stop_operation**\ (\ ) :ref:`🔗<class_Terrain3DEditor_method_stop_operation>`
 
-End a sculpting or painting operation.
+End a sculpting or painting operation. Commits any regions marked with :ref:`Terrain3DRegion.edited<class_Terrain3DRegion_property_edited>` in the undo/redo system and clears that flag.
 
 .. |virtual| replace:: :abbr:`virtual (This method should typically be overridden by the user to have any effect.)`
 .. |const| replace:: :abbr:`const (This method has no side effects. It doesn't modify any of the instance's member variables.)`

--- a/doc/api/class_terrain3dinstancer.rst
+++ b/doc/api/class_terrain3dinstancer.rst
@@ -39,7 +39,7 @@ Data is currently stored in :ref:`Terrain3DRegion.instances<class_Terrain3DRegio
 
 - Editing :ref:`Terrain3DRegion.instances<class_Terrain3DRegion_property_instances>` directly.
 
-After modifying region data, run :ref:`force_update_mmis()<class_Terrain3DInstancer_method_force_update_mmis>` to rebuild the MultiMeshInstance3Ds.
+After modifying region data, run :ref:`update_mmis()<class_Terrain3DInstancer_method_update_mmis>` to rebuild the MultiMeshInstance3Ds.
 
 \ **Read More:**\ 
 
@@ -76,11 +76,11 @@ Methods
    +--------+--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
    | |void| | :ref:`dump_mmis<class_Terrain3DInstancer_method_dump_mmis>`\ (\ )                                                                                                                                                                                                        |
    +--------+--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
-   | |void| | :ref:`force_update_mmis<class_Terrain3DInstancer_method_force_update_mmis>`\ (\ )                                                                                                                                                                                        |
-   +--------+--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
    | |void| | :ref:`remove_instances<class_Terrain3DInstancer_method_remove_instances>`\ (\ global_position\: ``Vector3``, params\: ``Dictionary``\ )                                                                                                                                  |
    +--------+--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
    | |void| | :ref:`swap_ids<class_Terrain3DInstancer_method_swap_ids>`\ (\ src_id\: ``int``, dest_id\: ``int``\ )                                                                                                                                                                     |
+   +--------+--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
+   | |void| | :ref:`update_mmis<class_Terrain3DInstancer_method_update_mmis>`\ (\ rebuild\: ``bool`` = false\ )                                                                                                                                                                        |
    +--------+--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
    | |void| | :ref:`update_transforms<class_Terrain3DInstancer_method_update_transforms>`\ (\ aabb\: ``AABB``\ )                                                                                                                                                                       |
    +--------+--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
@@ -224,18 +224,6 @@ Dumps the MultiMeshInstance3Ds attached to the tree and information about the no
 
 ----
 
-.. _class_Terrain3DInstancer_method_force_update_mmis:
-
-.. rst-class:: classref-method
-
-|void| **force_update_mmis**\ (\ ) :ref:`🔗<class_Terrain3DInstancer_method_force_update_mmis>`
-
-Removes and rebuilds all MultiMeshInstance3Ds attached to the tree.
-
-.. rst-class:: classref-item-separator
-
-----
-
 .. _class_Terrain3DInstancer_method_remove_instances:
 
 .. rst-class:: classref-method
@@ -255,6 +243,20 @@ Uses parameters asset_id, size, strength, fixed_scale, random_scale, slope (Vect
 |void| **swap_ids**\ (\ src_id\: ``int``, dest_id\: ``int``\ ) :ref:`🔗<class_Terrain3DInstancer_method_swap_ids>`
 
 Swaps the ID of two meshes without changing the mesh instances on the ground.
+
+.. rst-class:: classref-item-separator
+
+----
+
+.. _class_Terrain3DInstancer_method_update_mmis:
+
+.. rst-class:: classref-method
+
+|void| **update_mmis**\ (\ rebuild\: ``bool`` = false\ ) :ref:`🔗<class_Terrain3DInstancer_method_update_mmis>`
+
+Rebuilds the MMIs in cells that have been modified or are missing. See :ref:`Terrain3DRegion.instances<class_Terrain3DRegion_property_instances>`.
+
+- rebuild - Destroys all MMIs first then rebuilds all of them from scratch.
 
 .. rst-class:: classref-item-separator
 

--- a/doc/api/class_terrain3dregion.rst
+++ b/doc/api/class_terrain3dregion.rst
@@ -292,7 +292,7 @@ The format is instances{mesh_id:int} -> cells{grid_location:Vector2i} -> ( Array
 
 - 2: A bool that tracks if this cell has been modified
 
-After changing this data, :ref:`Terrain3DInstancer.force_update_mmis()<class_Terrain3DInstancer_method_force_update_mmis>` should be called to rebuild the MMIs.
+After changing this data, call :ref:`Terrain3DInstancer.update_mmis()<class_Terrain3DInstancer_method_update_mmis>` to rebuild the MMIs.
 
 .. rst-class:: classref-item-separator
 

--- a/doc/api/class_terrain3dregion.rst
+++ b/doc/api/class_terrain3dregion.rst
@@ -136,7 +136,7 @@ Color map - paints color on the terrain
 
 :ref:`MapType<enum_Terrain3DRegion_MapType>` **TYPE_MAX** = ``3``
 
-The number of elements in this enum.
+The number of elements in this enum. Often used to specify all map types for functions that request one.
 
 .. rst-class:: classref-section-separator
 
@@ -202,7 +202,7 @@ However, we interpret these images as format: `RenderingDevice.DATA_FORMAT_R32_U
 - |void| **set_deleted**\ (\ value\: ``bool``\ )
 - ``bool`` **is_deleted**\ (\ )
 
-This region is marked for deletion. It won't be rendered once :ref:`Terrain3DData.force_update_maps()<class_Terrain3DData_method_force_update_maps>` rebuilds the map index. The file will be deleted from disk on :ref:`save()<class_Terrain3DRegion_method_save>`.
+This region is marked for deletion. It won't be rendered once :ref:`Terrain3DData.update_maps()<class_Terrain3DData_method_update_maps>` rebuilds the map index. The file will be deleted from disk on :ref:`save()<class_Terrain3DRegion_method_save>`.
 
 .. rst-class:: classref-item-separator
 
@@ -219,7 +219,7 @@ This region is marked for deletion. It won't be rendered once :ref:`Terrain3DDat
 - |void| **set_edited**\ (\ value\: ``bool``\ )
 - ``bool`` **is_edited**\ (\ )
 
-This region is marked for saving in the undo/redo system by :ref:`Terrain3DEditor<class_Terrain3DEditor>` during an operation.
+This region is marked for updating by :ref:`Terrain3DData.update_maps()<class_Terrain3DData_method_update_maps>` and for undo/redo tracking when set between :ref:`Terrain3DEditor.start_operation()<class_Terrain3DEditor_method_start_operation>` and :ref:`Terrain3DEditor.stop_operation()<class_Terrain3DEditor_method_stop_operation>`. The latter method clears the edited flag. This flag serves a different purpose than :ref:`modified<class_Terrain3DRegion_property_modified>`.
 
 .. rst-class:: classref-item-separator
 
@@ -326,7 +326,7 @@ The region location, or region grid coordinates in the world space where this re
 - |void| **set_modified**\ (\ value\: ``bool``\ )
 - ``bool`` **is_modified**\ (\ )
 
-This region has been modified and will be saved.
+This region has been modified and will be saved to disk upon :ref:`save()<class_Terrain3DRegion_method_save>`. This serves a different purpose than the temporary :ref:`edited<class_Terrain3DRegion_property_edited>` setting.
 
 .. rst-class:: classref-item-separator
 
@@ -484,7 +484,7 @@ Saves this region to the current file name.
 
 - path - specifies a directory and file name to use from now on.
 
-- 16-bit - save this region with 16-bit height map instead of 32-bit. This process is lossy.
+- 16-bit - save this region with 16-bit height map instead of 32-bit. This process is lossy. Does not change the bit depth in memory.
 
 .. rst-class:: classref-item-separator
 

--- a/doc/doc_classes/Terrain3DCollision.xml
+++ b/doc/doc_classes/Terrain3DCollision.xml
@@ -46,10 +46,10 @@
 		</method>
 		<method name="update">
 			<return type="void" />
-			<param index="0" name="force" type="bool" default="false" />
+			<param index="0" name="rebuild" type="bool" default="false" />
 			<description>
-				- If [member mode] is Full, updates the existing collision shapes. If regions have been added or removed, set [code skip-lint]force[/code] to true or call [method build] instead. Can be slow.
-				- If [member mode] is Dynamic, repositions collision shapes around the camera and recalculates ones that moved. Set [code skip-lint]force[/code] to true to recalculate all shapes. This is very fast, and can be updated at 60fps for little cost.
+				- If [member mode] is Full, recalculates the existing collision shapes. If regions have been added or removed, set [code skip-lint]rebuild[/code] to true or call [method build] instead. Can be slow.
+				- If [member mode] is Dynamic, repositions collision shapes around the camera and recalculates ones that moved. Set [code skip-lint]rebuild[/code] to true to recalculate all shapes within [member radius]. This is very fast, and can be updated at 60fps for little cost.
 			</description>
 		</method>
 	</methods>

--- a/doc/doc_classes/Terrain3DCollision.xml
+++ b/doc/doc_classes/Terrain3DCollision.xml
@@ -49,7 +49,7 @@
 			<param index="0" name="force" type="bool" default="false" />
 			<description>
 				- If [member mode] is Full, updates the existing collision shapes. If regions have been added or removed, set [code skip-lint]force[/code] to true or call [method build] instead. Can be slow.
-				- If [member mode] is Dynamic, repositions collision shapes around the camera and recalculated ones not already in place, skipping those that are. Set [code skip-lint]force[/code] to true to recalculate all shapes. This is very fast, and can be updated at 60fps for little cost.
+				- If [member mode] is Dynamic, repositions collision shapes around the camera and recalculates ones that moved. Set [code skip-lint]force[/code] to true to recalculate all shapes. This is very fast, and can be updated at 60fps for little cost.
 			</description>
 		</method>
 	</methods>

--- a/doc/doc_classes/Terrain3DData.xml
+++ b/doc/doc_classes/Terrain3DData.xml
@@ -16,7 +16,7 @@
 				Adds a region for sculpting and painting.
 				The region should already be configured with the desired location and maps before sending to this function.
 				Upon saving, this region will be written to a data file stored in [member Terrain3D.data_directory].
-				- update - regenerates the texture arrays if true. Set to false if bulk adding many regions, then true on the last one or use [method force_update_maps].
+				- update - regenerates the texture arrays if true. Set to false if bulk adding many regions, then true on the last one or use [method update_maps].
 			</description>
 		</method>
 		<method name="add_region_blank">
@@ -69,16 +69,6 @@
 				R16 or exr are recommended for roundtrip external editing.
 				R16 can be edited by Krita, however you must know the dimensions and min/max before reimporting. This information is printed to the console.
 				Res/tres stores in Godot's native data format.
-			</description>
-		</method>
-		<method name="force_update_maps">
-			<return type="void" />
-			<param index="0" name="map_type" type="int" enum="Terrain3DRegion.MapType" default="3" />
-			<param index="1" name="generate_mipmaps" type="bool" default="false" />
-			<description>
-				Regenerates the region map and TextureArrays that house the requested map types. Using the default [enum Terrain3DRegion.MapType] TYPE_MAX(3) will regenerate all map types.
-				This function needs to be called after editing any of the maps.
-				- generate_mipmaps - Generates mipmaps for the color maps. This can also be done on individual regions with [code skip-lint]region.get_color_map().generate_mipmaps()[/code].
 			</description>
 		</method>
 		<method name="get_color" qualifiers="const">
@@ -541,7 +531,7 @@
 			<param index="2" name="pixel" type="Color" />
 			<description>
 				Sets the pixel for the map type associated with the specified position. This method is fine for setting a few pixels, but if you wish to modify thousands of pixels quickly, you should get the region and use [method Terrain3DRegion.get_map], then edit the images directly.
-				After setting pixels you need to call [method force_update_maps]. You may also need to regenerate collision if you don't have dynamic collision enabled.
+				After setting pixels you need to call [method update_maps]. You may also need to regenerate collision if you don't have dynamic collision enabled.
 			</description>
 		</method>
 		<method name="set_region_deleted">
@@ -566,6 +556,27 @@
 			<param index="1" name="roughness" type="float" />
 			<description>
 				Sets the roughness modifier (wetness) on the color map alpha channel associated with the specified position. See [method set_pixel] for important information.
+			</description>
+		</method>
+		<method name="update_maps">
+			<return type="void" />
+			<param index="0" name="map_type" type="int" enum="Terrain3DRegion.MapType" default="3" />
+			<param index="1" name="all_maps " type="bool" default="true" />
+			<param index="2" name="generate_mipmaps" type="bool" default="false" />
+			<description>
+				Regenerates the region map and the TextureArrays that combine the requested map types. This function needs to be called after editing any of the maps.
+				By default, this function rebuilds all maps for all regions.
+				- map_type - Regenerate only maps of this type.
+				- all_regions - Regenerate all regions if true, otherwise only those marked with [member Terrain3DRegion.edited].
+				- generate_mipmaps - Regenerate mipmaps if map_type is color or all (max), for the regions specified above. This can also be done on individual regions before calling this function with [code skip-lint]region.get_color_map().generate_mipmaps()[/code].
+				For frequent editing, rather than enabling all_regions, it is more optimal to only update changed regions as follows:
+				[codeblock]
+				terrain.data.set_height(global_position, 10.0)
+				var region:Terrain3DRegion = terrain.data.get_regionp(global_position)
+				region.set_edited(true)
+				terrain.data.update_maps(Terrain3DRegion.TYPE_HEIGHT, false)
+				region.set_edited(false)
+				[/codeblock]
 			</description>
 		</method>
 	</methods>

--- a/doc/doc_classes/Terrain3DEditor.xml
+++ b/doc/doc_classes/Terrain3DEditor.xml
@@ -86,13 +86,13 @@
 			<return type="void" />
 			<param index="0" name="position" type="Vector3" />
 			<description>
-				Begin a sculpting or painting operation.
+				Begin a sculpting or painting operation. Prepares to create an undo/redo commit.
 			</description>
 		</method>
 		<method name="stop_operation">
 			<return type="void" />
 			<description>
-				End a sculpting or painting operation.
+				End a sculpting or painting operation. Commits any regions marked with [member Terrain3DRegion.edited] in the undo/redo system and clears that flag.
 			</description>
 		</method>
 	</methods>

--- a/doc/doc_classes/Terrain3DInstancer.xml
+++ b/doc/doc_classes/Terrain3DInstancer.xml
@@ -14,7 +14,7 @@
 		- [method remove_instances] - Like add_instances, this is can be used procedurally but is designed for hand editing.
 		- [method clear_by_mesh], [method clear_by_location] - To erase large sections of instances
 		- Editing [member Terrain3DRegion.instances] directly.
-		After modifying region data, run [method force_update_mmis] to rebuild the MultiMeshInstance3Ds.
+		After modifying region data, run [method update_mmis] to rebuild the MultiMeshInstance3Ds.
 		[b]Read More:[/b]
 		- [b]Tutorial:[/b] [url=https://terrain3d.readthedocs.io/en/stable/docs/instancer.html]Foliage Instancing[/url]
 		- [b]Godot Reference:[/b] [url=https://docs.godotengine.org/en/stable/classes/class_multimesh.html]MultiMesh[/url]
@@ -112,12 +112,6 @@
 				Dumps the MultiMeshInstance3Ds attached to the tree and information about the nodes for all regions.
 			</description>
 		</method>
-		<method name="force_update_mmis">
-			<return type="void" />
-			<description>
-				Removes and rebuilds all MultiMeshInstance3Ds attached to the tree.
-			</description>
-		</method>
 		<method name="remove_instances">
 			<return type="void" />
 			<param index="0" name="global_position" type="Vector3" />
@@ -132,6 +126,14 @@
 			<param index="1" name="dest_id" type="int" />
 			<description>
 				Swaps the ID of two meshes without changing the mesh instances on the ground.
+			</description>
+		</method>
+		<method name="update_mmis">
+			<return type="void" />
+			<param index="0" name="rebuild" type="bool" default="false" />
+			<description>
+				Rebuilds the MMIs in cells that have been modified or are missing. See [member Terrain3DRegion.instances].
+				- rebuild - Destroys all MMIs first then rebuilds all of them from scratch.
 			</description>
 		</method>
 		<method name="update_transforms">

--- a/doc/doc_classes/Terrain3DRegion.xml
+++ b/doc/doc_classes/Terrain3DRegion.xml
@@ -62,7 +62,7 @@
 			<description>
 				Saves this region to the current file name.
 				- path - specifies a directory and file name to use from now on.
-				- 16-bit - save this region with 16-bit height map instead of 32-bit. This process is lossy.
+				- 16-bit - save this region with 16-bit height map instead of 32-bit. This process is lossy. Does not change the bit depth in memory.
 			</description>
 		</method>
 		<method name="set_data">
@@ -122,10 +122,10 @@
 			However, we interpret these images as format: [url=https://docs.godotengine.org/en/stable/classes/class_renderingdevice.html#class-renderingdevice-constant-data-format-r32-uint]RenderingDevice.DATA_FORMAT_R32_UINT[/url] aka OpenGL RG32UI 32-bit per pixel as unsigned integer. See [url=https://terrain3d.readthedocs.io/en/stable/docs/controlmap_format.html]Control map format[/url].
 		</member>
 		<member name="deleted" type="bool" setter="set_deleted" getter="is_deleted">
-			This region is marked for deletion. It won't be rendered once [method Terrain3DData.force_update_maps] rebuilds the map index. The file will be deleted from disk on [method save].
+			This region is marked for deletion. It won't be rendered once [method Terrain3DData.update_maps] rebuilds the map index. The file will be deleted from disk on [method save].
 		</member>
 		<member name="edited" type="bool" setter="set_edited" getter="is_edited">
-			This region is marked for saving in the undo/redo system by [Terrain3DEditor] during an operation.
+			This region is marked for updating by [method Terrain3DData.update_maps] and for undo/redo tracking when set between [method Terrain3DEditor.start_operation] and [method Terrain3DEditor.stop_operation]. The latter method clears the edited flag. This flag serves a different purpose than [member modified].
 		</member>
 		<member name="height_map" type="Image" setter="set_height_map" getter="get_height_map">
 			This map contains the real value heights for the terrain.
@@ -151,7 +151,7 @@
 			The region location, or region grid coordinates in the world space where this region lives.
 		</member>
 		<member name="modified" type="bool" setter="set_modified" getter="is_modified">
-			This region has been modified and will be saved.
+			This region has been modified and will be saved to disk upon [method save]. This serves a different purpose than the temporary [member edited] setting.
 		</member>
 		<member name="region_size" type="int" setter="set_region_size" getter="get_region_size" default="0">
 			The current region size for this region, calculated from the dimensions of the first loaded map. It should match [member Terrain3D.region_size].
@@ -174,7 +174,7 @@
 			Color map - paints color on the terrain
 		</constant>
 		<constant name="TYPE_MAX" value="3" enum="MapType">
-			The number of elements in this enum.
+			The number of elements in this enum. Often used to specify all map types for functions that request one.
 		</constant>
 	</constants>
 </class>

--- a/doc/doc_classes/Terrain3DRegion.xml
+++ b/doc/doc_classes/Terrain3DRegion.xml
@@ -145,7 +145,7 @@
 			- 0: An Array of Transform3Ds
 			- 1: A PackedColorArray with instance colors, same index as above
 			- 2: A bool that tracks if this cell has been modified
-			After changing this data, [method Terrain3DInstancer.force_update_mmis] should be called to rebuild the MMIs.
+			After changing this data, call [method Terrain3DInstancer.update_mmis] to rebuild the MMIs.
 		</member>
 		<member name="location" type="Vector2i" setter="set_location" getter="get_location">
 			The region location, or region grid coordinates in the world space where this region lives.

--- a/project/addons/terrain_3d/tools/importer.gd
+++ b/project/addons/terrain_3d/tools/importer.gd
@@ -29,7 +29,7 @@ func reset_terrain(p_value) -> void:
 	data_directory = ""
 	for region:Terrain3DRegion in data.get_regions_active():
 		data.remove_region(region, false)
-	data.force_update_maps()
+	data.update_maps(Terrain3DRegion.TYPE_MAX, true, false)
 
 
 func update_heights(p_value) -> void:

--- a/src/terrain_3d_assets.cpp
+++ b/src/terrain_3d_assets.cpp
@@ -620,9 +620,9 @@ void Terrain3DAssets::update_mesh_list() {
 			LOG(DEBUG, "Connecting setting_changed signal to _update_thumbnail");
 			mesh_asset->connect("setting_changed", callable_mp(this, &Terrain3DAssets::_update_thumbnail).bind(mesh_asset));
 		}
-		if (!mesh_asset->is_connected("instancer_setting_changed", callable_mp(_terrain->get_instancer(), &Terrain3DInstancer::force_update_mmis))) {
+		if (!mesh_asset->is_connected("instancer_setting_changed", callable_mp(_terrain->get_instancer(), &Terrain3DInstancer::update_mmis).bind(true))) {
 			LOG(DEBUG, "Connecting instancer_setting_changed signal to _update_mmis");
-			mesh_asset->connect("instancer_setting_changed", callable_mp(_terrain->get_instancer(), &Terrain3DInstancer::force_update_mmis));
+			mesh_asset->connect("instancer_setting_changed", callable_mp(_terrain->get_instancer(), &Terrain3DInstancer::update_mmis).bind(true));
 		}
 	}
 	LOG(DEBUG, "Emitting meshes_changed");

--- a/src/terrain_3d_collision.cpp
+++ b/src/terrain_3d_collision.cpp
@@ -281,11 +281,11 @@ void Terrain3DCollision::build() {
 	update();
 }
 
-void Terrain3DCollision::update(const bool p_force) {
+void Terrain3DCollision::update(const bool p_rebuild) {
 	if (!_initialized) {
 		return;
 	}
-	if (p_force && !is_dynamic_mode()) {
+	if (p_rebuild && !is_dynamic_mode()) {
 		build();
 		return;
 	}
@@ -298,7 +298,7 @@ void Terrain3DCollision::update(const bool p_force) {
 		LOG(EXTREME, "Updating collision at ", snapped_pos);
 
 		// Skip if location hasn't moved to next step
-		if (!p_force && (_last_snapped_pos - snapped_pos).length() < _shape_size) {
+		if (!p_rebuild && (_last_snapped_pos - snapped_pos).length() < _shape_size) {
 			return;
 		}
 
@@ -331,7 +331,7 @@ void Terrain3DCollision::update(const bool p_force) {
 			// Unique key: Top left corner of shape, snapped to grid
 			Vector2i shape_pos = _snap_to_grid(v3v2i(shape_center) - shape_offset);
 			// Optionally could adjust radius to account for corner (sqrt(_shape_size*2))
-			if (!p_force && (shape_center.x < FLT_MAX && v3v2i(shape_center).distance_to(snapped_pos) <= real_t(_radius))) {
+			if (!p_rebuild && (shape_center.x < FLT_MAX && v3v2i(shape_center).distance_to(snapped_pos) <= real_t(_radius))) {
 				// Get index into shape array
 				Vector2i grid_loc = (shape_pos - grid_pos) / _shape_size;
 				grid[grid_loc.y * grid_width + grid_loc.x] = i;
@@ -360,7 +360,7 @@ void Terrain3DCollision::update(const bool p_force) {
 				LOG(EXTREME, "grid[", i, ":", grid_loc, "] shape_pos : ", shape_pos, " out of circle, skipping");
 				continue;
 			}
-			if (!p_force && grid[i] >= 0) {
+			if (!p_rebuild && grid[i] >= 0) {
 				Vector2i center_pos = v3v2i(_shape_get_position(i));
 				LOG(EXTREME, "grid[", i, ":", grid_loc, "] shape_pos : ", shape_pos, " act ", center_pos - shape_offset, " Has active shape id: ", grid[i]);
 				continue;
@@ -564,7 +564,7 @@ void Terrain3DCollision::_bind_methods() {
 	BIND_ENUM_CONSTANT(FULL_EDITOR);
 
 	ClassDB::bind_method(D_METHOD("build"), &Terrain3DCollision::build);
-	ClassDB::bind_method(D_METHOD("update", "force"), &Terrain3DCollision::update, DEFVAL(false));
+	ClassDB::bind_method(D_METHOD("update", "rebuild"), &Terrain3DCollision::update, DEFVAL(false));
 	ClassDB::bind_method(D_METHOD("destroy"), &Terrain3DCollision::destroy);
 	ClassDB::bind_method(D_METHOD("set_mode", "mode"), &Terrain3DCollision::set_mode);
 	ClassDB::bind_method(D_METHOD("get_mode"), &Terrain3DCollision::get_mode);

--- a/src/terrain_3d_collision.h
+++ b/src/terrain_3d_collision.h
@@ -65,7 +65,7 @@ public:
 	void initialize(Terrain3D *p_terrain);
 
 	void build();
-	void update(const bool p_force = false);
+	void update(const bool p_rebuild = false);
 	void destroy();
 
 	void set_mode(const CollisionMode p_mode);

--- a/src/terrain_3d_data.cpp
+++ b/src/terrain_3d_data.cpp
@@ -68,7 +68,7 @@ void Terrain3DData::set_region_locations(const TypedArray<Vector2i> &p_locations
 	LOG(INFO, "Setting _region_locations with array sized: ", p_locations.size());
 	_region_locations = p_locations;
 	_region_map_dirty = true;
-	update_maps();
+	update_maps(TYPE_MAX, false, false); // only rebuild region map
 }
 
 // Returns an array of active regions, optionally a shallow or deep copy
@@ -174,8 +174,8 @@ void Terrain3DData::change_region_size(int p_new_size) {
 	}
 
 	calc_height_range(true);
-	force_update_maps(TYPE_MAX, true);
-	_terrain->get_instancer()->force_update_mmis();
+	update_maps(TYPE_MAX, true, true);
+	_terrain->get_instancer()->update_mmis(true);
 }
 
 void Terrain3DData::set_region_modified(const Vector2i &p_region_loc, const bool p_modified) {
@@ -260,7 +260,7 @@ Error Terrain3DData::add_region(const Ref<Terrain3DRegion> &p_region, const bool
 	_region_map_dirty = true;
 	LOG(DEBUG, "Storing region ", region_loc, " version ", vformat("%.3f", p_region->get_version()), " id: ", _region_locations.size());
 	if (p_update) {
-		force_update_maps();
+		update_maps(TYPE_MAX, true, false);
 		_terrain->get_instancer()->force_update_mmis();
 	}
 	return OK;
@@ -297,7 +297,7 @@ void Terrain3DData::remove_region(const Ref<Terrain3DRegion> &p_region, const bo
 	LOG(DEBUG, "Removing from region_locations, new size: ", _region_locations.size());
 	if (p_update) {
 		LOG(DEBUG, "Updating generated maps");
-		force_update_maps();
+		update_maps(TYPE_MAX, true, false);
 		_terrain->get_instancer()->force_update_mmis();
 	}
 }
@@ -395,7 +395,7 @@ void Terrain3DData::load_directory(const String &p_dir) {
 		region->set_version(CURRENT_VERSION); // Sends upgrade warning if old version
 		add_region(region, false);
 	}
-	force_update_maps();
+	update_maps(TYPE_MAX, true, false);
 }
 
 //TODO have load_directory call load_region, or make a load_file that loads a specific path
@@ -447,41 +447,45 @@ TypedArray<Image> Terrain3DData::get_maps(const MapType p_map_type) const {
 	return TypedArray<Image>();
 }
 
-void Terrain3DData::force_update_maps(const MapType p_map_type, const bool p_generate_mipmaps) {
-	LOG(EXTREME, "Regenerating maps of type: ", p_map_type);
-	switch (p_map_type) {
-		case TYPE_HEIGHT:
-			_generated_height_maps.clear();
-			break;
-		case TYPE_CONTROL:
-			_generated_control_maps.clear();
-			break;
-		case TYPE_COLOR:
-			_generated_color_maps.clear();
-			break;
-		default:
-			_generated_height_maps.clear();
-			_generated_control_maps.clear();
-			_generated_color_maps.clear();
-			_region_map_dirty = true;
-			break;
-	}
+void Terrain3DData::update_maps(const MapType p_map_type, const bool p_all_regions, const bool p_generate_mipmaps) {
+	// Generate region color mipmaps
 	if (p_generate_mipmaps && (p_map_type == TYPE_COLOR || p_map_type == TYPE_MAX)) {
 		LOG(EXTREME, "Regenerating color mipmaps");
 		for (int i = 0; i < _region_locations.size(); i++) {
 			Vector2i region_loc = _region_locations[i];
 			Terrain3DRegion *region = get_region_ptr(region_loc);
-			if (region) {
+			// Generate all or only those marked edited
+			if (region && (p_all_regions || region->is_edited())) {
 				region->get_color_map()->generate_mipmaps();
 			}
 		}
 	}
-	update_maps();
-}
 
-void Terrain3DData::update_maps(const MapType p_map_type) {
+	// Mark texture arrays dirty for rebuilding
+	if (p_all_regions) {
+		LOG(EXTREME, "Marking dirty maps of type: ", p_map_type);
+		switch (p_map_type) {
+			case TYPE_HEIGHT:
+				_generated_height_maps.clear();
+				break;
+			case TYPE_CONTROL:
+				_generated_control_maps.clear();
+				break;
+			case TYPE_COLOR:
+				_generated_color_maps.clear();
+				break;
+			default:
+				_generated_height_maps.clear();
+				_generated_control_maps.clear();
+				_generated_color_maps.clear();
+				_region_map_dirty = true;
+				break;
+		}
+	}
+
 	bool any_changed = false;
 
+	// Rebuild region map if dirty
 	if (_region_map_dirty) {
 		LOG(EXTREME, "Regenerating ", REGION_MAP_VSIZE, " region map array from active regions");
 		_region_map.clear();
@@ -505,6 +509,7 @@ void Terrain3DData::update_maps(const MapType p_map_type) {
 		emit_signal("region_map_changed");
 	}
 
+	// Rebulid height maps if dirty
 	if (_generated_height_maps.is_dirty()) {
 		LOG(EXTREME, "Regenerating height texture array from regions");
 		_height_maps.clear();
@@ -525,6 +530,7 @@ void Terrain3DData::update_maps(const MapType p_map_type) {
 		emit_signal("height_maps_changed");
 	}
 
+	// Rebulid control maps if dirty
 	if (_generated_control_maps.is_dirty()) {
 		LOG(EXTREME, "Regenerating control texture array from regions");
 		_control_maps.clear();
@@ -540,6 +546,7 @@ void Terrain3DData::update_maps(const MapType p_map_type) {
 		emit_signal("control_maps_changed");
 	}
 
+	// Rebulid color maps if dirty
 	if (_generated_color_maps.is_dirty()) {
 		LOG(EXTREME, "Regenerating color texture array from regions");
 		_color_maps.clear();
@@ -555,9 +562,9 @@ void Terrain3DData::update_maps(const MapType p_map_type) {
 		emit_signal("color_maps_changed");
 	}
 
+	// If no maps have been rebuilt, update only individual regions in the array.
+	// Regions marked Edited have been changed by Terrain3DEditor::_operate_map or undo / redo processing.
 	if (!any_changed) {
-		// If no maps have been rebuilt, it's safe to update individual layers. Regions marked Edited
-		// have either been recently changed by Terrain3DEditor::_operate_map or were marked by undo / redo.
 		for (int i = 0; i < _region_locations.size(); i++) {
 			Vector2i region_loc = _region_locations[i];
 			Terrain3DRegion *region = cast_to<Terrain3DRegion>(_regions[region_loc]);
@@ -1170,7 +1177,7 @@ void Terrain3DData::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("get_control_maps"), &Terrain3DData::get_control_maps);
 	ClassDB::bind_method(D_METHOD("get_color_maps"), &Terrain3DData::get_color_maps);
 	ClassDB::bind_method(D_METHOD("get_maps", "map_type"), &Terrain3DData::get_maps);
-	ClassDB::bind_method(D_METHOD("force_update_maps", "map_type", "generate_mipmaps"), &Terrain3DData::force_update_maps, DEFVAL(TYPE_MAX), DEFVAL(false));
+	ClassDB::bind_method(D_METHOD("update_maps", "map_type", "all_maps ", "generate_mipmaps"), &Terrain3DData::update_maps, DEFVAL(TYPE_MAX), DEFVAL(true), DEFVAL(false));
 	ClassDB::bind_method(D_METHOD("get_height_maps_rid"), &Terrain3DData::get_height_maps_rid);
 	ClassDB::bind_method(D_METHOD("get_control_maps_rid"), &Terrain3DData::get_control_maps_rid);
 	ClassDB::bind_method(D_METHOD("get_color_maps_rid"), &Terrain3DData::get_color_maps_rid);

--- a/src/terrain_3d_data.cpp
+++ b/src/terrain_3d_data.cpp
@@ -261,7 +261,7 @@ Error Terrain3DData::add_region(const Ref<Terrain3DRegion> &p_region, const bool
 	LOG(DEBUG, "Storing region ", region_loc, " version ", vformat("%.3f", p_region->get_version()), " id: ", _region_locations.size());
 	if (p_update) {
 		update_maps(TYPE_MAX, true, false);
-		_terrain->get_instancer()->force_update_mmis();
+		_terrain->get_instancer()->update_mmis(true);
 	}
 	return OK;
 }
@@ -298,7 +298,7 @@ void Terrain3DData::remove_region(const Ref<Terrain3DRegion> &p_region, const bo
 	if (p_update) {
 		LOG(DEBUG, "Updating generated maps");
 		update_maps(TYPE_MAX, true, false);
-		_terrain->get_instancer()->force_update_mmis();
+		_terrain->get_instancer()->update_mmis(true);
 	}
 }
 

--- a/src/terrain_3d_data.h
+++ b/src/terrain_3d_data.h
@@ -130,10 +130,7 @@ public:
 	TypedArray<Image> get_control_maps() const { return _control_maps; }
 	TypedArray<Image> get_color_maps() const { return _color_maps; }
 	TypedArray<Image> get_maps(const MapType p_map_type) const;
-
-	void force_update_maps(const MapType p_map_type = TYPE_MAX, const bool p_generate_mipmaps = false);
-	void update_maps(const MapType p_map_type = TYPE_MAX);
-
+	void update_maps(const MapType p_map_type = TYPE_MAX, const bool p_all_regions = true, const bool p_generate_mipmaps = false);
 	RID get_height_maps_rid() const { return _generated_height_maps.get_rid(); }
 	RID get_control_maps_rid() const { return _generated_control_maps.get_rid(); }
 	RID get_color_maps_rid() const { return _generated_color_maps.get_rid(); }

--- a/src/terrain_3d_editor.cpp
+++ b/src/terrain_3d_editor.cpp
@@ -527,10 +527,10 @@ void Terrain3DEditor::_operate_map(const Vector3 &p_global_position, const real_
 	}
 	// If no added or removed regions, update only changed texture array layers from the edited regions in the rendering server
 	if (_added_removed_locations.size() == regions_added_removed) {
-		data->update_maps(map_type);
+		data->update_maps(map_type, false, false);
 	} else {
 		// If region qty was changed, must fully rebuild the maps
-		data->force_update_maps(map_type);
+		data->update_maps(map_type, true, map_type == TYPE_COLOR);
 	}
 	data->add_edited_area(edited_area);
 
@@ -652,9 +652,9 @@ void Terrain3DEditor::_apply_undo(const Dictionary &p_data) {
 	}
 	// If this undo set modifies the region qty, we must rebuild the arrays. Otherwise we can update individual layers
 	if (p_data.has("added_regions") || p_data.has("removed_regions")) {
-		data->force_update_maps();
+		data->update_maps(TYPE_MAX, true, false);
 	} else {
-		data->update_maps();
+		data->update_maps(TYPE_MAX, false, false);
 	}
 	// After TextureArray updates clear edited regions flag.
 	if (p_data.has("edited_regions")) {

--- a/src/terrain_3d_editor.cpp
+++ b/src/terrain_3d_editor.cpp
@@ -666,7 +666,7 @@ void Terrain3DEditor::_apply_undo(const Dictionary &p_data) {
 			}
 		}
 	}
-	_terrain->get_instancer()->force_update_mmis();
+	_terrain->get_instancer()->update_mmis(true);
 	if (_terrain->get_plugin()->has_method("update_grid")) {
 		LOG(DEBUG, "Calling GDScript update_grid()");
 		_terrain->get_plugin()->call("update_grid");

--- a/src/terrain_3d_instancer.cpp
+++ b/src/terrain_3d_instancer.cpp
@@ -942,7 +942,7 @@ void Terrain3DInstancer::update_transforms(const AABB &p_aabb) {
 
 // Transfer foliage data from one region to another
 // p_src_rect is the vertex/pixel offset into the region data, NOT a global position
-// Need to force_update_mmis() after
+// Need to update_mmis() after
 void Terrain3DInstancer::copy_paste_dfr(const Terrain3DRegion *p_src_region, const Rect2i &p_src_rect, const Terrain3DRegion *p_dst_region) {
 	if (!p_src_region || !p_dst_region) {
 		LOG(ERROR, "Source (", p_src_region, ") or destination (", p_dst_region, ") regions are null");
@@ -1043,12 +1043,14 @@ void Terrain3DInstancer::swap_ids(const int p_src_id, const int p_dst_id) {
 			}
 			LOG(MESG, "Swapped mesh_ids for region: ", region_loc);
 		}
-		force_update_mmis();
+		update_mmis(true);
 	}
 }
 
-void Terrain3DInstancer::force_update_mmis() {
-	destroy();
+void Terrain3DInstancer::update_mmis(const bool p_rebuild) {
+	if (p_rebuild) {
+		destroy();
+	}
 	_update_mmis();
 }
 
@@ -1122,7 +1124,7 @@ void Terrain3DInstancer::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("append_location", "region_location", "mesh_id", "transforms", "colors", "update"), &Terrain3DInstancer::append_location, DEFVAL(true));
 	ClassDB::bind_method(D_METHOD("append_region", "region", "mesh_id", "transforms", "colors", "update"), &Terrain3DInstancer::append_region, DEFVAL(true));
 	ClassDB::bind_method(D_METHOD("update_transforms", "aabb"), &Terrain3DInstancer::update_transforms);
-	ClassDB::bind_method(D_METHOD("force_update_mmis"), &Terrain3DInstancer::force_update_mmis);
+	ClassDB::bind_method(D_METHOD("update_mmis", "rebuild"), &Terrain3DInstancer::update_mmis, DEFVAL(false));
 	ClassDB::bind_method(D_METHOD("swap_ids", "src_id", "dest_id"), &Terrain3DInstancer::swap_ids);
 	ClassDB::bind_method(D_METHOD("dump_data"), &Terrain3DInstancer::dump_data);
 	ClassDB::bind_method(D_METHOD("dump_mmis"), &Terrain3DInstancer::dump_mmis);

--- a/src/terrain_3d_instancer.h
+++ b/src/terrain_3d_instancer.h
@@ -74,7 +74,7 @@ public:
 	void copy_paste_dfr(const Terrain3DRegion *p_src_region, const Rect2i &p_src_rect, const Terrain3DRegion *p_dst_region);
 
 	void swap_ids(const int p_src_id, const int p_dst_id);
-	void force_update_mmis();
+	void update_mmis(const bool p_rebuild = false);
 
 	void reset_density_counter() { _density_counter = 0; }
 	void dump_data();


### PR DESCRIPTION
Removes usages of `force`, which we're using improperly. It should be used to bypass warnings put in place to protect against major mistakes like formatting your disk. 

**Texture Arrays**

Consolidates force_update_maps, update_maps into one function and expose all of the options for the user.

By default, update_maps() does the slowest, most complete option, and the parameters reduce what it does.

The second line is the same behavior as the former:
```c++
-data.force_update_maps()
+data.update_maps(Terrain3DRegion.TYPE_MAX, true, false)
```

A user can add this to Player.gd:_physics_process() to paint the terrain it walks over, updating only the region the player is in, and regenerating the mipmap for that region since it's editing the color. Update_maps also doesn't even need to be called every frame or physics frame; it could be run at 10fps and look fine.
```gdscript
    $"../Terrain3D".data.set_color(global_position, Color.DARK_RED)
    var region:Terrain3DRegion = $"../Terrain3D".data.get_regionp(global_position)
    region.set_edited(true)
    $"../Terrain3D".data.update_maps(Terrain3DRegion.TYPE_COLOR, false, true)
    region.set_edited(false)
```

**Collision**
* renames update(force=false) -> update(rebuild=false), no logic change

**Instancer**
* renames force_update_mmis() -> update_mmis(rebuild=true)
* offers a new option to not rebuild everything


@Xtarsia Will you review this please?

Should we always default the updates to the slowest/complete choice and specify parameters to limit, or the opposite, or do it individually for each (current)?

