### PR TITLE
Add contour lines shader & Hotkeys

### DIFF
--- a/doc/api/class_terrain3d.rst
+++ b/doc/api/class_terrain3d.rst
@@ -88,6 +88,8 @@ Properties
    +-------------------------------------------------------------+----------------------------------------------------------------------------+-----------------+
    | ``bool``                                                    | :ref:`show_colormap<class_Terrain3D_property_show_colormap>`               | ``false``       |
    +-------------------------------------------------------------+----------------------------------------------------------------------------+-----------------+
+   | ``bool``                                                    | :ref:`show_contours<class_Terrain3D_property_show_contours>`               | ``false``       |
+   +-------------------------------------------------------------+----------------------------------------------------------------------------+-----------------+
    | ``bool``                                                    | :ref:`show_control_angle<class_Terrain3D_property_show_control_angle>`     | ``false``       |
    +-------------------------------------------------------------+----------------------------------------------------------------------------+-----------------+
    | ``bool``                                                    | :ref:`show_control_blend<class_Terrain3D_property_show_control_blend>`     | ``false``       |
@@ -798,6 +800,23 @@ Alias for :ref:`Terrain3DMaterial.show_colormap<class_Terrain3DMaterial_property
 
 ----
 
+.. _class_Terrain3D_property_show_contours:
+
+.. rst-class:: classref-property
+
+``bool`` **show_contours** = ``false`` :ref:`🔗<class_Terrain3D_property_show_contours>`
+
+.. rst-class:: classref-property-setget
+
+- |void| **set_show_contours**\ (\ value\: ``bool``\ )
+- ``bool`` **get_show_contours**\ (\ )
+
+Alias for :ref:`Terrain3DMaterial.show_contours<class_Terrain3DMaterial_property_show_contours>`. Press `4` with the mouse in the viewport to toggle. Customize in the material.
+
+.. rst-class:: classref-item-separator
+
+----
+
 .. _class_Terrain3D_property_show_control_angle:
 
 .. rst-class:: classref-property
@@ -894,7 +913,7 @@ Alias for :ref:`Terrain3DMaterial.show_grey<class_Terrain3DMaterial_property_sho
 - |void| **set_show_region_grid**\ (\ value\: ``bool``\ )
 - ``bool`` **get_show_region_grid**\ (\ )
 
-Alias for :ref:`Terrain3DMaterial.show_region_grid<class_Terrain3DMaterial_property_show_region_grid>`.
+Alias for :ref:`Terrain3DMaterial.show_region_grid<class_Terrain3DMaterial_property_show_region_grid>`. Press `1` with the mouse in the viewport to toggle.
 
 .. rst-class:: classref-item-separator
 
@@ -928,7 +947,7 @@ Alias for :ref:`Terrain3DMaterial.show_heightmap<class_Terrain3DMaterial_propert
 - |void| **set_show_instancer_grid**\ (\ value\: ``bool``\ )
 - ``bool`` **get_show_instancer_grid**\ (\ )
 
-Alias for :ref:`Terrain3DMaterial.show_instancer_grid<class_Terrain3DMaterial_property_show_instancer_grid>`.
+Alias for :ref:`Terrain3DMaterial.show_instancer_grid<class_Terrain3DMaterial_property_show_instancer_grid>`. Press `2` with the mouse in the viewport to toggle.
 
 .. rst-class:: classref-item-separator
 
@@ -979,7 +998,7 @@ Alias for :ref:`Terrain3DMaterial.show_navigation<class_Terrain3DMaterial_proper
 - |void| **set_show_region_grid**\ (\ value\: ``bool``\ )
 - ``bool`` **get_show_region_grid**\ (\ )
 
-Alias for :ref:`Terrain3DMaterial.show_region_grid<class_Terrain3DMaterial_property_show_region_grid>`.
+Alias for :ref:`Terrain3DMaterial.show_region_grid<class_Terrain3DMaterial_property_show_region_grid>`. Press `1` with the mouse in the viewport to toggle.
 
 .. rst-class:: classref-item-separator
 
@@ -1064,7 +1083,7 @@ Alias for :ref:`Terrain3DMaterial.show_texture_rough<class_Terrain3DMaterial_pro
 - |void| **set_show_vertex_grid**\ (\ value\: ``bool``\ )
 - ``bool`` **get_show_vertex_grid**\ (\ )
 
-Alias for :ref:`Terrain3DMaterial.show_vertex_grid<class_Terrain3DMaterial_property_show_vertex_grid>`.
+Alias for :ref:`Terrain3DMaterial.show_vertex_grid<class_Terrain3DMaterial_property_show_vertex_grid>`. Press `3` with the mouse in the viewport to toggle.
 
 .. rst-class:: classref-item-separator
 

--- a/doc/api/class_terrain3dmaterial.rst
+++ b/doc/api/class_terrain3dmaterial.rst
@@ -50,6 +50,8 @@ Properties
    +------------------------------------------------------------------+------------------------------------------------------------------------------------------+-----------+
    | ``bool``                                                         | :ref:`show_colormap<class_Terrain3DMaterial_property_show_colormap>`                     | ``false`` |
    +------------------------------------------------------------------+------------------------------------------------------------------------------------------+-----------+
+   | ``bool``                                                         | :ref:`show_contours<class_Terrain3DMaterial_property_show_contours>`                     | ``false`` |
+   +------------------------------------------------------------------+------------------------------------------------------------------------------------------+-----------+
    | ``bool``                                                         | :ref:`show_control_angle<class_Terrain3DMaterial_property_show_control_angle>`           | ``false`` |
    +------------------------------------------------------------------+------------------------------------------------------------------------------------------+-----------+
    | ``bool``                                                         | :ref:`show_control_blend<class_Terrain3DMaterial_property_show_control_blend>`           | ``false`` |
@@ -312,6 +314,23 @@ Places the color map in the albedo channel.
 
 ----
 
+.. _class_Terrain3DMaterial_property_show_contours:
+
+.. rst-class:: classref-property
+
+``bool`` **show_contours** = ``false`` :ref:`🔗<class_Terrain3DMaterial_property_show_contours>`
+
+.. rst-class:: classref-property-setget
+
+- |void| **set_show_contours**\ (\ value\: ``bool``\ )
+- ``bool`` **get_show_contours**\ (\ )
+
+Overlays contour lines on the terrain. Customize the options in the material when enabled. Press `4` with the mouse in the viewport to toggle.
+
+.. rst-class:: classref-item-separator
+
+----
+
 .. _class_Terrain3DMaterial_property_show_control_angle:
 
 .. rst-class:: classref-property
@@ -425,7 +444,7 @@ Albedo is a white to black gradient depending on height. The gradient is scaled 
 - |void| **set_show_instancer_grid**\ (\ value\: ``bool``\ )
 - ``bool`` **get_show_instancer_grid**\ (\ )
 
-Draws the 32x32m cell grid on the terrain, which shows how the instancer data is partitioned.
+Overlays the 32x32m instancer grid on the terrain, which shows how the instancer data is partitioned. Press `2` with the mouse in the viewport to toggle.
 
 .. rst-class:: classref-item-separator
 
@@ -459,7 +478,7 @@ Displays the area designated for generating the navigation mesh.
 - |void| **set_show_region_grid**\ (\ value\: ``bool``\ )
 - ``bool`` **get_show_region_grid**\ (\ )
 
-Draws the region grid directly on the terrain. This is more accurate than the region grid gizmo for determining where the region border is when editing.
+Overlays the region grid on the terrain. This is more accurate than the region grid gizmo for determining where the region border is when editing. Press `1` with the mouse in the viewport to toggle.
 
 .. rst-class:: classref-item-separator
 
@@ -544,7 +563,7 @@ Albedo is set to the painted Roughness textures. This is different from the roug
 - |void| **set_show_vertex_grid**\ (\ value\: ``bool``\ )
 - ``bool`` **get_show_vertex_grid**\ (\ )
 
-Show a grid on the vertices, overlaying any above shader.
+Overlays the vertex grid on the terrain, showing where each vertex is. Press `3` with the mouse in the viewport to toggle.
 
 .. rst-class:: classref-item-separator
 

--- a/doc/doc_classes/Terrain3D.xml
+++ b/doc/doc_classes/Terrain3D.xml
@@ -198,6 +198,9 @@
 		<member name="show_colormap" type="bool" setter="set_show_colormap" getter="get_show_colormap" default="false">
 			Alias for [member Terrain3DMaterial.show_colormap].
 		</member>
+		<member name="show_contours" type="bool" setter="set_show_contours" getter="get_show_contours" default="false">
+			Alias for [member Terrain3DMaterial.show_contours]. Press `4` with the mouse in the viewport to toggle. Customize in the material.
+		</member>
 		<member name="show_control_angle" type="bool" setter="set_show_control_angle" getter="get_show_control_angle" default="false">
 			Alias for [member Terrain3DMaterial.show_control_angle].
 		</member>
@@ -214,13 +217,13 @@
 			Alias for [member Terrain3DMaterial.show_grey].
 		</member>
 		<member name="show_grid" type="bool" setter="set_show_region_grid" getter="get_show_region_grid" default="false">
-			Alias for [member Terrain3DMaterial.show_region_grid].
+			Alias for [member Terrain3DMaterial.show_region_grid]. Press `1` with the mouse in the viewport to toggle.
 		</member>
 		<member name="show_heightmap" type="bool" setter="set_show_heightmap" getter="get_show_heightmap" default="false">
 			Alias for [member Terrain3DMaterial.show_heightmap].
 		</member>
 		<member name="show_instancer_grid" type="bool" setter="set_show_instancer_grid" getter="get_show_instancer_grid" default="false">
-			Alias for [member Terrain3DMaterial.show_instancer_grid].
+			Alias for [member Terrain3DMaterial.show_instancer_grid]. Press `2` with the mouse in the viewport to toggle.
 		</member>
 		<member name="show_instances" type="bool" setter="set_show_instances" getter="get_show_instances" default="true">
 			Shows or hides all instancer meshes.
@@ -229,7 +232,7 @@
 			Alias for [member Terrain3DMaterial.show_navigation].
 		</member>
 		<member name="show_region_grid" type="bool" setter="set_show_region_grid" getter="get_show_region_grid" default="false">
-			Alias for [member Terrain3DMaterial.show_region_grid].
+			Alias for [member Terrain3DMaterial.show_region_grid]. Press `1` with the mouse in the viewport to toggle.
 		</member>
 		<member name="show_roughmap" type="bool" setter="set_show_roughmap" getter="get_show_roughmap" default="false">
 			Alias for [member Terrain3DMaterial.show_autoshader].
@@ -244,7 +247,7 @@
 			Alias for [member Terrain3DMaterial.show_texture_rough].
 		</member>
 		<member name="show_vertex_grid" type="bool" setter="set_show_vertex_grid" getter="get_show_vertex_grid" default="false">
-			Alias for [member Terrain3DMaterial.show_vertex_grid].
+			Alias for [member Terrain3DMaterial.show_vertex_grid]. Press `3` with the mouse in the viewport to toggle.
 		</member>
 		<member name="version" type="String" setter="" getter="get_version" default="&quot;1.1.0-dev&quot;">
 			The current version of Terrain3D.

--- a/doc/doc_classes/Terrain3DMaterial.xml
+++ b/doc/doc_classes/Terrain3DMaterial.xml
@@ -79,6 +79,9 @@
 		<member name="show_colormap" type="bool" setter="set_show_colormap" getter="get_show_colormap" default="false">
 			Places the color map in the albedo channel.
 		</member>
+		<member name="show_contours" type="bool" setter="set_show_contours" getter="get_show_contours" default="false">
+			Overlays contour lines on the terrain. Customize the options in the material when enabled. Press `4` with the mouse in the viewport to toggle.
+		</member>
 		<member name="show_control_angle" type="bool" setter="set_show_control_angle" getter="get_show_control_angle" default="false">
 			Albedo shows the painted angle. Orange means 0°, Yellow 270°, Cyan 180°, Violet 90°. Or warm colors towards -Z, cool colors +Z, greens/yellows +X, reds/blues -X. Draw all angles coming from the center of a circle for a better understanding.
 		</member>
@@ -98,13 +101,13 @@
 			Albedo is a white to black gradient depending on height. The gradient is scaled to a height of 300, so above that or far below 0 will be all white or black.
 		</member>
 		<member name="show_instancer_grid" type="bool" setter="set_show_instancer_grid" getter="get_show_instancer_grid" default="false">
-			Draws the 32x32m cell grid on the terrain, which shows how the instancer data is partitioned.
+			Overlays the 32x32m instancer grid on the terrain, which shows how the instancer data is partitioned. Press `2` with the mouse in the viewport to toggle.
 		</member>
 		<member name="show_navigation" type="bool" setter="set_show_navigation" getter="get_show_navigation" default="false">
 			Displays the area designated for generating the navigation mesh.
 		</member>
 		<member name="show_region_grid" type="bool" setter="set_show_region_grid" getter="get_show_region_grid" default="false">
-			Draws the region grid directly on the terrain. This is more accurate than the region grid gizmo for determining where the region border is when editing.
+			Overlays the region grid on the terrain. This is more accurate than the region grid gizmo for determining where the region border is when editing. Press `1` with the mouse in the viewport to toggle.
 		</member>
 		<member name="show_roughmap" type="bool" setter="set_show_roughmap" getter="get_show_roughmap" default="false">
 			Albedo is set to the roughness modification map as grey scale. Middle grey, 0.5 means no roughness modification. Black would be high gloss while white is very rough.
@@ -119,7 +122,7 @@
 			Albedo is set to the painted Roughness textures. This is different from the roughness modification map above.
 		</member>
 		<member name="show_vertex_grid" type="bool" setter="set_show_vertex_grid" getter="get_show_vertex_grid" default="false">
-			Show a grid on the vertices, overlaying any above shader.
+			Overlays the vertex grid on the terrain, showing where each vertex is. Press `3` with the mouse in the viewport to toggle.
 		</member>
 		<member name="texture_filtering" type="int" setter="set_texture_filtering" getter="get_texture_filtering" enum="Terrain3DMaterial.TextureFiltering" default="0">
 			Sets how the renderer should filter textures. See [enum TextureFiltering] for options.

--- a/doc/docs/troubleshooting.md
+++ b/doc/docs/troubleshooting.md
@@ -80,13 +80,13 @@ If loading scenes via code, this is because `free_editor_textures` is enabled by
 To load them in all scenes, you can either:
 * Disable `free_editor_textures`
 * Make your asset list unique to each scene. (Think about this one. A shared texture list is useful.)
-* Reload the textures when loading a scene with Terrain3D
-
+* Reload the textures when loading a scene with Terrain3D:
 
 ```
 terrain.assets = ResourceLoader.load("res://scenes/terrains/asset_list.tres", "", ResourceLoader.CACHE_MODE_IGNORE)
 ```
 
+Terrain3D will continue to clear the textures on `_ready()` after compiling the arrays. You can clear textures at other times with `terrain.assets.clear_textures()`.
 
 ---
 

--- a/doc/docs/user_interface.md
+++ b/doc/docs/user_interface.md
@@ -27,35 +27,71 @@ First, select the Region Tool (first one: square with a cross), and click the gr
 
 The following mouse and keyboard shortcuts are available.
 
+
 ### General Keys
+
 * <kbd>LMB</kbd> - Click the terrain to positively apply the current tool.
-* <kbd>Ctrl + LMB</kbd> - **Inverse** the tool. Removes regions, color, wetness, autoshader, holes, navigation, foliage. Height picks first+. Use <kbd>Cmd</kbd> on **macOS**.
+* <kbd>Ctrl + LMB</kbd> - **Inverse** the tool. Removes regions, color, wetness, autoshader, holes, navigation, foliage. 
+  * Ctrl + Height picks the height at the cursor then flattens.
+  * Use <kbd>Cmd</kbd> on **macOS**.
 * <kbd>Shift + LMB</kbd> - Temporarily change to the **Smooth** sculpting tool.
+* <kbd>Alt + LMB</kbd> - Use a special alternate mode when applicable. See Raise and Slope Filter below.
 * <kbd>Ctrl + Z</kbd> - **Undo**. You can view the entries in the Godot `History` panel.
 * <kbd>Ctrl + Shift + Z</kbd> - **Redo**.
-* <kbd>Ctrl + S</kbd> - **Save** the scene and all data.
+* <kbd>Ctrl + S</kbd> - **Save** the scene and all terrain data.
 
-+ To clarify **Ctrl + Height**, this picks the height at the mouse cursor first, then flattens the landscape at that height.
+
+### Tool Selection
+
+The mouse must be in the 3D Viewport for these.
+
+* <kbd>E</kbd> - Add / remove **rEgion**.
+* <kbd>R</kbd> - Sculpt **Raise** or lower.
+* <kbd>H</kbd> - Sculpt **Height**.
+* <kbd>S</kbd> - Sculpt **Slope**.
+* <kbd>B</kbd> - Paint **Base** texture.
+* <kbd>V</kbd> - Spray **oVerlay** texture.
+* <kbd>A</kbd> - Paint **Autoshader**.
+* <kbd>C</kbd> - Paint **Color**.
+* <kbd>W</kbd> - Paint **Wetness**.
+* <kbd>N</kbd> - Paint **Navigation**.
+* <kbd>I</kbd> - **Instance** meshes.
+
+
+### Raise Sculpting Specific
+
+These modes are applicable only when using the Raise sculpting tool.
+
+* <kbd>Alt + LMB</kbd> - **Lift floors**. This lifts up lower portions of the terrain without affecting higher terrain. Use it along the bottom of cliff faces. See [videos demonstrating before and after](https://github.com/TokisanGames/Terrain3D/pull/409). 
+* <kbd>Ctrl + Alt + LMB</kbd> - **Flatten peaks**. The inverse of the above. This reduces peaks and ridges without affecting lower terrain around it.
+
 
 ### Slope Filter
 
-The slope filter on the bottom settings bar limits operations based on terrain slope. Don't confuse this with the slope sculpting tool on the left toolbar.
+The slope filter on the bottom [Tool Settings](#tool-settings) bar allows you to paint by slope. E.g., If the slope filter is 0-45 degrees, then it will paint if the slope of the ground is 45 degrees or less. There's also an option to inverse the slope and paint if the ground is between 45 and 90 degrees.
 
-These operations support filtering by slope: **Paint**, **Spray**, **Color**, **Wetness**, **Instancer**.
+Don't confuse this with the slope sculpting tool on the left toolbar.
 
-* <kbd>LMB</kbd> - Add within the defined slope.
+These operations work with the slope filter: **Paint**, **Spray**, **Color**, **Wetness**, **Instancer**.
+
+* <kbd>LMB</kbd> - Add as normal, within the defined slope. 
 * <kbd>Ctrl + LMB</kbd> - Remove within the defined slope.
 * <kbd>Alt + LMB</kbd> - Add with the slope inversed.
 * <kbd>Ctrl + Alt + LMB</kbd> - Remove with the slope inversed.
 
-### Sculpting Specific
-* <kbd>Alt + LMB</kbd> - **Lift floors**. This lifts up lower portions of the terrain without affecting higher terrain. Use it along the bottom of cliff faces. See [videos demonstrating before and after](https://github.com/TokisanGames/Terrain3D/pull/409). 
-* <kbd>Ctrl + Alt + LMB</kbd> - **Flatten peaks**. The inverse of the above. This reduces peaks and ridges without affecting lower terrain around it.
 
 ### Instancer Specific
-* <kbd>LMB</kbd> - Add the selected mesh instance to the terrain.
+* <kbd>LMB</kbd> - Add the selected mesh to the terrain.
 * <kbd>Ctrl + LMB</kbd> - Remove instances of the selected type.
 * <kbd>Ctrl + Shift + LMB</kbd> - Remove instances of **any** type.
+
+
+### Overlays
+The mouse must be in the 3D Viewport for these.
+* <kbd>1</kbd> - Overlay the **Region Grid**.
+* <kbd>2</kbd> - Overlay the **Instancer Grid**.
+* <kbd>3</kbd> - Overlay the **Vertex Grid**.
+* <kbd>4</kbd> - Overlay **Contour Lines**. Customize in the material when enabled.
 
 ### Special Cases
 
@@ -84,7 +120,9 @@ The settings are saved across sessions in `Editor Settings / Terrain3D / Tool Se
 
 Some tools like `Paint`, `Spray`, and `Color` have options to disable some features. e.g. Disabling `Texture` on `Paint` means it will only apply scale or angle. Enabling `Texture` on `Color` will filter color painting to the selected texture.
 
-On the right, the three dots button is the advanced menu. One noteworthy setting is `Jitter`, which is what causes the brush to spin while painting. Reduce it to zero if you don't want this.
+See [Slope Filter](#slope-filter) for keys that expand painting by slope functionality.
+
+The three dots button on the right is the advanced options menu. One noteworthy setting is `Jitter`, which is what causes the brush to spin while painting. Reduce it to zero if you don't want this.
 
 Brushes can be edited in the `addons/terrain_3d/brushes` directory, using your OS folder explorer. The folder is hidden to Godot. The files are 100x100 alpha masks saved as EXR. Larger sizes should work fine, but will be slow if too big.
 
@@ -120,22 +158,21 @@ Next the slider will resize the thumbnails.
 Finally, when the dock is in the sidebar, there are three vertical, grey dots, shown in the image above, in the top right. This also allows you to change the sidebar position, however setting it here won't save. Ignore this and use our dropdown instead.
 
 
-### Setting Up Assets
+### Adding Assets
 
-#### Adding Assets
 You can add resources by dragging a texture onto the `Add Texture` icon, a mesh (a packed scene: tscn, scn, fbx, glb) onto the `Add Mesh` icon, or by clicking either `Add` button and setting them up. 
+
+If you add a new texture and the terrain turns white, see [Troubleshooting](troubleshooting.md#added-a-texture-now-the-terrain-is-white).
 
 Each asset resource type has their own settings described in the API docs for [Terrain3DTextureAsset](../api/class_terrain3dtextureasset.rst) and [Terrain3DMeshAsset](../api/class_terrain3dmeshasset.rst).
 
 You can read more about mesh setup on the [Foliage Instancer page](instancer.md#how-to-use-the-instancer).
 
-#### Operations
+### Dock Operations
 
-<kbd>LMB</kbd> - Select the asset to paint with.
-
-<kbd>RMB</kbd> - Edit the asset in the inspector. You can also click the pencil on the thumbnail.
-
-<kbd>MMB</kbd> - Clear the asset. You can also click the X on the thumbnail. If this asset is at the end of the list, this will also remove it. You can clear and reuse this asset, or change its ID to move it to the end for removal. When using the instancer, this will remove all instances painted on the ground. It will ask for confirmation first.
+* <kbd>LMB</kbd> - Select the asset to paint with.
+* <kbd>RMB</kbd> - Edit the asset in the inspector. You can also click the pencil on the thumbnail.
+* <kbd>MMB</kbd> - Clear the asset. You can also click the X on the thumbnail. If this asset is at the end of the list, this will also remove it. You can clear and reuse this asset, or change its ID to move it to the end for removal. When using the instancer, this will remove all instances painted on the ground. It will ask for confirmation first.
 
 
 

--- a/project/addons/terrain_3d/src/toolbar.gd
+++ b/project/addons/terrain_3d/src/toolbar.gd
@@ -22,70 +22,72 @@ const ICON_INSTANCER: String = "res://addons/terrain_3d/icons/multimesh.svg"
 
 var add_tool_group: ButtonGroup = ButtonGroup.new()
 var sub_tool_group: ButtonGroup = ButtonGroup.new()
+var buttons: Dictionary
 
 
 func _init() -> void:
 	set_custom_minimum_size(Vector2(20, 0))
+
 
 func _ready() -> void:
 	add_tool_group.pressed.connect(_on_tool_selected)
 	sub_tool_group.pressed.connect(_on_tool_selected)
 
 	add_tool_button({ "tool":Terrain3DEditor.REGION, 
-		"add_text":"Add Region", "add_op":Terrain3DEditor.ADD, "add_icon":ICON_REGION_ADD,
+		"add_text":"Add Region (E)", "add_op":Terrain3DEditor.ADD, "add_icon":ICON_REGION_ADD,
 		"sub_text":"Remove Region", "sub_op":Terrain3DEditor.SUBTRACT, "sub_icon":ICON_REGION_REMOVE })
 	
 	add_child(HSeparator.new())
 	
 	add_tool_button({ "tool":Terrain3DEditor.SCULPT, 
-		"add_text":"Raise", "add_op":Terrain3DEditor.ADD, "add_icon":ICON_HEIGHT_ADD,
-		"sub_text":"Lower", "sub_op":Terrain3DEditor.SUBTRACT, "sub_icon":ICON_HEIGHT_SUB })
+		"add_text":"Raise (R)", "add_op":Terrain3DEditor.ADD, "add_icon":ICON_HEIGHT_ADD,
+		"sub_text":"Lower (R)", "sub_op":Terrain3DEditor.SUBTRACT, "sub_icon":ICON_HEIGHT_SUB })
 
 	add_tool_button({ "tool":Terrain3DEditor.SCULPT, 
-		"add_text":"Smooth", "add_op":Terrain3DEditor.AVERAGE, "add_icon":ICON_HEIGHT_SMOOTH })
+		"add_text":"Smooth (Shift)", "add_op":Terrain3DEditor.AVERAGE, "add_icon":ICON_HEIGHT_SMOOTH })
 
 	add_tool_button({ "tool":Terrain3DEditor.HEIGHT, 
-		"add_text":"Height", "add_op":Terrain3DEditor.ADD, "add_icon":ICON_HEIGHT_FLAT,
-		"sub_text":"Zero", "sub_op":Terrain3DEditor.SUBTRACT, "sub_icon":ICON_HEIGHT_FLAT })
+		"add_text":"Height (H)", "add_op":Terrain3DEditor.ADD, "add_icon":ICON_HEIGHT_FLAT,
+		"sub_text":"Height (H)", "sub_op":Terrain3DEditor.SUBTRACT, "sub_icon":ICON_HEIGHT_FLAT })
 
 	add_tool_button({ "tool":Terrain3DEditor.SCULPT, 
-		"add_text":"Slope", "add_op":Terrain3DEditor.GRADIENT, "add_icon":ICON_HEIGHT_SLOPE })
+		"add_text":"Slope (S)", "add_op":Terrain3DEditor.GRADIENT, "add_icon":ICON_HEIGHT_SLOPE })
 
 	add_child(HSeparator.new())
 
 	add_tool_button({ "tool":Terrain3DEditor.TEXTURE, 
-		"add_text":"Paint Base Texture", "add_op":Terrain3DEditor.REPLACE, "add_icon":ICON_PAINT_TEXTURE })
+		"add_text":"Paint Base Texture (B)", "add_op":Terrain3DEditor.REPLACE, "add_icon":ICON_PAINT_TEXTURE })
 
 	add_tool_button({ "tool":Terrain3DEditor.TEXTURE, 
-		"add_text":"Spray Overlay Texture", "add_op":Terrain3DEditor.ADD, "add_icon":ICON_SPRAY_TEXTURE })
+		"add_text":"Spray Overlay Texture (V)", "add_op":Terrain3DEditor.ADD, "add_icon":ICON_SPRAY_TEXTURE })
 
 	add_tool_button({ "tool":Terrain3DEditor.AUTOSHADER,
-		"add_text":"Enable Autoshader", "add_op":Terrain3DEditor.ADD, "add_icon":ICON_AUTOSHADER,
-		"sub_text":"Disable Autoshader", "sub_op":Terrain3DEditor.SUBTRACT })
+		"add_text":"Paint Autoshader (A)", "add_op":Terrain3DEditor.ADD, "add_icon":ICON_AUTOSHADER,
+		"sub_text":"Disable Autoshader (A)", "sub_op":Terrain3DEditor.SUBTRACT })
 
 	add_child(HSeparator.new())
 
 	add_tool_button({ "tool":Terrain3DEditor.COLOR,
-		"add_text":"Paint Color", "add_op":Terrain3DEditor.ADD, "add_icon":ICON_COLOR,
-		"sub_text":"Remove Color", "sub_op":Terrain3DEditor.SUBTRACT })
+		"add_text":"Paint Color (C)", "add_op":Terrain3DEditor.ADD, "add_icon":ICON_COLOR,
+		"sub_text":"Remove Color (C)", "sub_op":Terrain3DEditor.SUBTRACT })
 	
 	add_tool_button({ "tool":Terrain3DEditor.ROUGHNESS,
-		"add_text":"Paint Wetness", "add_op":Terrain3DEditor.ADD, "add_icon":ICON_WETNESS,
-		"sub_text":"Remove Wetness", "sub_op":Terrain3DEditor.SUBTRACT })
+		"add_text":"Paint Wetness (W)", "add_op":Terrain3DEditor.ADD, "add_icon":ICON_WETNESS,
+		"sub_text":"Remove Wetness (W)", "sub_op":Terrain3DEditor.SUBTRACT })
 
 	add_child(HSeparator.new())
 
 	add_tool_button({ "tool":Terrain3DEditor.HOLES,
-		"add_text":"Add Holes", "add_op":Terrain3DEditor.ADD, "add_icon":ICON_HOLES,
-		"sub_text":"Remove Holes", "sub_op":Terrain3DEditor.SUBTRACT })
+		"add_text":"Add Holes (X)", "add_op":Terrain3DEditor.ADD, "add_icon":ICON_HOLES,
+		"sub_text":"Remove Holes (X)", "sub_op":Terrain3DEditor.SUBTRACT })
 
 	add_tool_button({ "tool":Terrain3DEditor.NAVIGATION,
-		"add_text":"Paint Navigable Area", "add_op":Terrain3DEditor.ADD, "add_icon":ICON_NAVIGATION,
-		"sub_text":"Remove Navigable Area", "sub_op":Terrain3DEditor.SUBTRACT })
+		"add_text":"Paint Navigable Area (N)", "add_op":Terrain3DEditor.ADD, "add_icon":ICON_NAVIGATION,
+		"sub_text":"Remove Navigable Area (N)", "sub_op":Terrain3DEditor.SUBTRACT })
 
 	add_tool_button({ "tool":Terrain3DEditor.INSTANCER,
-		"add_text":"Instance Meshes", "add_op":Terrain3DEditor.ADD, "add_icon":ICON_INSTANCER,
-		"sub_text":"Remove Meshes", "sub_op":Terrain3DEditor.SUBTRACT })
+		"add_text":"Instance Meshes (I)", "add_op":Terrain3DEditor.ADD, "add_icon":ICON_INSTANCER,
+		"sub_text":"Remove Meshes (I)", "sub_op":Terrain3DEditor.SUBTRACT })
 
 	# Select first button
 	var buttons: Array[BaseButton] = add_tool_group.get_buttons()
@@ -96,7 +98,8 @@ func _ready() -> void:
 func add_tool_button(p_params: Dictionary) -> void:
 	# Additive button
 	var button := Button.new()
-	button.set_name(p_params.get("add_text", "blank").to_pascal_case())
+	var name_str: String = p_params.get("add_text", "blank").get_slice('(', 0).to_pascal_case()
+	button.set_name(name_str)
 	button.set_meta("Tool", p_params.get("tool", 0))
 	button.set_meta("Operation", p_params.get("add_op", 0))
 	button.set_meta("ID", add_tool_group.get_buttons().size() + 1)
@@ -107,12 +110,14 @@ func add_tool_button(p_params: Dictionary) -> void:
 	button.set_h_size_flags(SIZE_SHRINK_END)
 	button.set_button_group(p_params.get("group", add_tool_group))
 	add_child(button, true)
+	buttons[button.get_name()] = button
 
 	# Subtractive button
 	var button2: Button
 	if p_params.has("sub_text"):
 		button2 = Button.new()
-		button2.set_name(p_params.get("sub_text", "blank").to_pascal_case())
+		name_str = p_params.get("sub_text", "blank").get_slice('(', 0).to_pascal_case()
+		button.set_name(name_str)
 		button2.set_meta("Tool", p_params.get("tool", 0))
 		button2.set_meta("Operation", p_params.get("sub_op", 0))
 		button2.set_meta("ID", button.get_meta("ID"))
@@ -125,6 +130,11 @@ func add_tool_button(p_params: Dictionary) -> void:
 		button2 = button.duplicate()
 	button2.set_button_group(p_params.get("group", sub_tool_group))
 	add_child(button2, true)
+	buttons[button2.get_name()] = button
+
+
+func get_button(p_name: String) -> Button:
+	return buttons.get(p_name, null)
 
 
 func show_add_buttons(p_enable: bool) -> void:

--- a/project/addons/terrain_3d/src/ui.gd
+++ b/project/addons/terrain_3d/src/ui.gd
@@ -316,6 +316,45 @@ func _invert_operation(p_operation: Terrain3DEditor.Operation, flags: int = OP_N
 	return p_operation
 
 
+func consume_hotkey(keycode: int) -> bool:
+	match keycode:
+		KEY_1:
+			plugin.terrain.material.set_show_region_grid(!plugin.terrain.material.get_show_region_grid())
+		KEY_2:
+			plugin.terrain.material.set_show_instancer_grid(!plugin.terrain.material.get_show_instancer_grid())
+		KEY_3:
+			plugin.terrain.material.set_show_vertex_grid(!plugin.terrain.material.get_show_vertex_grid())
+		KEY_4:
+			plugin.terrain.material.set_show_contours(!plugin.terrain.material.get_show_contours())
+		KEY_E:
+			toolbar.get_button("AddRegion").set_pressed(true)
+		KEY_R:
+			toolbar.get_button("Raise").set_pressed(true)
+		KEY_H:
+			toolbar.get_button("Height").set_pressed(true)
+		KEY_S:
+			toolbar.get_button("Slope").set_pressed(true)
+		KEY_C:
+			toolbar.get_button("PaintColor").set_pressed(true)
+		KEY_N:
+			toolbar.get_button("PaintNavigableArea").set_pressed(true)
+		KEY_I:
+			toolbar.get_button("InstanceMeshes").set_pressed(true)
+		KEY_X:
+			toolbar.get_button("AddHoles").set_pressed(true)
+		KEY_W:
+			toolbar.get_button("PaintWetness").set_pressed(true)
+		KEY_B:
+			toolbar.get_button("PaintBaseTexture").set_pressed(true)
+		KEY_V:
+			toolbar.get_button("SprayOverlayTexture").set_pressed(true)
+		KEY_A:
+			toolbar.get_button("PaintAutoshader").set_pressed(true)
+		_:
+			return false
+	return true
+
+
 func update_decal() -> void:
 	if not plugin.terrain or brush_data.size() <= 3:
 		return

--- a/src/shaders/debug_views.glsl
+++ b/src/shaders/debug_views.glsl
@@ -6,208 +6,317 @@
 R"(
 //INSERT: DEBUG_CHECKERED
 	// Show a checkered grid
-	vec2 __p = uv * 1.0; // scale
-	vec2 __ddx = dFdx(__p);
-	vec2 __ddy = dFdy(__p);
-	vec2 __w = max(abs(__ddx), abs(__ddy)) + 0.01;
-	vec2 __i = 2.0 * (abs(fract((__p - 0.5 * __w) / 2.0) - 0.5) - abs(fract((__p + 0.5 * __w) / 2.0) - 0.5)) / __w;
-	ALBEDO = vec3((0.5 - 0.5 * __i.x * __i.y) * 0.2 + 0.2);
-	ROUGHNESS = 0.7;
-	SPECULAR = 0.;
-	NORMAL_MAP = vec3(0.5, 0.5, 1.0);
-	AO = 1.0;
+	{
+		vec2 __p = uv * 1.0; // scale
+		vec2 __ddx = dFdx(__p);
+		vec2 __ddy = dFdy(__p);
+		vec2 __w = max(abs(__ddx), abs(__ddy)) + 0.01;
+		vec2 __i = 2.0 * (abs(fract((__p - 0.5 * __w) / 2.0) - 0.5) - abs(fract((__p + 0.5 * __w) / 2.0) - 0.5)) / __w;
+		ALBEDO = vec3((0.5 - 0.5 * __i.x * __i.y) * 0.2 + 0.2);
+		ROUGHNESS = 0.7;
+		SPECULAR = 0.;
+		NORMAL_MAP = vec3(0.5, 0.5, 1.0);
+		AO = 1.0;
+	}
 
 //INSERT: DEBUG_GREY
 	// Show all grey
-	ALBEDO = vec3(0.2);
-	ROUGHNESS = 0.7;
-	SPECULAR = 0.;
-	NORMAL_MAP = vec3(0.5, 0.5, 1.0);
-	AO = 1.0;
+	{
+		ALBEDO = vec3(0.2);
+		ROUGHNESS = 0.7;
+		SPECULAR = 0.;
+		NORMAL_MAP = vec3(0.5, 0.5, 1.0);
+		AO = 1.0;
+	}
 
 //INSERT: DEBUG_HEIGHTMAP
 	// Show heightmap
-	ALBEDO = vec3(smoothstep(-0.1, 2.0, 0.5 + v_vertex.y/300.0));
-	ROUGHNESS = 0.7;
-	SPECULAR = 0.;
-	NORMAL_MAP = vec3(0.5, 0.5, 1.0);
-	AO = 1.0;
+	{
+		ALBEDO = vec3(smoothstep(-0.1, 2.0, 0.5 + v_vertex.y/300.0));
+		ROUGHNESS = 0.7;
+		SPECULAR = 0.;
+		NORMAL_MAP = vec3(0.5, 0.5, 1.0);
+		AO = 1.0;
+	}
 
 //INSERT: DEBUG_COLORMAP
 	// Show colormap
-	ALBEDO = color_map.rgb;
-	ROUGHNESS = 0.7;
-	SPECULAR = 0.;
-	NORMAL_MAP = vec3(0.5, 0.5, 1.0);
-	AO = 1.0;
+	{
+		ALBEDO = color_map.rgb;
+		ROUGHNESS = 0.7;
+		SPECULAR = 0.;
+		NORMAL_MAP = vec3(0.5, 0.5, 1.0);
+		AO = 1.0;
+	}
 
 //INSERT: DEBUG_ROUGHMAP
 	// Show roughness map
-	ALBEDO = vec3(color_map.a);
-	ROUGHNESS = 0.7;
-	SPECULAR = 0.;
-	NORMAL_MAP = vec3(0.5, 0.5, 1.0);
-	AO = 1.0;
+	{
+		ALBEDO = vec3(color_map.a);
+		ROUGHNESS = 0.7;
+		SPECULAR = 0.;
+		NORMAL_MAP = vec3(0.5, 0.5, 1.0);
+		AO = 1.0;
+	}
 
 //INSERT: DEBUG_CONTROL_TEXTURE
-	
 	// Show control map texture selection
-	vec3 __t_colors[32];
-	__t_colors[0] = vec3(1.0, 0.0, 0.0);
-	__t_colors[1] = vec3(0.0, 1.0, 0.0);
-	__t_colors[2] = vec3(0.0, 0.0, 1.0);
-	__t_colors[3] = vec3(1.0, 0.0, 1.0);
-	__t_colors[4] = vec3(0.0, 1.0, 1.0);
-	__t_colors[5] = vec3(1.0, 1.0, 0.0);
-	__t_colors[6] = vec3(0.2, 0.0, 0.0);
-	__t_colors[7] = vec3(0.0, 0.2, 0.0);
-	__t_colors[8] = vec3(0.0, 0.0, 0.35);
-	__t_colors[9] = vec3(0.2, 0.0, 0.2);
-	__t_colors[10] = vec3(0.0, 0.2, 0.2);
-	__t_colors[11] = vec3(0.2, 0.2, 0.0);
-	__t_colors[12] = vec3(0.1, 0.0, 0.0);
-	__t_colors[13] = vec3(0.0, 0.1, 0.0);
-	__t_colors[14] = vec3(0.0, 0.0, 0.15);
-	__t_colors[15] = vec3(0.1, 0.0, 0.1);
-	__t_colors[16] = vec3(0.0, 0.1, 0.1);
-	__t_colors[17] = vec3(0.1, 0.1, 0.0);
-	__t_colors[18] = vec3(0.2, 0.05, 0.05);
-	__t_colors[19] = vec3(0.1, 0.3, 0.1);
-	__t_colors[20] = vec3(0.05, 0.05, 0.2);
-	__t_colors[21] = vec3(0.1, 0.05, 0.2);
-	__t_colors[22] = vec3(0.05, 0.15, 0.2);
-	__t_colors[23] = vec3(0.2, 0.2, 0.1);
-	__t_colors[24] = vec3(1.0);
-	__t_colors[25] = vec3(0.5);
-	__t_colors[26] = vec3(0.35);
-	__t_colors[27] = vec3(0.25);
-	__t_colors[28] = vec3(0.15);
-	__t_colors[29] = vec3(0.1);
-	__t_colors[30] = vec3(0.05);
-	__t_colors[31] = vec3(0.0125);
-	vec3 __ctrl_base = __t_colors[mat[3].base];
-	vec3 __ctrl_over = __t_colors[mat[3].over];
-	float base_over = (length(fract(uv) - 0.5) < fma(mat[3].blend, 0.45, 0.1) ? 1.0 : 0.0);
-	ALBEDO = mix(__ctrl_base, __ctrl_over, base_over);	
-	ROUGHNESS = 1.0;
-	SPECULAR = 0.0;
-	NORMAL_MAP = vec3(0.5, 0.5, 1.0);
-	AO = 1.0;
+	{
+		vec3 __t_colors[32];
+		__t_colors[0] = vec3(1.0, 0.0, 0.0);
+		__t_colors[1] = vec3(0.0, 1.0, 0.0);
+		__t_colors[2] = vec3(0.0, 0.0, 1.0);
+		__t_colors[3] = vec3(1.0, 0.0, 1.0);
+		__t_colors[4] = vec3(0.0, 1.0, 1.0);
+		__t_colors[5] = vec3(1.0, 1.0, 0.0);
+		__t_colors[6] = vec3(0.2, 0.0, 0.0);
+		__t_colors[7] = vec3(0.0, 0.2, 0.0);
+		__t_colors[8] = vec3(0.0, 0.0, 0.35);
+		__t_colors[9] = vec3(0.2, 0.0, 0.2);
+		__t_colors[10] = vec3(0.0, 0.2, 0.2);
+		__t_colors[11] = vec3(0.2, 0.2, 0.0);
+		__t_colors[12] = vec3(0.1, 0.0, 0.0);
+		__t_colors[13] = vec3(0.0, 0.1, 0.0);
+		__t_colors[14] = vec3(0.0, 0.0, 0.15);
+		__t_colors[15] = vec3(0.1, 0.0, 0.1);
+		__t_colors[16] = vec3(0.0, 0.1, 0.1);
+		__t_colors[17] = vec3(0.1, 0.1, 0.0);
+		__t_colors[18] = vec3(0.2, 0.05, 0.05);
+		__t_colors[19] = vec3(0.1, 0.3, 0.1);
+		__t_colors[20] = vec3(0.05, 0.05, 0.2);
+		__t_colors[21] = vec3(0.1, 0.05, 0.2);
+		__t_colors[22] = vec3(0.05, 0.15, 0.2);
+		__t_colors[23] = vec3(0.2, 0.2, 0.1);
+		__t_colors[24] = vec3(1.0);
+		__t_colors[25] = vec3(0.5);
+		__t_colors[26] = vec3(0.35);
+		__t_colors[27] = vec3(0.25);
+		__t_colors[28] = vec3(0.15);
+		__t_colors[29] = vec3(0.1);
+		__t_colors[30] = vec3(0.05);
+		__t_colors[31] = vec3(0.0125);
+		vec3 __ctrl_base = __t_colors[mat[3].base];
+		vec3 __ctrl_over = __t_colors[mat[3].over];
+		float base_over = (length(fract(uv) - 0.5) < fma(mat[3].blend, 0.45, 0.1) ? 1.0 : 0.0);
+		ALBEDO = mix(__ctrl_base, __ctrl_over, base_over);	
+		ROUGHNESS = 1.0;
+		SPECULAR = 0.0;
+		NORMAL_MAP = vec3(0.5, 0.5, 1.0);
+		AO = 1.0;
+	}
 
 //INSERT: DEBUG_CONTROL_ANGLE
-	ivec3 __auv = get_index_coord(floor(uv), SKIP_PASS);
-	uint __a_control = floatBitsToUint(texelFetch(_control_maps, __auv, 0)).r;
-	uint __angle = (__a_control >>10u & 0xFu);
-	vec3 __a_colors[16] = {
-		vec3(1., .2, .0), vec3(.8, 0., .2), vec3(.6, .0, .4), vec3(.4, .0, .6),
-		vec3(.2, 0., .8), vec3(.1, .1, .8), vec3(0., .2, .8), vec3(0., .4, .6),
-		vec3(0., .6, .4), vec3(0., .8, .2), vec3(0., 1., 0.), vec3(.2, 1., 0.),
-		vec3(.4, 1., 0.), vec3(.6, 1., 0.), vec3(.8, .6, 0.), vec3(1., .4, 0.)
-	};
-	ALBEDO = __a_colors[__angle];
-	ROUGHNESS = 1.;
-	SPECULAR = 0.;
-	NORMAL_MAP = vec3(0.5, 0.5, 1.0);
-	AO = 1.0;
+	// Show control map texture angle
+	{
+		ivec3 __auv = get_index_coord(floor(uv), SKIP_PASS);
+		uint __a_control = floatBitsToUint(texelFetch(_control_maps, __auv, 0)).r;
+		uint __angle = (__a_control >>10u & 0xFu);
+		vec3 __a_colors[16] = {
+			vec3(1., .2, .0), vec3(.8, 0., .2), vec3(.6, .0, .4), vec3(.4, .0, .6),
+			vec3(.2, 0., .8), vec3(.1, .1, .8), vec3(0., .2, .8), vec3(0., .4, .6),
+			vec3(0., .6, .4), vec3(0., .8, .2), vec3(0., 1., 0.), vec3(.2, 1., 0.),
+			vec3(.4, 1., 0.), vec3(.6, 1., 0.), vec3(.8, .6, 0.), vec3(1., .4, 0.)
+		};
+		ALBEDO = __a_colors[__angle];
+		ROUGHNESS = 1.;
+		SPECULAR = 0.;
+		NORMAL_MAP = vec3(0.5, 0.5, 1.0);
+		AO = 1.0;
+	}
 
 //INSERT: DEBUG_CONTROL_SCALE
-	ivec3 __suv = get_index_coord(floor(uv), SKIP_PASS);
-	uint __s_control = floatBitsToUint(texelFetch(_control_maps, __suv, 0)).r;
-	uint __scale = (__s_control >>7u & 0x7u);
-	vec3 __s_colors[8] = {
-		vec3(.5, .5, .5), vec3(.675, .25, .375), vec3(.75, .125, .25), vec3(.875, .0, .125), vec3(1., 0., 0.),
-		vec3(0., 0., 1.), vec3(.0, .166, .833), vec3(.166, .333, .666)
-	};
-	ALBEDO = __s_colors[__scale];
-	ROUGHNESS = 1.;
-	SPECULAR = 0.;
-	NORMAL_MAP = vec3(0.5 ,0.5 ,1.0);
-	AO = 1.0;
+	// Show control map texture scale
+	{
+		ivec3 __suv = get_index_coord(floor(uv), SKIP_PASS);
+		uint __s_control = floatBitsToUint(texelFetch(_control_maps, __suv, 0)).r;
+		uint __scale = (__s_control >>7u & 0x7u);
+		vec3 __s_colors[8] = {
+			vec3(.5, .5, .5), vec3(.675, .25, .375), vec3(.75, .125, .25), vec3(.875, .0, .125), vec3(1., 0., 0.),
+			vec3(0., 0., 1.), vec3(.0, .166, .833), vec3(.166, .333, .666)
+		};
+		ALBEDO = __s_colors[__scale];
+		ROUGHNESS = 1.;
+		SPECULAR = 0.;
+		NORMAL_MAP = vec3(0.5 ,0.5 ,1.0);
+		AO = 1.0;
+	}
 
 //INSERT: DEBUG_CONTROL_BLEND
 	// Show control map blend values
-	float __ctrl_blend = mat[3].blend;
-	ALBEDO = vec3(__ctrl_blend);
-	ROUGHNESS = 1.;
-	SPECULAR = 0.;
-	NORMAL_MAP = vec3(0.5, 0.5, 1.0);
-	AO = 1.0;
+	{
+		float __ctrl_blend = mat[3].blend;
+		ALBEDO = vec3(__ctrl_blend);
+		ROUGHNESS = 1.;
+		SPECULAR = 0.;
+		NORMAL_MAP = vec3(0.5, 0.5, 1.0);
+		AO = 1.0;
+	}
 
 //INSERT: DEBUG_AUTOSHADER
-	ivec3 __ruv = get_index_coord(floor(uv), SKIP_PASS);
-	uint __control = floatBitsToUint(texelFetch(_control_maps, __ruv, 0)).r;
-	float __autoshader = float( bool(__control & 0x1u) || __ruv.z<0 );
-	ALBEDO = vec3(__autoshader);
-	ROUGHNESS = 1.;
-	SPECULAR = 0.;
-	NORMAL_MAP = vec3(0.5, 0.5, 1.0);
-	AO = 1.0;
+	// Show where autoshader enabled
+	{
+		ivec3 __ruv = get_index_coord(floor(uv), SKIP_PASS);
+		uint __control = floatBitsToUint(texelFetch(_control_maps, __ruv, 0)).r;
+		float __autoshader = float( bool(__control & 0x1u) || __ruv.z<0 );
+		ALBEDO = vec3(__autoshader);
+		ROUGHNESS = 1.;
+		SPECULAR = 0.;
+		NORMAL_MAP = vec3(0.5, 0.5, 1.0);
+		AO = 1.0;
+	}
 
 //INSERT: DEBUG_TEXTURE_HEIGHT
 	// Show height textures
-	ALBEDO = vec3(albedo_height.a);
-	ROUGHNESS = 0.7;
-	SPECULAR = 0.;
-	NORMAL_MAP = vec3(0.5, 0.5, 1.0);
-	AO = 1.0;
+	{
+		ALBEDO = vec3(albedo_height.a);
+		ROUGHNESS = 0.7;
+		SPECULAR = 0.;
+		NORMAL_MAP = vec3(0.5, 0.5, 1.0);
+		AO = 1.0;
+	}
 
 //INSERT: DEBUG_TEXTURE_NORMAL
 	// Show normal map textures
-	ALBEDO = pack_normal(normal_rough.rgb);
-	ROUGHNESS = 0.7;
-	SPECULAR = 0.;
-	NORMAL_MAP = vec3(0.5, 0.5, 1.0);
-	AO = 1.0;
+	{
+		ALBEDO = pack_normal(normal_rough.rgb);
+		ROUGHNESS = 0.7;
+		SPECULAR = 0.;
+		NORMAL_MAP = vec3(0.5, 0.5, 1.0);
+		AO = 1.0;
+	}
 
 //INSERT: DEBUG_TEXTURE_ROUGHNESS
 	// Show roughness textures
-	ALBEDO = vec3(normal_rough.a);
-	ROUGHNESS = 0.7;
-	SPECULAR = 0.;
-	NORMAL_MAP = vec3(0.5, 0.5, 1.0);
-	AO = 1.0;
-
-//INSERT: DEBUG_REGION_GRID
-	// Show region grid
-	vec3 __pixel_pos1 = (INV_VIEW_MATRIX * vec4(VERTEX,1.0)).xyz;
-	float __region_line = 1.0;		// Region line thickness
-	__region_line *= .1*sqrt(length(_camera_pos - __pixel_pos1));
-	if (mod(__pixel_pos1.x * _vertex_density + __region_line*.5, _region_size) <= __region_line || 
-		mod(__pixel_pos1.z * _vertex_density + __region_line*.5, _region_size) <= __region_line ) {
-		ALBEDO = vec3(1.);
+	{
+		ALBEDO = vec3(normal_rough.a);
+		ROUGHNESS = 0.7;
+		SPECULAR = 0.;
+		NORMAL_MAP = vec3(0.5, 0.5, 1.0);
+		AO = 1.0;
 	}
 
-//INSERT: DEBUG_VERTEX_GRID
+//INSERT: OVERLAY_REGION_GRID
+	// Show region grid
+	{
+		vec3 __pixel_pos = (INV_VIEW_MATRIX * vec4(VERTEX,1.0)).xyz;
+		float __region_line = 1.0;		// Region line thickness
+		__region_line *= .1*sqrt(length(_camera_pos - __pixel_pos));
+		if (mod(__pixel_pos.x * _vertex_density + __region_line*.5, _region_size) <= __region_line || 
+			mod(__pixel_pos.z * _vertex_density + __region_line*.5, _region_size) <= __region_line ) {
+			ALBEDO = vec3(1.);
+		}
+	}
+
+//INSERT: OVERLAY_INSTANCER_GRID
+	// Show region grid
+	{
+		vec3 __pixel_pos = (INV_VIEW_MATRIX * vec4(VERTEX,1.0)).xyz;
+		float __cell_line = 0.5;		// Cell line thickness
+		__cell_line *= .1*sqrt(length(_camera_pos - __pixel_pos));
+		#define CELL_SIZE 32
+		if (mod(__pixel_pos.x * _vertex_density + __cell_line*.5, CELL_SIZE) <= __cell_line || 
+			mod(__pixel_pos.z * _vertex_density + __cell_line*.5, CELL_SIZE) <= __cell_line ) {
+			ALBEDO = vec3(.033);
+		}
+	}
+
+//INSERT: OVERLAY_VERTEX_GRID
 	// Show vertex grids
-	vec3 __pixel_pos2 = (INV_VIEW_MATRIX * vec4(VERTEX,1.0)).xyz;
-	float __grid_line = 0.05;		// Vertex grid line thickness
-	float __grid_step = 1.0;			// Vertex grid size, 1.0 == integer units
-	float __vertex_size = 4.;		// Size of vertices
-	float __view_distance = 300.0;	// Visible distance of grid
-	vec3 __vertex_mul = vec3(0.);
-	vec3 __vertex_add = vec3(0.);
-	float __distance_factor = clamp(1.-length(_camera_pos - __pixel_pos2)/__view_distance, 0., 1.);
-	// Draw vertex grid
-	if ( mod(__pixel_pos2.x * _vertex_density + __grid_line*.5, __grid_step) < __grid_line || 
-	  	 mod(__pixel_pos2.z * _vertex_density + __grid_line*.5, __grid_step) < __grid_line ) { 
-		__vertex_mul = vec3(0.5) * __distance_factor;
-	}
-	// Draw Vertices
-	if ( mod(UV.x + __grid_line*__vertex_size*.5, __grid_step) < __grid_line*__vertex_size &&
-	  	 mod(UV.y + __grid_line*__vertex_size*.5, __grid_step) < __grid_line*__vertex_size ) { 
-		__vertex_add = vec3(0.15) * __distance_factor;
-	}
-	ALBEDO = fma(ALBEDO, 1.-__vertex_mul, __vertex_add);
-
-//INSERT: DEBUG_INSTANCER_GRID
-	// Show region grid
-	vec3 __pixel_pos3 = (INV_VIEW_MATRIX * vec4(VERTEX,1.0)).xyz;
-	float __cell_line = 0.5;		// Cell line thickness
-	__cell_line *= .1*sqrt(length(_camera_pos - __pixel_pos3));
-	#define CELL_SIZE 32
-	if (mod(__pixel_pos3.x * _vertex_density + __cell_line*.5, CELL_SIZE) <= __cell_line || 
-		mod(__pixel_pos3.z * _vertex_density + __cell_line*.5, CELL_SIZE) <= __cell_line ) {
-		ALBEDO = vec3(.033);
+	{
+		vec3 __pixel_pos = (INV_VIEW_MATRIX * vec4(VERTEX,1.0)).xyz;
+		float __grid_line = 0.05;		// Vertex grid line thickness
+		float __grid_step = 1.0;			// Vertex grid size, 1.0 == integer units
+		float __vertex_size = 4.;		// Size of vertices
+		float __view_distance = 300.0;	// Visible distance of grid
+		vec3 __vertex_mul = vec3(0.);
+		vec3 __vertex_add = vec3(0.);
+		float __distance_factor = clamp(1.-length(_camera_pos - __pixel_pos)/__view_distance, 0., 1.);
+		// Draw vertex grid
+		if ( mod(__pixel_pos.x * _vertex_density + __grid_line*.5, __grid_step) < __grid_line || 
+	  		 mod(__pixel_pos.z * _vertex_density + __grid_line*.5, __grid_step) < __grid_line ) { 
+			__vertex_mul = vec3(0.5) * __distance_factor;
+		}
+		// Draw Vertices
+		if ( mod(UV.x + __grid_line*__vertex_size*.5, __grid_step) < __grid_line*__vertex_size &&
+	  		 mod(UV.y + __grid_line*__vertex_size*.5, __grid_step) < __grid_line*__vertex_size ) { 
+			__vertex_add = vec3(0.15) * __distance_factor;
+		}
+		ALBEDO = fma(ALBEDO, 1.-__vertex_mul, __vertex_add);
 	}
 
+//INSERT: OVERLAY_CONTOURS_SETUP
+uniform bool contour_dynamic = true;
+uniform float contour_interval: hint_range(0.25, 100.0, 0.001) = 1.0;
+uniform float contour_thickness : hint_range(0.0, 10.0, 0.001) = 1.0;
+uniform vec4 contour_color : source_color = vec4(.85, .85, .19, 1.);
+
+float contour_lines(float thickness, float interval, vec3 spatial_coords, vec3 normal, vec3 base_ddx, vec3 base_ddy) {
+    float y = spatial_coords.y;
+    float y_fwidth = abs(base_ddx.y) + abs(base_ddy.y);
+    thickness *= smoothstep(0., 0.0125, clamp(1.0 - normal.y, 0., 1.));
+    float mi = max(0.0, thickness - 1.0);
+    float ma = max(1.0, thickness);
+    float mx = max(0.0, 1.0 - thickness);
+    float inv_interval = 1.0 / interval;
+    float f_a = abs(fract((y + interval * 0.5) * inv_interval) - 0.5);
+    float df_a = y_fwidth * inv_interval;
+    float line_a = clamp((f_a - df_a * mi) / (df_a * (ma - mi)), mx, 1.0);
+    return line_a;
+}
+
+float fractal_contour_lines(float thickness, float interval, vec3 spatial_coords, vec3 normal, vec3 base_ddx, vec3 base_ddy) {
+    float depth = max(log(length(spatial_coords - _camera_pos) / interval) * (1.0 / log2(2.0)) - 1.0, 1.0);
+
+    float interval_a = interval * exp2(max(floor(depth) - 1.0, 1.0)) * 0.5;
+    float interval_b = interval * exp2(max(floor(depth), 1.0)) * 0.5;
+    float interval_c = interval * exp2(max(floor(depth + 0.5) - 1.0, 1.0)) * 0.5;
+
+    float y = spatial_coords.y;
+    float y_fwidth = abs(base_ddx.y) + abs(base_ddy.y);
+
+    thickness *= smoothstep(0., 0.0125, clamp(1.0 - normal.y, 0., 1.));
+    float mi = max(0.0, thickness - 1.0);
+    float ma = max(1.0, thickness);
+    float mx = max(0.0, 1.0 - thickness);
+
+    // Line A
+    float inv_interval_a = 1.0 / interval_a;
+    float f_a = abs(fract((y + interval_a * 0.5) * inv_interval_a) - 0.5);
+    float df_a = y_fwidth * inv_interval_a;
+    float line_a = clamp((f_a - df_a * mi) / (df_a * (ma - mi)), mx, 1.0);
+
+    // Line B
+    float inv_interval_b = 1.0 / interval_b;
+    float f_b = abs(fract((y + interval_b * 0.5) * inv_interval_b) - 0.5);
+    float df_b = y_fwidth * inv_interval_b;
+    float line_b = clamp((f_b - df_b * mi) / (df_b * (ma - mi)), mx, 1.0);
+
+    // Line C
+    float inv_interval_c = 1.0 / interval_c;
+    float f_c = abs(fract((y + interval_c * 0.5) * inv_interval_c) - 0.5);
+    float df_c = y_fwidth * inv_interval_c;
+    float line_c = clamp((f_c - df_c * mi) / (df_c * (ma - mi)), mx, 1.0);
+
+    // Blend out
+    float p = fract(depth - 0.5);
+    float line = mix(mix(line_a, line_b, fract(depth)), line_c, (4.0 * p * (1.0 - p)));
+    return line;
+}
+
+//INSERT: OVERLAY_CONTOURS_RENDER
+	// Show contour lines
+	{
+		float __line = 0.;
+		vec3 __pixel_pos = (INV_VIEW_MATRIX * vec4(VERTEX,1.0)).xyz;
+		vec3 __base_ddx = dFdxCoarse(__pixel_pos);
+		vec3 __base_ddy = dFdyCoarse(__pixel_pos);
+		vec3 __w_normal = normalize(cross(__base_ddy, __base_ddx));
+
+		if(contour_dynamic) {
+			__line = fractal_contour_lines(contour_thickness, contour_interval, __pixel_pos, __w_normal, __base_ddx, __base_ddy);
+		} else {
+			__line = contour_lines(contour_thickness, contour_interval, __pixel_pos, __w_normal, __base_ddx, __base_ddy);
+		}
+		ALBEDO = mix(ALBEDO, contour_color.rgb, (1.-__line) * contour_color.a);
+	}
 )"

--- a/src/shaders/editor_functions.glsl
+++ b/src/shaders/editor_functions.glsl
@@ -5,11 +5,13 @@
 R"(
 //INSERT: EDITOR_NAVIGATION
 	// Show navigation
-	if(bool(floatBitsToUint(texelFetch(_control_maps, get_index_coord(floor(uv + 0.5), SKIP_PASS), 0)).r >>1u & 0x1u)) {
-		ALBEDO *= vec3(.5, .0, .85);
+	{
+		if(bool(floatBitsToUint(texelFetch(_control_maps, get_index_coord(floor(uv + 0.5), SKIP_PASS), 0)).r >>1u & 0x1u)) {
+			ALBEDO *= vec3(.5, .0, .85);
+		}
 	}
 
-//INSERT: EDITOR_SETUP_DECAL
+//INSERT: EDITOR_DECAL_SETUP
 uniform highp sampler2D _editor_brush_texture : source_color, filter_linear, repeat_disable;
 uniform highp sampler2D _editor_ring_texture : source_color, filter_linear, repeat_disable;
 uniform vec2 _editor_decal_position[3];
@@ -61,7 +63,9 @@ vec3 get_decal(vec3 albedo, vec2 uv) {
 	return albedo;
 }
 
-//INSERT: EDITOR_RENDER_DECAL
-	ALBEDO = get_decal(ALBEDO, uv);
-
+//INSERT: EDITOR_DECAL_RENDER
+	// Render decal
+	{
+		ALBEDO = get_decal(ALBEDO, uv);
+	}
 )"

--- a/src/terrain_3d.cpp
+++ b/src/terrain_3d.cpp
@@ -1062,6 +1062,18 @@ void Terrain3D::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("set_show_instances", "visible"), &Terrain3D::set_show_instances);
 	ClassDB::bind_method(D_METHOD("get_show_instances"), &Terrain3D::get_show_instances);
 
+	// Overlays
+	ClassDB::bind_method(D_METHOD("set_show_region_grid", "enabled"), &Terrain3D::set_show_region_grid);
+	ClassDB::bind_method(D_METHOD("get_show_region_grid"), &Terrain3D::get_show_region_grid);
+	ClassDB::bind_method(D_METHOD("set_show_instancer_grid", "enabled"), &Terrain3D::set_show_instancer_grid);
+	ClassDB::bind_method(D_METHOD("get_show_instancer_grid"), &Terrain3D::get_show_instancer_grid);
+	ClassDB::bind_method(D_METHOD("set_show_vertex_grid", "enabled"), &Terrain3D::set_show_vertex_grid);
+	ClassDB::bind_method(D_METHOD("get_show_vertex_grid"), &Terrain3D::get_show_vertex_grid);
+	ClassDB::bind_method(D_METHOD("set_show_contours", "enabled"), &Terrain3D::set_show_contours);
+	ClassDB::bind_method(D_METHOD("get_show_contours"), &Terrain3D::get_show_contours);
+	ClassDB::bind_method(D_METHOD("set_show_navigation", "enabled"), &Terrain3D::set_show_navigation);
+	ClassDB::bind_method(D_METHOD("get_show_navigation"), &Terrain3D::get_show_navigation);
+
 	// Debug Views
 	ClassDB::bind_method(D_METHOD("set_show_checkered", "enabled"), &Terrain3D::set_show_checkered);
 	ClassDB::bind_method(D_METHOD("get_show_checkered"), &Terrain3D::get_show_checkered);
@@ -1083,20 +1095,12 @@ void Terrain3D::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("get_show_control_blend"), &Terrain3D::get_show_control_blend);
 	ClassDB::bind_method(D_METHOD("set_show_autoshader", "enabled"), &Terrain3D::set_show_autoshader);
 	ClassDB::bind_method(D_METHOD("get_show_autoshader"), &Terrain3D::get_show_autoshader);
-	ClassDB::bind_method(D_METHOD("set_show_navigation", "enabled"), &Terrain3D::set_show_navigation);
-	ClassDB::bind_method(D_METHOD("get_show_navigation"), &Terrain3D::get_show_navigation);
 	ClassDB::bind_method(D_METHOD("set_show_texture_height", "enabled"), &Terrain3D::set_show_texture_height);
 	ClassDB::bind_method(D_METHOD("get_show_texture_height"), &Terrain3D::get_show_texture_height);
 	ClassDB::bind_method(D_METHOD("set_show_texture_normal", "enabled"), &Terrain3D::set_show_texture_normal);
 	ClassDB::bind_method(D_METHOD("get_show_texture_normal"), &Terrain3D::get_show_texture_normal);
 	ClassDB::bind_method(D_METHOD("set_show_texture_rough", "enabled"), &Terrain3D::set_show_texture_rough);
 	ClassDB::bind_method(D_METHOD("get_show_texture_rough"), &Terrain3D::get_show_texture_rough);
-	ClassDB::bind_method(D_METHOD("set_show_region_grid", "enabled"), &Terrain3D::set_show_region_grid);
-	ClassDB::bind_method(D_METHOD("get_show_region_grid"), &Terrain3D::get_show_region_grid);
-	ClassDB::bind_method(D_METHOD("set_show_instancer_grid", "enabled"), &Terrain3D::set_show_instancer_grid);
-	ClassDB::bind_method(D_METHOD("get_show_instancer_grid"), &Terrain3D::get_show_instancer_grid);
-	ClassDB::bind_method(D_METHOD("set_show_vertex_grid", "enabled"), &Terrain3D::set_show_vertex_grid);
-	ClassDB::bind_method(D_METHOD("get_show_vertex_grid"), &Terrain3D::get_show_vertex_grid);
 
 	// Utility
 	ClassDB::bind_method(D_METHOD("get_intersection", "src_pos", "direction", "gpu_mode"), &Terrain3D::get_intersection, DEFVAL(false));
@@ -1144,6 +1148,13 @@ void Terrain3D::_bind_methods() {
 	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "free_editor_textures"), "set_free_editor_textures", "get_free_editor_textures");
 	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "show_instances"), "set_show_instances", "get_show_instances");
 
+	ADD_GROUP("Overlays", "show_");
+	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "show_region_grid"), "set_show_region_grid", "get_show_region_grid");
+	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "show_instancer_grid"), "set_show_instancer_grid", "get_show_instancer_grid");
+	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "show_vertex_grid"), "set_show_vertex_grid", "get_show_vertex_grid");
+	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "show_contours"), "set_show_contours", "get_show_contours");
+	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "show_navigation"), "set_show_navigation", "get_show_navigation");
+
 	ADD_GROUP("Debug Views", "show_");
 	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "show_checkered"), "set_show_checkered", "get_show_checkered");
 	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "show_grey"), "set_show_grey", "get_show_grey");
@@ -1155,13 +1166,9 @@ void Terrain3D::_bind_methods() {
 	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "show_control_scale"), "set_show_control_scale", "get_show_control_scale");
 	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "show_control_blend"), "set_show_control_blend", "get_show_control_blend");
 	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "show_autoshader"), "set_show_autoshader", "get_show_autoshader");
-	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "show_navigation"), "set_show_navigation", "get_show_navigation");
 	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "show_texture_height"), "set_show_texture_height", "get_show_texture_height");
 	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "show_texture_normal"), "set_show_texture_normal", "get_show_texture_normal");
 	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "show_texture_rough"), "set_show_texture_rough", "get_show_texture_rough");
-	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "show_region_grid"), "set_show_region_grid", "get_show_region_grid");
-	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "show_instancer_grid"), "set_show_instancer_grid", "get_show_instancer_grid");
-	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "show_vertex_grid"), "set_show_vertex_grid", "get_show_vertex_grid");
 
 	ADD_SIGNAL(MethodInfo("material_changed"));
 	ADD_SIGNAL(MethodInfo("assets_changed"));

--- a/src/terrain_3d.h
+++ b/src/terrain_3d.h
@@ -211,6 +211,18 @@ public:
 	void set_physics_material(const Ref<PhysicsMaterial> &p_mat) { _collision ? _collision->set_physics_material(p_mat) : void(); }
 	Ref<PhysicsMaterial> get_physics_material() const { return _collision ? _collision->get_physics_material() : Ref<PhysicsMaterial>(); }
 
+	// Overlay Aliases
+	void set_show_region_grid(const bool p_enabled) { _material.is_valid() ? _material->set_show_region_grid(p_enabled) : void(); }
+	bool get_show_region_grid() const { return _material.is_valid() ? _material->get_show_region_grid() : false; }
+	void set_show_instancer_grid(const bool p_enabled) { _material.is_valid() ? _material->set_show_instancer_grid(p_enabled) : void(); }
+	bool get_show_instancer_grid() const { return _material.is_valid() ? _material->get_show_instancer_grid() : false; }
+	void set_show_vertex_grid(const bool p_enabled) { _material.is_valid() ? _material->set_show_vertex_grid(p_enabled) : void(); }
+	bool get_show_vertex_grid() const { return _material.is_valid() ? _material->get_show_vertex_grid() : false; }
+	void set_show_contours(const bool p_enabled) { _material.is_valid() ? _material->set_show_contours(p_enabled) : void(); }
+	bool get_show_contours() const { return _material.is_valid() ? _material->get_show_contours() : false; }
+	void set_show_navigation(const bool p_enabled) { _material.is_valid() ? _material->set_show_navigation(p_enabled) : void(); }
+	bool get_show_navigation() const { return _material.is_valid() ? _material->get_show_navigation() : false; }
+
 	// Debug View Aliases
 	void set_show_checkered(const bool p_enabled) { _material.is_valid() ? _material->set_show_checkered(p_enabled) : void(); }
 	bool get_show_checkered() const { return _material.is_valid() ? _material->get_show_checkered() : false; }
@@ -232,20 +244,12 @@ public:
 	bool get_show_control_blend() const { return _material.is_valid() ? _material->get_show_control_blend() : false; }
 	void set_show_autoshader(const bool p_enabled) { _material.is_valid() ? _material->set_show_autoshader(p_enabled) : void(); }
 	bool get_show_autoshader() const { return _material.is_valid() ? _material->get_show_autoshader() : false; }
-	void set_show_navigation(const bool p_enabled) { _material.is_valid() ? _material->set_show_navigation(p_enabled) : void(); }
-	bool get_show_navigation() const { return _material.is_valid() ? _material->get_show_navigation() : false; }
 	void set_show_texture_height(const bool p_enabled) { _material.is_valid() ? _material->set_show_texture_height(p_enabled) : void(); }
 	bool get_show_texture_height() const { return _material.is_valid() ? _material->get_show_texture_height() : false; }
 	void set_show_texture_normal(const bool p_enabled) { _material.is_valid() ? _material->set_show_texture_normal(p_enabled) : void(); }
 	bool get_show_texture_normal() const { return _material.is_valid() ? _material->get_show_texture_normal() : false; }
 	void set_show_texture_rough(const bool p_enabled) { _material.is_valid() ? _material->set_show_texture_rough(p_enabled) : void(); }
 	bool get_show_texture_rough() const { return _material.is_valid() ? _material->get_show_texture_rough() : false; }
-	void set_show_region_grid(const bool p_enabled) { _material.is_valid() ? _material->set_show_region_grid(p_enabled) : void(); }
-	bool get_show_region_grid() const { return _material.is_valid() ? _material->get_show_region_grid() : false; }
-	void set_show_instancer_grid(const bool p_enabled) { _material.is_valid() ? _material->set_show_instancer_grid(p_enabled) : void(); }
-	bool get_show_instancer_grid() const { return _material.is_valid() ? _material->get_show_instancer_grid() : false; }
-	void set_show_vertex_grid(const bool p_enabled) { _material.is_valid() ? _material->set_show_vertex_grid(p_enabled) : void(); }
-	bool get_show_vertex_grid() const { return _material.is_valid() ? _material->get_show_vertex_grid() : false; }
 
 protected:
 	void _notification(const int p_what);

--- a/src/terrain_3d_material.cpp
+++ b/src/terrain_3d_material.cpp
@@ -263,6 +263,7 @@ String Terrain3DMaterial::_inject_editor_code(const String &p_shader) const {
 	//	shader = shader.insert(idx, "\n\n" + insert);
 	//	idx += insert.length();
 	//}
+	//insert_names.clear();
 
 	// Insert before vertex()
 	regex->compile("void\\s+vertex\\s*\\(");
@@ -272,15 +273,19 @@ String Terrain3DMaterial::_inject_editor_code(const String &p_shader) const {
 		LOG(DEBUG, "No void vertex(); cannot inject editor code");
 		return shader;
 	}
-	insert_names.clear();
 	if (IS_EDITOR && _terrain && _terrain->get_editor()) {
-		insert_names.push_back("EDITOR_SETUP_DECAL");
+		insert_names.push_back("EDITOR_DECAL_SETUP");
 	}
+	if (_show_contours) {
+		insert_names.push_back("OVERLAY_CONTOURS_SETUP");
+	}
+	// Apply pending inserts
 	for (int i = 0; i < insert_names.size(); i++) {
 		String insert = _shader_code[insert_names[i]];
 		shader = shader.insert(idx, "\n" + insert);
 		idx += insert.length();
 	}
+	insert_names.clear();
 
 	// Insert at the end of `fragment(){ }`
 	// Check for each nested {} pair until the closing } is found.
@@ -306,7 +311,8 @@ String Terrain3DMaterial::_inject_editor_code(const String &p_shader) const {
 		LOG(DEBUG, "No ending bracket; cannot inject editor code");
 		return shader;
 	}
-	insert_names.clear();
+
+	// Debug Views
 	if (_debug_view_checkered) {
 		insert_names.push_back("DEBUG_CHECKERED");
 	}
@@ -346,21 +352,27 @@ String Terrain3DMaterial::_inject_editor_code(const String &p_shader) const {
 	if (_debug_view_tex_rough) {
 		insert_names.push_back("DEBUG_TEXTURE_ROUGHNESS");
 	}
-	if (_debug_view_region_grid) {
-		insert_names.push_back("DEBUG_REGION_GRID");
+
+	// Overlays & Editor Functions
+	if (_show_contours) {
+		insert_names.push_back("OVERLAY_CONTOURS_RENDER");
 	}
-	if (_debug_view_instancer_grid) {
-		insert_names.push_back("DEBUG_INSTANCER_GRID");
+	if (_show_region_grid) {
+		insert_names.push_back("OVERLAY_REGION_GRID");
 	}
-	if (_debug_view_vertex_grid) {
-		insert_names.push_back("DEBUG_VERTEX_GRID");
+	if (_show_instancer_grid) {
+		insert_names.push_back("OVERLAY_INSTANCER_GRID");
+	}
+	if (_show_vertex_grid) {
+		insert_names.push_back("OVERLAY_VERTEX_GRID");
 	}
 	if (_show_navigation || (IS_EDITOR && _terrain && _terrain->get_editor() && _terrain->get_editor()->get_tool() == Terrain3DEditor::NAVIGATION)) {
 		insert_names.push_back("EDITOR_NAVIGATION");
 	}
 	if (IS_EDITOR && _terrain && _terrain->get_editor()) {
-		insert_names.push_back("EDITOR_RENDER_DECAL");
+		insert_names.push_back("EDITOR_DECAL_RENDER");
 	}
+	// Apply pending inserts
 	for (int i = 0; i < insert_names.size(); i++) {
 		String insert = _shader_code[insert_names[i]];
 		shader = shader.insert(idx, "\n" + insert);
@@ -633,6 +645,36 @@ Variant Terrain3DMaterial::get_shader_param(const StringName &p_name) const {
 	return value;
 }
 
+void Terrain3DMaterial::set_show_region_grid(const bool p_enabled) {
+	LOG(INFO, "Enable show_region_grid: ", p_enabled);
+	_show_region_grid = p_enabled;
+	_update_shader();
+}
+
+void Terrain3DMaterial::set_show_instancer_grid(const bool p_enabled) {
+	LOG(INFO, "Enable show_instancer_grid: ", p_enabled);
+	_show_instancer_grid = p_enabled;
+	_update_shader();
+}
+
+void Terrain3DMaterial::set_show_vertex_grid(const bool p_enabled) {
+	LOG(INFO, "Enable show_vertex_grid: ", p_enabled);
+	_show_vertex_grid = p_enabled;
+	_update_shader();
+}
+
+void Terrain3DMaterial::set_show_contours(const bool p_enabled) {
+	LOG(INFO, "Enable show_contours: ", p_enabled);
+	_show_contours = p_enabled;
+	_update_shader();
+}
+
+void Terrain3DMaterial::set_show_navigation(const bool p_enabled) {
+	LOG(INFO, "Enable show_navigation: ", p_enabled);
+	_show_navigation = p_enabled;
+	_update_shader();
+}
+
 void Terrain3DMaterial::set_show_checkered(const bool p_enabled) {
 	LOG(INFO, "Enable set_show_checkered: ", p_enabled);
 	_debug_view_checkered = p_enabled;
@@ -693,12 +735,6 @@ void Terrain3DMaterial::set_show_autoshader(const bool p_enabled) {
 	_update_shader();
 }
 
-void Terrain3DMaterial::set_show_navigation(const bool p_enabled) {
-	LOG(INFO, "Enable show_navigation: ", p_enabled);
-	_show_navigation = p_enabled;
-	_update_shader();
-}
-
 void Terrain3DMaterial::set_show_texture_height(const bool p_enabled) {
 	LOG(INFO, "Enable show_texture_height: ", p_enabled);
 	_debug_view_tex_height = p_enabled;
@@ -714,24 +750,6 @@ void Terrain3DMaterial::set_show_texture_normal(const bool p_enabled) {
 void Terrain3DMaterial::set_show_texture_rough(const bool p_enabled) {
 	LOG(INFO, "Enable show_texture_rough: ", p_enabled);
 	_debug_view_tex_rough = p_enabled;
-	_update_shader();
-}
-
-void Terrain3DMaterial::set_show_region_grid(const bool p_enabled) {
-	LOG(INFO, "Enable show_region_grid: ", p_enabled);
-	_debug_view_region_grid = p_enabled;
-	_update_shader();
-}
-
-void Terrain3DMaterial::set_show_instancer_grid(const bool p_enabled) {
-	LOG(INFO, "Enable show_instancer_grid: ", p_enabled);
-	_debug_view_instancer_grid = p_enabled;
-	_update_shader();
-}
-
-void Terrain3DMaterial::set_show_vertex_grid(const bool p_enabled) {
-	LOG(INFO, "Enable show_vertex_grid: ", p_enabled);
-	_debug_view_vertex_grid = p_enabled;
 	_update_shader();
 }
 
@@ -929,6 +947,19 @@ void Terrain3DMaterial::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("set_shader_param", "name", "value"), &Terrain3DMaterial::set_shader_param);
 	ClassDB::bind_method(D_METHOD("get_shader_param", "name"), &Terrain3DMaterial::get_shader_param);
 
+	// Overlays
+	ClassDB::bind_method(D_METHOD("set_show_region_grid", "enabled"), &Terrain3DMaterial::set_show_region_grid);
+	ClassDB::bind_method(D_METHOD("get_show_region_grid"), &Terrain3DMaterial::get_show_region_grid);
+	ClassDB::bind_method(D_METHOD("set_show_instancer_grid", "enabled"), &Terrain3DMaterial::set_show_instancer_grid);
+	ClassDB::bind_method(D_METHOD("get_show_instancer_grid"), &Terrain3DMaterial::get_show_instancer_grid);
+	ClassDB::bind_method(D_METHOD("set_show_vertex_grid", "enabled"), &Terrain3DMaterial::set_show_vertex_grid);
+	ClassDB::bind_method(D_METHOD("get_show_vertex_grid"), &Terrain3DMaterial::get_show_vertex_grid);
+	ClassDB::bind_method(D_METHOD("set_show_contours", "enabled"), &Terrain3DMaterial::set_show_contours);
+	ClassDB::bind_method(D_METHOD("get_show_contours"), &Terrain3DMaterial::get_show_contours);
+	ClassDB::bind_method(D_METHOD("set_show_navigation", "enabled"), &Terrain3DMaterial::set_show_navigation);
+	ClassDB::bind_method(D_METHOD("get_show_navigation"), &Terrain3DMaterial::get_show_navigation);
+
+	// Debug Views
 	ClassDB::bind_method(D_METHOD("set_show_checkered", "enabled"), &Terrain3DMaterial::set_show_checkered);
 	ClassDB::bind_method(D_METHOD("get_show_checkered"), &Terrain3DMaterial::get_show_checkered);
 	ClassDB::bind_method(D_METHOD("set_show_grey", "enabled"), &Terrain3DMaterial::set_show_grey);
@@ -949,47 +980,42 @@ void Terrain3DMaterial::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("get_show_control_blend"), &Terrain3DMaterial::get_show_control_blend);
 	ClassDB::bind_method(D_METHOD("set_show_autoshader", "enabled"), &Terrain3DMaterial::set_show_autoshader);
 	ClassDB::bind_method(D_METHOD("get_show_autoshader"), &Terrain3DMaterial::get_show_autoshader);
-	ClassDB::bind_method(D_METHOD("set_show_navigation", "enabled"), &Terrain3DMaterial::set_show_navigation);
-	ClassDB::bind_method(D_METHOD("get_show_navigation"), &Terrain3DMaterial::get_show_navigation);
 	ClassDB::bind_method(D_METHOD("set_show_texture_height", "enabled"), &Terrain3DMaterial::set_show_texture_height);
 	ClassDB::bind_method(D_METHOD("get_show_texture_height"), &Terrain3DMaterial::get_show_texture_height);
 	ClassDB::bind_method(D_METHOD("set_show_texture_normal", "enabled"), &Terrain3DMaterial::set_show_texture_normal);
 	ClassDB::bind_method(D_METHOD("get_show_texture_normal"), &Terrain3DMaterial::get_show_texture_normal);
 	ClassDB::bind_method(D_METHOD("set_show_texture_rough", "enabled"), &Terrain3DMaterial::set_show_texture_rough);
 	ClassDB::bind_method(D_METHOD("get_show_texture_rough"), &Terrain3DMaterial::get_show_texture_rough);
-	ClassDB::bind_method(D_METHOD("set_show_region_grid", "enabled"), &Terrain3DMaterial::set_show_region_grid);
-	ClassDB::bind_method(D_METHOD("get_show_region_grid"), &Terrain3DMaterial::get_show_region_grid);
-	ClassDB::bind_method(D_METHOD("set_show_instancer_grid", "enabled"), &Terrain3DMaterial::set_show_instancer_grid);
-	ClassDB::bind_method(D_METHOD("get_show_instancer_grid"), &Terrain3DMaterial::get_show_instancer_grid);
-	ClassDB::bind_method(D_METHOD("set_show_vertex_grid", "enabled"), &Terrain3DMaterial::set_show_vertex_grid);
-	ClassDB::bind_method(D_METHOD("get_show_vertex_grid"), &Terrain3DMaterial::get_show_vertex_grid);
 
 	ClassDB::bind_method(D_METHOD("save", "path"), &Terrain3DMaterial::save, DEFVAL(""));
 
 	ADD_PROPERTY(PropertyInfo(Variant::INT, "world_background", PROPERTY_HINT_ENUM, "None,Flat,Noise"), "set_world_background", "get_world_background");
 	ADD_PROPERTY(PropertyInfo(Variant::INT, "texture_filtering", PROPERTY_HINT_ENUM, "Linear,Nearest"), "set_texture_filtering", "get_texture_filtering");
-	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "auto_shader", PROPERTY_HINT_NONE), "set_auto_shader", "get_auto_shader");
-	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "dual_scaling", PROPERTY_HINT_NONE), "set_dual_scaling", "get_dual_scaling");
+	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "auto_shader"), "set_auto_shader", "get_auto_shader");
+	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "dual_scaling"), "set_dual_scaling", "get_dual_scaling");
 
-	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "shader_override_enabled", PROPERTY_HINT_NONE), "enable_shader_override", "is_shader_override_enabled");
+	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "shader_override_enabled"), "enable_shader_override", "is_shader_override_enabled");
 	ADD_PROPERTY(PropertyInfo(Variant::OBJECT, "shader_override", PROPERTY_HINT_RESOURCE_TYPE, "Shader"), "set_shader_override", "get_shader_override");
 
+	ADD_GROUP("Overlays", "show_");
+	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "show_region_grid"), "set_show_region_grid", "get_show_region_grid");
+	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "show_instancer_grid"), "set_show_instancer_grid", "get_show_instancer_grid");
+	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "show_vertex_grid"), "set_show_vertex_grid", "get_show_vertex_grid");
+	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "show_contours"), "set_show_contours", "get_show_contours");
+	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "show_navigation"), "set_show_navigation", "get_show_navigation");
+
 	ADD_GROUP("Debug Views", "show_");
-	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "show_checkered", PROPERTY_HINT_NONE), "set_show_checkered", "get_show_checkered");
-	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "show_grey", PROPERTY_HINT_NONE), "set_show_grey", "get_show_grey");
-	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "show_heightmap", PROPERTY_HINT_NONE), "set_show_heightmap", "get_show_heightmap");
-	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "show_colormap", PROPERTY_HINT_NONE), "set_show_colormap", "get_show_colormap");
-	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "show_roughmap", PROPERTY_HINT_NONE), "set_show_roughmap", "get_show_roughmap");
-	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "show_control_texture", PROPERTY_HINT_NONE), "set_show_control_texture", "get_show_control_texture");
-	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "show_control_angle", PROPERTY_HINT_NONE), "set_show_control_angle", "get_show_control_angle");
-	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "show_control_scale", PROPERTY_HINT_NONE), "set_show_control_scale", "get_show_control_scale");
-	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "show_control_blend", PROPERTY_HINT_NONE), "set_show_control_blend", "get_show_control_blend");
-	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "show_autoshader", PROPERTY_HINT_NONE), "set_show_autoshader", "get_show_autoshader");
-	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "show_navigation", PROPERTY_HINT_NONE), "set_show_navigation", "get_show_navigation");
-	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "show_texture_height", PROPERTY_HINT_NONE), "set_show_texture_height", "get_show_texture_height");
-	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "show_texture_normal", PROPERTY_HINT_NONE), "set_show_texture_normal", "get_show_texture_normal");
-	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "show_texture_rough", PROPERTY_HINT_NONE), "set_show_texture_rough", "get_show_texture_rough");
-	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "show_region_grid", PROPERTY_HINT_NONE), "set_show_region_grid", "get_show_region_grid");
-	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "show_instancer_grid", PROPERTY_HINT_NONE), "set_show_instancer_grid", "get_show_instancer_grid");
-	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "show_vertex_grid", PROPERTY_HINT_NONE), "set_show_vertex_grid", "get_show_vertex_grid");
+	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "show_checkered"), "set_show_checkered", "get_show_checkered");
+	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "show_grey"), "set_show_grey", "get_show_grey");
+	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "show_heightmap"), "set_show_heightmap", "get_show_heightmap");
+	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "show_colormap"), "set_show_colormap", "get_show_colormap");
+	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "show_roughmap"), "set_show_roughmap", "get_show_roughmap");
+	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "show_control_texture"), "set_show_control_texture", "get_show_control_texture");
+	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "show_control_angle"), "set_show_control_angle", "get_show_control_angle");
+	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "show_control_scale"), "set_show_control_scale", "get_show_control_scale");
+	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "show_control_blend"), "set_show_control_blend", "get_show_control_blend");
+	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "show_autoshader"), "set_show_autoshader", "get_show_autoshader");
+	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "show_texture_height"), "set_show_texture_height", "get_show_texture_height");
+	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "show_texture_normal"), "set_show_texture_normal", "get_show_texture_normal");
+	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "show_texture_rough"), "set_show_texture_rough", "get_show_texture_rough");
 }

--- a/src/terrain_3d_material.h
+++ b/src/terrain_3d_material.h
@@ -46,8 +46,14 @@ private:
 	bool _dual_scaling = false;
 	bool _auto_shader = false;
 
-	// Editor Functions / Debug views
+	// Overlays
+	bool _show_region_grid = false;
+	bool _show_instancer_grid = false;
+	bool _show_vertex_grid = false;
+	bool _show_contours = false;
 	bool _show_navigation = false;
+
+	// Debug Views
 	bool _debug_view_checkered = false;
 	bool _debug_view_grey = false;
 	bool _debug_view_heightmap = false;
@@ -62,9 +68,6 @@ private:
 	bool _debug_view_tex_height = false;
 	bool _debug_view_tex_normal = false;
 	bool _debug_view_tex_rough = false;
-	bool _debug_view_region_grid = false;
-	bool _debug_view_instancer_grid = false;
-	bool _debug_view_vertex_grid = false;
 
 	// Functions
 	void _preload_shaders();
@@ -109,7 +112,19 @@ public:
 	void set_shader_param(const StringName &p_name, const Variant &p_value);
 	Variant get_shader_param(const StringName &p_name) const;
 
-	// Editor functions / Debug views
+	// Overlays
+	void set_show_region_grid(const bool p_enabled);
+	bool get_show_region_grid() const { return _show_region_grid; }
+	void set_show_instancer_grid(const bool p_enabled);
+	bool get_show_instancer_grid() const { return _show_instancer_grid; }
+	void set_show_vertex_grid(const bool p_enabled);
+	bool get_show_vertex_grid() const { return _show_vertex_grid; }
+	void set_show_contours(const bool p_enabled);
+	bool get_show_contours() const { return _show_contours; }
+	void set_show_navigation(const bool p_enabled);
+	bool get_show_navigation() const { return _show_navigation; }
+
+	// Debug views
 	void set_show_checkered(const bool p_enabled);
 	bool get_show_checkered() const { return _debug_view_checkered; }
 	void set_show_grey(const bool p_enabled);
@@ -130,20 +145,12 @@ public:
 	bool get_show_control_blend() const { return _debug_view_control_blend; }
 	void set_show_autoshader(const bool p_enabled);
 	bool get_show_autoshader() const { return _debug_view_autoshader; }
-	void set_show_navigation(const bool p_enabled);
-	bool get_show_navigation() const { return _show_navigation; }
 	void set_show_texture_height(const bool p_enabled);
 	bool get_show_texture_height() const { return _debug_view_tex_height; }
 	void set_show_texture_normal(const bool p_enabled);
 	bool get_show_texture_normal() const { return _debug_view_tex_normal; }
 	void set_show_texture_rough(const bool p_enabled);
 	bool get_show_texture_rough() const { return _debug_view_tex_rough; }
-	void set_show_region_grid(const bool p_enabled);
-	bool get_show_region_grid() const { return _debug_view_region_grid; }
-	void set_show_instancer_grid(const bool p_enabled);
-	bool get_show_instancer_grid() const { return _debug_view_instancer_grid; }
-	void set_show_vertex_grid(const bool p_enabled);
-	bool get_show_vertex_grid() const { return _debug_view_vertex_grid; }
 
 	Error save(const String &p_path = "");
 


### PR DESCRIPTION
Partially resolves #605 

* Adds customizable contour lines (enable w/ `4` or Overlays, and customize in material)
* Adds hotkeys 
* Update docs

![{8E0BB697-0CE6-44DC-A8CF-6DC0EDF93BFD}](https://github.com/user-attachments/assets/415e0e37-97bb-41f1-b2c3-7b31ad9fde82)

Contributions to this PR by @Xtarsia 

Reference:
* https://github.com/TokisanGames/Terrain3D/discussions/358
* https://github.com/FishOfTheNorthStar/Terrain3D_altCustom/tree/master/project/addons/terrain_3d/shader/mods `(carto*)`
