### PR TITLE
Instance collision

### DIFF
--- a/src/terrain_3d.cpp
+++ b/src/terrain_3d.cpp
@@ -178,6 +178,7 @@ void Terrain3D::_destroy_collision(const bool p_final) {
 	LOG(INFO, "Destroying Collision");
 	if (_collision) {
 		_collision->destroy();
+		_collision->destroy_instance_collision();
 	}
 	if (p_final) {
 		memdelete_safely(_collision);
@@ -686,6 +687,7 @@ void Terrain3D::set_vertex_spacing(const real_t p_spacing) {
 		_material->update();
 		_collision->destroy();
 		_collision->build();
+		_collision->set_instance_collision_dirty(true);
 		_update_displacement_buffer();
 	}
 	if (IS_EDITOR && _editor_plugin) {

--- a/src/terrain_3d.cpp
+++ b/src/terrain_3d.cpp
@@ -1099,6 +1099,7 @@ void Terrain3D::_notification(const int p_what) {
 			set_physics_process(false);
 			_destroy_mesher();
 			_destroy_instancer();
+			_destroy_collision();
 			_destroy_mouse_picking();
 			_destroy_displacement_buffer();
 			if (_assets.is_valid()) {

--- a/src/terrain_3d.cpp
+++ b/src/terrain_3d.cpp
@@ -127,6 +127,9 @@ void Terrain3D::__physics_process(const double p_delta) {
 	if (_collision && _collision->is_dynamic_mode()) {
 		_collision->update();
 	}
+	if (_collision && _collision->is_instance_collision_enabled()) {
+		_collision->update_instance_collision();
+	}
 }
 
 /**
@@ -1220,6 +1223,12 @@ void Terrain3D::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("set_physics_material", "material"), &Terrain3D::set_physics_material);
 	ClassDB::bind_method(D_METHOD("get_physics_material"), &Terrain3D::get_physics_material);
 
+	// Instance Collision
+	ClassDB::bind_method(D_METHOD("set_instance_collision_mode", "mode"), &Terrain3D::set_instance_collision_mode);
+	ClassDB::bind_method(D_METHOD("get_instance_collision_mode"), &Terrain3D::get_instance_collision_mode);
+	ClassDB::bind_method(D_METHOD("set_instance_collision_radius", "radius"), &Terrain3D::set_instance_collision_radius);
+	ClassDB::bind_method(D_METHOD("get_instance_collision_radius"), &Terrain3D::get_instance_collision_radius);
+
 	// Terrain Mesh
 	ClassDB::bind_method(D_METHOD("set_mesh_lods", "count"), &Terrain3D::set_mesh_lods);
 	ClassDB::bind_method(D_METHOD("get_mesh_lods"), &Terrain3D::get_mesh_lods);
@@ -1338,6 +1347,9 @@ void Terrain3D::_bind_methods() {
 	ADD_PROPERTY(PropertyInfo(Variant::INT, "collision_mask", PROPERTY_HINT_LAYERS_3D_PHYSICS), "set_collision_mask", "get_collision_mask");
 	ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "collision_priority", PROPERTY_HINT_RANGE, "0.1,256,.1"), "set_collision_priority", "get_collision_priority");
 	ADD_PROPERTY(PropertyInfo(Variant::OBJECT, "physics_material", PROPERTY_HINT_RESOURCE_TYPE, "PhysicsMaterial"), "set_physics_material", "get_physics_material");
+	ADD_SUBGROUP("Instance Collision", "");
+	ADD_PROPERTY(PropertyInfo(Variant::INT, "instance_collision_mode", PROPERTY_HINT_ENUM, "Disabled, Dynamic / Game, Dynamic / Editor"), "set_instance_collision_mode", "get_instance_collision_mode");
+	ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "instance_collision_radius", PROPERTY_HINT_RANGE, "1.,256.,1."), "set_instance_collision_radius", "get_instance_collision_radius");
 
 	ADD_GROUP("Terrain Mesh", "");
 	ADD_PROPERTY(PropertyInfo(Variant::OBJECT, "clipmap_target", PROPERTY_HINT_NODE_TYPE, "Node3D", PROPERTY_USAGE_DEFAULT, "Node3D"), "set_clipmap_target", "get_clipmap_target");

--- a/src/terrain_3d.h
+++ b/src/terrain_3d.h
@@ -236,6 +236,12 @@ public:
 	void set_physics_material(const Ref<PhysicsMaterial> &p_mat) { _collision ? _collision->set_physics_material(p_mat) : void(); }
 	Ref<PhysicsMaterial> get_physics_material() const { return _collision ? _collision->get_physics_material() : Ref<PhysicsMaterial>(); }
 
+	// Instance Collision Aliases
+	void set_instance_collision_mode(const InstanceCollisionMode p_mode) { _collision ? _collision->set_instance_collision_mode(p_mode) : void(); }
+	InstanceCollisionMode get_instance_collision_mode() const { return _collision ? _collision->get_instance_collision_mode() : InstanceCollisionMode::INSTANCE_COLLISION_DYNAMIC_GAME; }
+	void set_instance_collision_radius(const real_t p_radius) { _collision ? _collision->set_instance_collision_radius(p_radius) : void(); }
+	real_t get_instance_collision_radius() const { return _collision ? _collision->get_instance_collision_radius() : 64.f; }
+
 	// Instancer Aliases
 	void set_instancer_mode(const InstancerMode p_mode) { _instancer ? _instancer->set_mode(p_mode) : void(); }
 	InstancerMode get_instancer_mode() const { return _instancer ? _instancer->get_mode() : InstancerMode::NORMAL; }

--- a/src/terrain_3d_collision.cpp
+++ b/src/terrain_3d_collision.cpp
@@ -358,7 +358,7 @@ Dictionary Terrain3DCollision::_get_instance_build_data(const TypedArray<Vector2
 			transformed_xforms.resize(xforms.size());
 			for (int xi = 0; xi < xforms.size(); xi++) {
 				Transform3D t = Transform3D(xforms[xi]); // region-local
-				t.origin += region_global_offset;        // global transform
+				t.origin += region_global_offset; // global transform
 				transformed_xforms[xi] = t;
 			}
 
@@ -1097,7 +1097,7 @@ void Terrain3DCollision::set_instance_collision_radius(const real_t p_radius) {
 	SET_IF_DIFF(_instance_collision_radius, p_radius);
 	LOG(INFO, "Setting instance collision redius: ", p_radius);
 	if (is_instance_collision_enabled()) {
-		update_instance_collision();
+		set_instance_collision_dirty();
 	}
 }
 

--- a/src/terrain_3d_collision.cpp
+++ b/src/terrain_3d_collision.cpp
@@ -569,8 +569,8 @@ void Terrain3DCollision::_generate_instances(const Dictionary &p_instance_build_
 						const int shape_id = PS->body_get_shape_count(_instance_static_body_rid);
 						// Add the index to our map
 						_RID_index_map[shape_rid] = shape_id;
-						PS->body_add_shape(_instance_static_body_rid, shape_rid, this_transform);
 						PS->shape_set_data(shape_rid, PS->shape_get_data(ma_shape->get_rid()));
+						PS->body_add_shape(_instance_static_body_rid, shape_rid, this_transform);
 						shapes.push_back(shape_rid);
 						if (is_editor_mode()) {
 							_queue_debug_mesh_update(shape_rid, this_transform, ma_shape->get_debug_mesh(), DebugMeshInstanceData::Action::CREATE);

--- a/src/terrain_3d_collision.cpp
+++ b/src/terrain_3d_collision.cpp
@@ -217,346 +217,385 @@ void Terrain3DCollision::_reload_physics_material() {
 	}
 }
 
-Vector2i Terrain3DCollision::_get_cell(const Vector3 &p_global_position, const int p_region_size) {
-	real_t vertex_spacing = _terrain->get_vertex_spacing();
-	Vector2i cell;
-	cell.x = UtilityFunctions::posmod(UtilityFunctions::floori(p_global_position.x / vertex_spacing), p_region_size) / _terrain->get_instancer()->CELL_SIZE;
-	cell.y = UtilityFunctions::posmod(UtilityFunctions::floori(p_global_position.z / vertex_spacing), p_region_size) / _terrain->get_instancer()->CELL_SIZE;
-	return cell;
+TypedArray<Vector3> Terrain3DCollision::_get_instance_cells_to_build(const Vector2i &p_snapped_pos, const int &p_region_size, const int &p_cell_size, const real_t &p_vertex_spacing) {
+	LOG(INFO, "Building list of instance cells within the radius");
+	TypedArray<Vector3> instance_cells_to_build;
+	// If we are in dynamic mode, we only build cells within the radius
+	if (is_dynamic_mode()) {
+		const int grid_size = _radius * 2;
+		const int step = 32;
+		for (int x = 0; x < grid_size; x += step) {
+			for (int y = 0; y < grid_size; y += step) {
+				const Vector3 grid_offset = Vector3(x - _radius, 0.0, y - _radius) * p_vertex_spacing;
+				const Vector3 grid_pos = v2v3(p_snapped_pos) + grid_offset;
+				const Vector3 region_loc = v2v3(_terrain->get_data()->get_region_location(grid_pos)) * p_region_size * p_vertex_spacing;
+				const Vector3 cell_loc = region_loc + v2v3(Util::get_cell(grid_pos, p_region_size, p_vertex_spacing, _terrain->get_instancer()->CELL_SIZE)) * p_cell_size * p_vertex_spacing;
+				if (!_active_instance_cells.has(cell_loc)) {
+					const Vector3 cell_centre = cell_loc + Vector3(p_vertex_spacing * p_cell_size * 0.5f, 0.0f, p_vertex_spacing * p_cell_size * 0.5f);
+					// Check if the cell is within the radius
+					if (v2v3(p_snapped_pos).distance_squared_to(cell_centre) < real_t(_radius ^ 2)) {
+						if (!_terrain->get_data()->get_regionp(cell_centre).is_valid()) {
+							continue;
+						}
+						instance_cells_to_build.push_back(cell_loc);
+					}
+				}
+			}
+		}
+	} else {
+		// Full collision
+		const TypedArray<Vector2i> region_locs = _terrain->get_data()->get_region_locations();
+		for (int i = 0; i < region_locs.size(); i++) {
+			const Vector3 region_pos = v2v3(region_locs[i]) * p_region_size * p_vertex_spacing;
+			for (int x = 0; x < p_cell_size; x++) {
+				for (int y = 0; y < p_cell_size; y++) {
+					const Vector3 cell_pos = region_pos + Vector3(x * p_cell_size * p_vertex_spacing, 0.0, y * p_cell_size * p_vertex_spacing);
+					instance_cells_to_build.push_back(cell_pos);
+				}
+			}
+		}
+	}
+	return instance_cells_to_build;
 }
 
-void Terrain3DCollision::_destroy_unused_shapes() {
-	int time = Time::get_singleton()->get_ticks_usec();
-	bool is_dirty = false;
-	LOG(EXTREME, "Destroying unused shapes");
-	Array shape_types = _unused_instance_shapes.keys();
-	LOG(EXTREME, "    Found ", shape_types.size(), " shape_types to destroy");
-	for (int i = 0; i < shape_types.size(); i++) {
-		Dictionary inactive_shapes = _unused_instance_shapes[shape_types[i]];
-		Array shape_keys = inactive_shapes.keys();
-		LOG(EXTREME, "    Shape type: ", shape_types[i], " Found ", shape_keys.size(), " shapes");
-		for (int s = 0; s < shape_keys.size(); s++) {
-			RID shape_rid = shape_keys[s];
-			LOG(EXTREME, "Destroying ", shape_rid);
-			_destroy_visual_instance(shape_rid);
-			if (!shape_rid.is_valid()) {
-				LOG(WARN, "Attempted to destroy an invalid shape");
+Dictionary Terrain3DCollision::_get_recyclable_instances(const Vector2i &p_snapped_pos, const real_t &p_radius) {
+	Dictionary recyclable_mesh_instance_shapes;
+	if (is_dynamic_mode()) {
+		LOG(INFO, "Decomposing cells beyond ", p_radius, " of ", p_snapped_pos);
+		const TypedArray<Vector3> instance_cells = _active_instance_cells.keys();
+		for (const Vector3 cell_origin : instance_cells) {
+			const Vector3 cell_centre = cell_origin + Vector3(16.0f, 0.0f, 16.0f);
+			if (v2v3(p_snapped_pos).distance_to(cell_centre) > p_radius) {
+				LOG(EXTREME, "Decomposing at ", cell_origin);
+				const Dictionary active_instances_dict = _active_instance_cells[cell_origin];
+				const TypedArray<int> mesh_asset_keys = active_instances_dict.keys();
+				for (const int mesh_asset_id : mesh_asset_keys) {
+					const Array active_instances_arr = active_instances_dict[mesh_asset_id];
+					Array unused_assets = recyclable_mesh_instance_shapes[mesh_asset_id];
+					for (int j = 0; j < active_instances_arr.size(); j++) {
+						unused_assets.append(active_instances_arr[j]);
+					}
+					recyclable_mesh_instance_shapes[mesh_asset_id] = unused_assets;
+					LOG(EXTREME, "Stashed ", active_instances_arr.size(), " * mesh asset ID ", mesh_asset_id);
+				}
+				_active_instance_cells.erase(cell_origin);
+			}
+		}
+	}
+	return recyclable_mesh_instance_shapes;
+}
+
+Dictionary Terrain3DCollision::_get_instance_build_data(const TypedArray<Vector3> &p_instance_cells_to_build, const int &p_region_size, const real_t &p_vertex_spacing) {
+	Dictionary mesh_instance_build_data;
+	LOG(INFO, "Building instance data");
+	for (const Vector3 cell_position : p_instance_cells_to_build) {
+		const Vector2i region_loc = _terrain->get_data()->get_region_location(cell_position);
+		const Vector2i cell_loc = Util::get_cell(cell_position, p_region_size, p_vertex_spacing, _terrain->get_instancer()->CELL_SIZE);
+		const Terrain3DRegion *region = _terrain->get_data()->get_region_ptr(region_loc);
+		if (!region) {
+			LOG(WARN, "Could not get region at ", cell_position);
+			continue;
+		}
+		const Dictionary mesh_inst_dict = region->get_instances();
+		const Array mesh_types = mesh_inst_dict.keys();
+		for (const int mesh_id : mesh_types) {
+			LOG(EXTREME, "Checking mesh id ", mesh_id, " in region ", region_loc, " cell: ", cell_loc);
+			// Verify mesh id is valid and has some meshes
+			const Ref<Terrain3DMeshAsset> ma = _terrain->get_assets()->get_mesh_asset(mesh_id);
+			if (ma.is_valid()) {
+				if (!ma->is_enabled()) {
+					continue;
+				}
+				if (ma->get_shape_count() == 0) {
+					LOG(EXTREME, "MeshAsset ", mesh_id, " valid but has no collision shapes, skipping");
+					continue;
+				}
+			} else {
+				LOG(WARN, "MeshAsset ", mesh_id, " is null, skipping");
 				continue;
 			}
-			is_dirty = true;
-			PS->free_rid(shape_rid);
-		}
-		_unused_instance_shapes.erase(shape_types[i]);
-	}
-	if (_unused_instance_shapes.size()) {
-		LOG(WARN, "Failed to destroy all instance shapes");
-	}
-
-	LOG(EXTREME, "Destroyed all shapes in : ", Time::get_singleton()->get_ticks_usec() - time, " us");
-	if (is_dirty) {
-		_rebuild_shape_indices();
-	}
-}
-
-void Terrain3DCollision::_rebuild_shape_indices() {
-	int time = Time::get_singleton()->get_ticks_usec();
-	LOG(EXTREME, "Rebuilding shape indices");
-
-	Dictionary RID_to_index;
-
-	for (int i = 0; i < PS->body_get_shape_count(_instance_static_body_rid); i++) {
-		RID_to_index.get_or_add(PS->body_get_shape(_instance_static_body_rid, i), i);
-	}
-
-	Array cell_keys = _active_instance_cells.keys();
-
-	for (int c = 0; c < cell_keys.size(); c++) {
-		Vector3 cell_loc = cell_keys[c];
-
-		Dictionary mesh_asset_dict = _active_instance_cells[cell_loc];
-		Array mesh_asset_keys = mesh_asset_dict.keys();
-
-		for (int m = 0; m < mesh_asset_keys.size(); m++) {
-			int mesh_asset_id = mesh_asset_keys[m];
-			Array instances = mesh_asset_dict[mesh_asset_id];
-			for (int i = 0; i < instances.size(); i++) {
-				Array instance = instances[i];
-				for (int s = 0; s < instance.size(); s++) {
-					Array shape = instance[s];
-					shape[1] = RID_to_index[shape[0]];
-					instance[s] = shape;
-				}
-				instances[i] = instance;
+			const Dictionary cell_inst_dict = mesh_inst_dict[mesh_id];
+			if (!cell_inst_dict.has(cell_loc)) {
+				// no instances in this cell
+				continue;
 			}
-			mesh_asset_dict[mesh_asset_id] = instances;
+			const Array triple = cell_inst_dict[cell_loc];
+			if (triple.size() < 3) {
+				LOG(WARN, "Triple is empty");
+				continue;
+			}
+			TypedArray<Transform3D> xforms = triple[0];
+			if (xforms.is_empty()) {
+				// no instances to add
+				continue;
+			}
+			LOG(DEBUG, xforms.size(), " instances of ", mesh_id, " to build in ", cell_position);
+			for (int x = 0; x < xforms.size(); x++) {
+				Transform3D xform = xforms[x];
+				xform.origin += v2v3(region_loc * p_region_size * p_vertex_spacing);
+				xforms[x] = xform;
+			}
+			TypedArray<Vector3> cell_positions;
+			cell_positions.resize(xforms.size());
+			cell_positions.fill(cell_position);
+			// 0 = xforms, 1 = cell_positions
+			Array instance_data = mesh_instance_build_data[mesh_id];
+			if (instance_data.is_empty()) {
+				instance_data.resize(2);
+			}
+			TypedArray<Transform3D> xforms_arr = instance_data[0];
+			TypedArray<Vector3> cell_positions_arr = instance_data[1];
+			xforms_arr.append_array(xforms);
+			cell_positions_arr.append_array(cell_positions);
+			instance_data[0] = xforms_arr;
+			instance_data[1] = cell_positions_arr;
+
+			mesh_instance_build_data[mesh_id] = instance_data;
+			// Next mesh type
 		}
-		_active_instance_cells[cell_loc] = mesh_asset_dict;
+		// Next cell
 	}
-	LOG(EXTREME, "Rebuilt shape indices in : ", Time::get_singleton()->get_ticks_usec() - time, " us");
+	return mesh_instance_build_data;
 }
 
-void Terrain3DCollision::_generate_instance_collision_cell(const Vector3 &cell_origin) {
-	int time = Time::get_singleton()->get_ticks_usec();
-
-	const Ref<Terrain3DRegion> region = _terrain->get_data()->get_regionp(cell_origin);
-	if (!region.is_valid()) {
-		LOG(EXTREME, "Tried to generate inside invalid region, skipping");
-		return;
+Dictionary Terrain3DCollision::_get_unused_instance_shapes(const Dictionary &p_instance_build_data, Dictionary &p_recyclable_instance_shapes) {
+	Dictionary unused_instance_shapes;
+	if (is_dynamic_mode()) {
+		LOG(INFO, "Decomposing spare assets");
+		const TypedArray<int> spare_instance_keys = p_recyclable_instance_shapes.keys();
+		LOG(DEBUG, spare_instance_keys.size(), " types of instance to decompose");
+		for (const int mesh_id : spare_instance_keys) {
+			LOG(EXTREME, "Decomposing  spare mesh id ", mesh_id);
+			TypedArray<Transform3D> mesh_instance_transforms;
+			const Array instance_data = p_instance_build_data[mesh_id];
+			if (instance_data.size() > 0) {
+				mesh_instance_transforms = TypedArray<Transform3D>(instance_data[0]);
+			}
+			LOG(DEBUG, "Decomposing all but ", mesh_instance_transforms.size(), " assets of type ", mesh_id);
+			const int time = Time::get_singleton()->get_ticks_usec();
+			if (!p_recyclable_instance_shapes.has(mesh_id)) {
+				LOG(WARN, "Tried to decompose mesh ", mesh_id, " when none exist");
+				continue;
+			}
+			Array ma_arr = p_recyclable_instance_shapes[mesh_id];
+			if (ma_arr.is_empty()) {
+				LOG(ERROR, "Unexpectedly found no more assets to decompose");
+				continue;
+			}
+			const int nb_instances_to_decompose = MAX(0, ma_arr.size() - mesh_instance_transforms.size());
+			for (int i = 0; i < nb_instances_to_decompose; i++) {
+				const TypedArray<RID> ma_instance = ma_arr.pop_back();
+				if (ma_arr.is_empty()) {
+					p_recyclable_instance_shapes.erase(mesh_id);
+				} else {
+					p_recyclable_instance_shapes[mesh_id] = ma_arr;
+				}
+				for (const RID rid : ma_instance) {
+					const int shape_type = PS->shape_get_type(rid);
+					if (!rid.is_valid()) {
+						LOG(WARN, "Tried to decompose shape with invalid RID");
+						continue;
+					}
+					TypedArray<RID> unused_shapes = unused_instance_shapes[shape_type];
+					unused_shapes.push_back(rid);
+					unused_instance_shapes[shape_type] = unused_shapes;
+					LOG(EXTREME, "Stored shape ", rid);
+				}
+			}
+		}
 	}
-	const Vector2i region_loc = region->get_location();
-	const real_t vertex_spacing = _terrain->get_vertex_spacing();
+	return unused_instance_shapes;
+}
 
-	// Get the region transform
-	Transform3D region_transform = Transform3D();
-	const int region_size = region->get_region_size();
-	region_transform.origin.x += region_loc.x * region_size * vertex_spacing;
-	region_transform.origin.z += region_loc.y * region_size * vertex_spacing;
+void Terrain3DCollision::_destroy_remaining_instance_shapes(Dictionary &p_unused_instance_shapes) {
+	if (is_dynamic_mode()) {
+		LOG(INFO, "Destroying unused shapes");
+		// This tracks whether we destroyed any shapes, if so we will update our RID/index map
+		bool is_dirty = false;
+		const TypedArray<int> shape_types = p_unused_instance_shapes.keys();
+		for (const int shape_type : shape_types) {
+			const TypedArray<RID> inactive_shapes = p_unused_instance_shapes[shape_type];
+			LOG(DEBUG, "    Shape type: ", shape_type, " Found ", inactive_shapes.size(), " shapes");
+			for (const RID shape_rid : inactive_shapes) {
+				if (!shape_rid.is_valid()) {
+					LOG(WARN, "Attempted to destroy an invalid shape");
+					continue;
+				}
+				_queue_debug_mesh_update(shape_rid, Transform3D(), Ref<ArrayMesh>(), DebugMeshInstanceData::Action::DESTROY);
+				PS->free_rid(shape_rid);
+				is_dirty = true;
+				LOG(EXTREME, "Destroyed ", shape_rid);
+			}
+			p_unused_instance_shapes.erase(shape_type);
+		}
+		// If we destroyed shapes the body_shape indices will need to update the RID/index map.
+		//
+		if (is_dirty) {
+			LOG(INFO, "Rebuilding shape indices");
+			for (int i = 0; i < PS->body_get_shape_count(_instance_static_body_rid); i++) {
+				_RID_index_map[PS->body_get_shape(_instance_static_body_rid, i)] = i;
+			}
+		}
+	}
+}
 
-	const Vector2i cell_loc = _get_cell(cell_origin, region->get_region_size());
-
-	const Dictionary mesh_inst_dict = region->get_instances();
-
-	const Array mesh_types = mesh_inst_dict.keys();
-
-	for (int m = 0; m < mesh_types.size(); m++) {
-		const int mesh_id = mesh_types[m];
-
+void Terrain3DCollision::_generate_instances(const Dictionary &p_instance_build_data, Dictionary &p_recyclable_instances, Dictionary &p_unused_instance_shapes) {
+	LOG(INFO, "Generating instances");
+	const TypedArray<int> mesh_instance_keys = p_instance_build_data.keys();
+	for (const int mesh_id : mesh_instance_keys) {
 		// Verify mesh id is valid and has some meshes
 		const Ref<Terrain3DMeshAsset> ma = _terrain->get_assets()->get_mesh_asset(mesh_id);
 		if (ma.is_valid()) {
 			if (!ma->is_enabled()) {
+				LOG(ERROR, mesh_id, " is not enabled. This shouldn't happen.");
 				continue;
 			}
-			if (ma->get_shape_count() == 0) {
-				LOG(EXTREME, "MeshAsset ", mesh_id, " valid but has no collision shapes, skipping");
+			if (ma->get_shapes().is_empty()) {
+				LOG(ERROR, "MeshAsset ", mesh_id, " valid but has no collision shapes, skipping. This shouldn't happen.");
 				continue;
 			}
 		} else {
-			LOG(WARN, "MeshAsset ", mesh_id, " is null, skipping");
+			LOG(ERROR, "MeshAsset ", mesh_id, " is null, skipping. This shouldn't happen.");
 			continue;
 		}
-
-		const Dictionary cell_inst_dict = mesh_inst_dict[mesh_id];
-
-		if (!cell_inst_dict.has(cell_loc)) {
+		const Array instance_data = p_instance_build_data[mesh_id];
+		if (instance_data.is_empty()) {
+			// No new instances of this type are needed
 			continue;
 		}
-
-		const Array triple = cell_inst_dict[cell_loc];
-
-		if (triple.size() < 3) {
-			LOG(WARN, "Triple is empty");
+		const TypedArray<Transform3D> xforms = TypedArray<Transform3D>(instance_data[0]);
+		const TypedArray<Vector3> cell_positions = TypedArray<Vector3>(instance_data[1]);
+		if (xforms.is_empty() || cell_positions.is_empty()) {
+			LOG(ERROR, "No instances of type ", mesh_id, " to create. This shouldn't happen.");
 			continue;
 		}
-
-		TypedArray<Transform3D> xforms = triple[0];
-
-		_add_mesh_asset_instance(mesh_id, ma, region_transform, cell_origin, xforms);
-	}
-
-	LOG(EXTREME, "Generated cell ", cell_origin, " in : ", Time::get_singleton()->get_ticks_usec() - time, " us");
-}
-
-void Terrain3DCollision::_decompose_cells_outside_of_radius(const Vector3 &p_decompose_origin, const real_t p_radius) {
-	int time = Time::get_singleton()->get_ticks_usec();
-	LOG(EXTREME, "Decomposing cells beyond ", p_radius, " of ", p_decompose_origin) {
-	}
-	TypedArray<Vector3> instance_cells = _active_instance_cells.keys();
-	for (int i = 0; i < instance_cells.size(); i++) {
-		Vector3 cell_origin = instance_cells[i];
-		Vector3 cell_centre = cell_origin + Vector3(16.0f, 0.0f, 16.0f);
-		if (p_decompose_origin.distance_to(cell_centre) > p_radius) {
-			_decompose_instance_collision_cell(cell_origin);
-		}
-	}
-
-	LOG(EXTREME, "Decomposed old cells in : ", Time::get_singleton()->get_ticks_usec() - time, " us");
-}
-
-void Terrain3DCollision::_decompose_instance_collision_cell(const Vector3 &cell_origin) {
-	int time = Time::get_singleton()->get_ticks_usec();
-	// Dictionary { cell_loc, {mesh_asset_id, [instances] -> [shapes] -> [RID, Body_ID] } ]
-
-	LOG(EXTREME, "Decomposing at ", cell_origin);
-	if (!_active_instance_cells.has(cell_origin)) {
-		LOG(WARN, "Tried to decompose invalid cell at ", cell_origin);
-		return;
-	}
-
-	Dictionary active_mesh_instance_dict = _active_instance_cells[cell_origin];
-
-	Array mesh_asset_keys = active_mesh_instance_dict.keys();
-
-	for (int i = 0; i < mesh_asset_keys.size(); i++) {
-		const int mesh_asset_id = mesh_asset_keys[i];
-		LOG(EXTREME, "Dealing with mesh asset ID ", mesh_asset_id);
-
-		Array active_instances_arr = active_mesh_instance_dict[mesh_asset_id];
-
-		Array unused_assets = _inactive_mesh_asset_instances[mesh_asset_id];
-
-		for (int instance = 0; instance < active_instances_arr.size(); instance++) {
-			LOG(EXTREME, "Storing ", active_instances_arr[instance]);
-			unused_assets.push_back(active_instances_arr[instance]);
-		}
-
-		_inactive_mesh_asset_instances[mesh_asset_id] = unused_assets;
-	}
-
-	_active_instance_cells.erase(cell_origin);
-
-	LOG(EXTREME, "Decomposed cell ", cell_origin, " in : ", Time::get_singleton()->get_ticks_usec() - time, " us");
-}
-
-void Terrain3DCollision::_decompose_mesh_asset_to_unused_shapes(const int &p_mesh_id, Array &ma_dict) {
-	int time = Time::get_singleton()->get_ticks_usec();
-
-	for (int instance = 0; instance < ma_dict.size(); instance++) {
-		Array ma_instance = ma_dict[instance];
-		const Ref<Terrain3DMeshAsset> ma = _terrain->get_assets()->get_mesh_asset(p_mesh_id);
-
-		for (int s = 0; s < ma->get_shape_count(); s++) {
-			Array shape_details = ma_instance[s];
-			RID rid = shape_details[0];
-			int shape_index = shape_details[1];
-			int shape_type = PS->shape_get_type(rid);
-
-			if (!rid.is_valid()) {
-				LOG(WARN, "Tried to decompose shape with invalid RID");
-				continue;
+		for (int x = 0; x < xforms.size(); x++) {
+			const Transform3D xform = xforms[x];
+			const Vector3 cell_pos = cell_positions[x];
+			TypedArray<RID> shapes;
+			Dictionary active_instances_dict = _active_instance_cells[cell_pos];
+			Array active_instances_arr = active_instances_dict[mesh_id];
+			Array reusable_assets;
+			if (p_recyclable_instances.has(mesh_id)) {
+				reusable_assets = Array(p_recyclable_instances[mesh_id]);
 			}
-
-			Dictionary unused_shapes = _unused_instance_shapes[shape_type];
-			unused_shapes[rid] = shape_index;
-			_unused_instance_shapes[shape_type] = unused_shapes;
-		}
-	}
-	LOG(EXTREME, "Decomposed mesh asset to shape in : ", Time::get_singleton()->get_ticks_usec() - time, " us");
-}
-
-void Terrain3DCollision::_decompose_inactive_mesh_assets() {
-	int time = Time::get_singleton()->get_ticks_usec();
-
-	Array inactive_mesh_asset_keys = _inactive_mesh_asset_instances.keys();
-	if (!inactive_mesh_asset_keys.size()) {
-		return;
-	}
-
-	for (int i = 0; i < inactive_mesh_asset_keys.size(); i++) {
-		Array ma_dict = _inactive_mesh_asset_instances[inactive_mesh_asset_keys[i]];
-		_decompose_mesh_asset_to_unused_shapes(inactive_mesh_asset_keys[i], ma_dict);
-		_inactive_mesh_asset_instances.erase(inactive_mesh_asset_keys[i]);
-	}
-
-	if (_inactive_mesh_asset_instances.size()) {
-		LOG(WARN, "Failed to decompose all inactive mesh asset instances");
-	}
-
-	LOG(EXTREME, "Decomposed all MeshAssets to shapes in : ", Time::get_singleton()->get_ticks_usec() - time, " us");
-}
-
-void Terrain3DCollision::_add_mesh_asset_instance(const int &p_mesh_asset_id, const Ref<Terrain3DMeshAsset> p_ma, const Transform3D &p_region_transform, const Vector3 &p_cell_origin, const TypedArray<Transform3D> &p_xforms) {
-	int time = Time::get_singleton()->get_ticks_usec();
-
-	Dictionary active_mesh_asset_dict = _active_instance_cells[p_cell_origin];
-	Array active_instances_arr = active_mesh_asset_dict[p_mesh_asset_id];
-
-	for (int x = 0; x < p_xforms.size(); x++) {
-		Array shapes;
-		const Transform3D xform = p_xforms[x];
-
-		// Reuse mesh asset instance if possible
-		if (_inactive_mesh_asset_instances.has(p_mesh_asset_id)) {
-			Array reusable_assets = _inactive_mesh_asset_instances[p_mesh_asset_id];
-			Array reusable_shapes = reusable_assets.pop_back();
-
-			for (int s = 0; s < reusable_shapes.size(); s++) {
-				Transform3D shape_transforms = p_ma->get_shape_transforms()[s];
-				Transform3D this_transform = p_region_transform * xform * shape_transforms;
-
-				Array shape_details = reusable_shapes[s];
-				RID shape_rid = shape_details[0];
-				int shape_id = shape_details[1];
-				LOG(EXTREME, "Recycling shape_rid : ", shape_rid, " id : ", shape_id);
-
-				PS->body_set_shape_transform(_instance_static_body_rid, shape_id, this_transform);
-				_update_visual_instance(shape_rid, this_transform);
-			}
-
-			active_instances_arr.push_back(reusable_shapes);
-
-			if (reusable_assets.size() == 0) {
-				_inactive_mesh_asset_instances.erase(p_mesh_asset_id);
-			} else {
-				_inactive_mesh_asset_instances[p_mesh_asset_id] = reusable_assets;
-			}
-		} else {
-			LOG(EXTREME, "No instances to recycle, creating new shapes");
-			for (int i = 0; i < p_ma->get_shape_count(); i++) {
-				Ref<Shape3D> ma_shape = cast_to<Shape3D>(p_ma->get_shapes()[i]);
-				Transform3D shape_transforms = p_ma->get_shape_transforms()[i];
-				int shape_type = PS->shape_get_type(ma_shape->get_rid());
-				Transform3D this_transform = p_region_transform * xform * shape_transforms;
-
-				RID shape_rid = RID();
-				int shape_id = -1;
-
-				if (!shape_rid.is_valid()) {
-					// Create shape using PS
-					// Different methods are required to create different shapes
-					switch (shape_type) {
-						case PhysicsServer3D::ShapeType::SHAPE_SPHERE:
-							shape_rid = PS->sphere_shape_create();
-							break;
-						case PhysicsServer3D::ShapeType::SHAPE_BOX:
-							shape_rid = PS->box_shape_create();
-							break;
-						case PhysicsServer3D::ShapeType::SHAPE_CAPSULE:
-							shape_rid = PS->capsule_shape_create();
-							break;
-						case PhysicsServer3D::ShapeType::SHAPE_CYLINDER:
-							shape_rid = PS->cylinder_shape_create();
-							break;
-						case PhysicsServer3D::ShapeType::SHAPE_CONVEX_POLYGON:
-							shape_rid = PS->convex_polygon_shape_create();
-							break;
-						case PhysicsServer3D::ShapeType::SHAPE_CONCAVE_POLYGON:
-							shape_rid = PS->concave_polygon_shape_create();
-							break;
-						default:
-							LOG(WARN, "Tried to use unsupported shape type : ", shape_type);
-							break;
-					}
-					if (!shape_rid.is_valid()) {
-						LOG(ERROR, "Failed to create shape");
+			if (!reusable_assets.is_empty()) {
+				const TypedArray<RID> reusable_shapes = TypedArray<RID>(reusable_assets.pop_back());
+				if (reusable_assets.is_empty()) {
+					p_recyclable_instances.erase(mesh_id);
+				} else {
+					p_recyclable_instances[mesh_id] = reusable_assets;
+				}
+				for (int s = 0; s < reusable_shapes.size(); s++) {
+					const Transform3D shape_transform = ma->get_shape_transforms()[s];
+					const Transform3D this_transform = xform * shape_transform;
+					const RID shape_rid = reusable_shapes[s];
+					// Get the shape index from the map
+					if (!_RID_index_map.has(shape_rid)) {
+						// There is a problem with our RID/index map
+						LOG(ERROR, shape_rid, " does not have an entry in RID_index_map. This shouldn't happen.");
 						continue;
 					}
-
-					shape_id = PS->body_get_shape_count(_instance_static_body_rid);
-					PS->body_add_shape(_instance_static_body_rid, shape_rid, this_transform, false);
-					PS->shape_set_data(shape_rid, PS->shape_get_data(ma_shape->get_rid()));
-
-					Array shape_details;
-					shape_details.push_back(shape_rid);
-					shape_details.push_back(shape_id);
-					shapes.push_back(shape_details);
-
+					const int shape_id = _RID_index_map[shape_rid];
+					LOG(EXTREME, "Recycling shape_rid : ", shape_rid, " id : ", shape_id);
+					PS->body_set_shape_transform(_instance_static_body_rid, shape_id, this_transform);
 					if (is_editor_mode()) {
-						_create_visual_instance(shape_rid, ma_shape->get_debug_mesh(), this_transform);
+						const Ref<Shape3D> &ma_shape = cast_to<Shape3D>(ma->get_shapes()[s]);
+						_queue_debug_mesh_update(shape_rid, xform, ma_shape->get_debug_mesh(), DebugMeshInstanceData::Action::UPDATE);
 					}
 				}
+				active_instances_arr.push_back(reusable_shapes);
+			} else {
+				// No shapes to recycle, create new ones
+				LOG(DEBUG, "No instances of ", mesh_id, " to recycle");
+				for (int i = 0; i < ma->get_shape_count(); i++) {
+					const Ref<Shape3D> ma_shape = cast_to<Shape3D>(ma->get_shapes()[i]);
+					const Transform3D shape_transforms = ma->get_shape_transforms()[i];
+					const int shape_type = PS->shape_get_type(ma_shape->get_rid());
+					const Transform3D this_transform = xform * shape_transforms;
+					RID shape_rid = RID();
+					// Check for a shape in the unused shapes pool
+					if (p_unused_instance_shapes.has(shape_type)) {
+						// Reuse a shape from the unused shapes pool
+						TypedArray<RID> unused_shapes = p_unused_instance_shapes[shape_type];
+						if (!unused_shapes.is_empty()) {
+							shape_rid = unused_shapes.pop_back();
+							if (unused_shapes.is_empty()) {
+								p_unused_instance_shapes.erase(shape_type);
+							} else {
+								p_unused_instance_shapes[shape_type] = unused_shapes;
+							}
+							const int shape_id = _RID_index_map[shape_rid];
+							PS->shape_set_data(shape_rid, PS->shape_get_data(ma_shape->get_rid()));
+							PS->body_set_shape_transform(_instance_static_body_rid, shape_id, this_transform);
+							shapes.push_back(shape_rid);
+							if (is_editor_mode()) {
+								_queue_debug_mesh_update(shape_rid, xform, ma_shape->get_debug_mesh(), DebugMeshInstanceData::Action::UPDATE);
+							}
+						}
+					}
+					// If we didn't find a shape to recycle, create a new one
+					if (!shape_rid.is_valid()) {
+						LOG(DEBUG, "No shapes to recycle. Creating new shape for ", ma_shape->get_name(), " type: ", shape_type);
+						// Create shape using PS
+						// Different methods are required to create different shapes
+						switch (shape_type) {
+							case PhysicsServer3D::ShapeType::SHAPE_SPHERE:
+								shape_rid = PS->sphere_shape_create();
+								break;
+							case PhysicsServer3D::ShapeType::SHAPE_BOX:
+								shape_rid = PS->box_shape_create();
+								break;
+							case PhysicsServer3D::ShapeType::SHAPE_CAPSULE:
+								shape_rid = PS->capsule_shape_create();
+								break;
+							case PhysicsServer3D::ShapeType::SHAPE_CYLINDER:
+								shape_rid = PS->cylinder_shape_create();
+								break;
+							case PhysicsServer3D::ShapeType::SHAPE_CONVEX_POLYGON:
+								shape_rid = PS->convex_polygon_shape_create();
+								break;
+							case PhysicsServer3D::ShapeType::SHAPE_CONCAVE_POLYGON:
+								shape_rid = PS->concave_polygon_shape_create();
+								break;
+							default:
+								LOG(WARN, "Tried to use unsupported shape type : ", shape_type);
+								break;
+						}
+						if (!shape_rid.is_valid()) {
+							LOG(ERROR, "Failed to create shape type : ", shape_type);
+							continue;
+						}
+						const int shape_id = PS->body_get_shape_count(_instance_static_body_rid);
+						// Add the index to our map
+						_RID_index_map[shape_rid] = shape_id;
+						PS->body_add_shape(_instance_static_body_rid, shape_rid, this_transform);
+						PS->shape_set_data(shape_rid, PS->shape_get_data(ma_shape->get_rid()));
+						shapes.push_back(shape_rid);
+						if (is_editor_mode()) {
+							_queue_debug_mesh_update(shape_rid, this_transform, ma_shape->get_debug_mesh(), DebugMeshInstanceData::Action::CREATE);
+						}
+					}
+					// next shape++
+				}
+				active_instances_arr.push_back(shapes);
 			}
-			active_instances_arr.push_back(shapes);
+			active_instances_dict[mesh_id] = active_instances_arr;
+			_active_instance_cells[cell_pos] = active_instances_dict;
 		}
 	}
-	active_mesh_asset_dict[p_mesh_asset_id] = active_instances_arr;
-	_active_instance_cells[p_cell_origin] = active_mesh_asset_dict;
-	LOG(EXTREME, "Added mesh instance in : ", Time::get_singleton()->get_ticks_usec() - time, " us");
 }
 
 void Terrain3DCollision::_update_instance_collision() {
-	int time = Time::get_singleton()->get_ticks_usec();
-
+	const int time = Time::get_singleton()->get_ticks_usec();
+	const int region_size = _terrain->get_region_size();
+	const real_t vertex_spacing = _terrain->get_vertex_spacing();
+	const int cell_size = _terrain->get_instancer()->CELL_SIZE;
+	const Vector2i snapped_pos = _snap_to_grid(_terrain->get_collision_target_position() / vertex_spacing);
+	if (!_terrain->get_data()->get_regionp(v2v3(snapped_pos)).is_valid()) {
+		return;
+	}
+	// Create a static body if none exists
 	if (!_instance_static_body_rid.is_valid()) {
 		_instance_static_body_rid = PS->body_create();
 		PS->body_set_mode(_instance_static_body_rid, PhysicsServer3D::BODY_MODE_STATIC);
@@ -567,179 +606,158 @@ void Terrain3DCollision::_update_instance_collision() {
 		PS->body_set_collision_priority(_instance_static_body_rid, _priority);
 	}
 
-	const int cell_size = _terrain->get_instancer()->CELL_SIZE;
-	Dictionary cells_to_build = {};
+	// Determine which cells need to be built
+	const TypedArray<Vector3> instance_cells_to_build = _get_instance_cells_to_build(snapped_pos, region_size, cell_size, vertex_spacing);
 
-	const real_t vertex_spacing = _terrain->get_vertex_spacing();
-	Vector2i snapped_pos = _snap_to_grid(_terrain->get_collision_target_position() / vertex_spacing);
+	// Decompose cells outside of radius
+	// Stored as {mesh_asset_id:int} -> [shapes [RID, Body_ID]]
+	Dictionary recyclable_instances = _get_recyclable_instances(snapped_pos, real_t(_radius));
 
-	if (is_dynamic_mode()) {
-		_decompose_cells_outside_of_radius(v2iv3(snapped_pos), real_t(_radius));
-		int grid_size = _radius * 2;
-		int step = 32;
-		for (int x = 0; x < grid_size; x += step) {
-			for (int y = 0; y < grid_size; y += step) {
-				Vector3 cell_offset = Vector3(x - _radius, 0.0, y - _radius) * vertex_spacing;
-				Vector3 cell_pos = v2v3(snapped_pos) + cell_offset;
-				if (!_active_instance_cells.has(cell_pos)) {
-					Vector3 cell_centre = cell_pos + Vector3(cell_size * 0.5f, 0, cell_size * 0.5f);
-					if (cell_centre.distance_to(v2v3(snapped_pos)) < real_t(_radius)) {
-						cells_to_build[cell_pos] = NULL;
-					}
-				}
-			}
-		}
-	} else {
-		// Full collision
-		TypedArray<Vector2i> region_locs = _terrain->get_data()->get_region_locations();
-		for (int i = 0; i < region_locs.size(); i++) {
-			Vector3 region_pos = v2v3(region_locs[i]) * _terrain->get_region_size() * vertex_spacing;
-			for (int x = 0; x < cell_size; x++) {
-				for (int y = 0; y < cell_size; y++) {
-					Vector3 cell_pos = region_pos + Vector3(x * cell_size * vertex_spacing, 0.0, y * cell_size * vertex_spacing);
-					cells_to_build[cell_pos] = NULL;
-				}
-			}
-		}
-	}
+	// Build a list of instances to create
+	// Stored as {mesh_id: int} [global_xform] [cell_position]
+	Dictionary instance_build_data = _get_instance_build_data(instance_cells_to_build, region_size, vertex_spacing);
 
-	TypedArray<Vector3> cell_locs = cells_to_build.keys();
+	// Decompose assets which will not be recycled in full
+	// They are decomposed into their component shapes, which may yet be reused
+	// Stored as {ShapeType:int} -> [shapes [RID, Body_ID]]
+	Dictionary unused_instance_shapes = _get_unused_instance_shapes(instance_build_data, recyclable_instances);
 
-	int build_time = Time::get_singleton()->get_ticks_usec();
-	LOG(EXTREME, "Building ", cell_locs.size(), " cells");
-	for (int i = 0; i < cell_locs.size(); i++) {
-		_generate_instance_collision_cell(cell_locs[i]);
-	}
-	LOG(EXTREME, " Active cell count : ", _active_instance_cells.size());
-	LOG(EXTREME, "Instance collision built in : ", Time::get_singleton()->get_ticks_usec() - build_time, " us");
+	// Do the instancing
+	//
+	_generate_instances(instance_build_data, recyclable_instances, unused_instance_shapes);
 
-	_decompose_inactive_mesh_assets();
-	_destroy_unused_shapes();
+	// Destroy any remaining unused shapes
+	//
+	_destroy_remaining_instance_shapes(unused_instance_shapes);
 
+	LOG(EXTREME, "Active instance collision cell count : ", _active_instance_cells.size());
 	LOG(EXTREME, "Instance shape count = ", PS->body_get_shape_count(_instance_static_body_rid));
 	LOG(EXTREME, "Instance collision update time: ", Time::get_singleton()->get_ticks_usec() - time, " us");
 }
 
 void Terrain3DCollision::_destroy_instance_collision() {
-	int time = Time::get_singleton()->get_ticks_usec();
-
-	Array cell_locs = _active_instance_cells.keys();
-	for (int i = 0; i < cell_locs.size(); i++) {
-		_decompose_instance_collision_cell(cell_locs[i]);
-	}
-
-	_destroy_unused_shapes();
-
+	LOG(INFO, "Destroying instance collision");
+	const int time = Time::get_singleton()->get_ticks_usec();
+	_destroy_debug_mesh_instances();
 	if (_instance_static_body_rid.is_valid()) {
-		// We shouldn't have any shapes left but just to be sure...
 		while (PS->body_get_shape_count(_instance_static_body_rid) > 0) {
-			RID shape_rid = PS->body_get_shape(_instance_static_body_rid, 0);
+			const RID shape_rid = PS->body_get_shape(_instance_static_body_rid, 0);
 			PS->free_rid(shape_rid);
 		}
-
 		PS->free_rid(_instance_static_body_rid);
 		_instance_static_body_rid = RID();
 	}
 	_active_instance_cells.clear();
-	_inactive_mesh_asset_instances.clear();
-	_unused_instance_shapes.clear();
-
 	LOG(EXTREME, "Destroy instance collision update time: ", Time::get_singleton()->get_ticks_usec() - time, " us");
 }
 
-void Terrain3DCollision::_create_visual_instance(const RID &p_shape_rid, Ref<ArrayMesh> p_debug_mesh, const Transform3D &p_xform) {
-	int time = Time::get_singleton()->get_ticks_usec();
-	if (!p_shape_rid.is_valid()) {
-		LOG(WARN, "Tried to create visual instance for invalid shape rid");
-		return;
-	}
-
+void Terrain3DCollision::_create_debug_mesh_instance(const RID &p_shape_rid, const Transform3D &p_xform, const Ref<ArrayMesh> &p_debug_mesh) {
+	const int time = Time::get_singleton()->get_ticks_usec();
 	if (!p_xform.is_finite()) {
 		LOG(WARN, "Transform invalid for shape ", p_shape_rid);
 		LOG(WARN, "xform: ", p_xform);
 		return;
 	}
-
 	if (!p_debug_mesh.is_valid()) {
 		LOG(WARN, "Invalid debug mesh for shape ", p_shape_rid);
 		return;
 	}
-
-	if (_instance_shape_visual_pairs.has(p_shape_rid)) {
-		LOG(WARN, "Visual instance already exists for shape ", p_shape_rid);
+	if (_shape_debug_mesh_pairs.has(p_shape_rid)) {
+		LOG(WARN, "Debug mesh instance already exists for shape ", p_shape_rid);
 		return;
 	}
-
-	RID visual_rid = RS->instance_create();
+	const RID visual_rid = RS->instance_create();
 	RS->instance_set_scenario(visual_rid, _terrain->get_world_3d()->get_scenario());
 	RS->instance_set_base(visual_rid, p_debug_mesh->get_rid());
 	RS->instance_set_transform(visual_rid, p_xform);
-
-	_instance_shape_visual_pairs[p_shape_rid] = visual_rid;
-
-	LOG(EXTREME, "Created visual rid ", visual_rid, "to pair with ", p_shape_rid, " at ", p_xform.origin);
-	LOG(EXTREME, "Created visual instance in : ", Time::get_singleton()->get_ticks_usec() - time, " us");
+	_shape_debug_mesh_pairs[p_shape_rid] = visual_rid;
+	LOG(EXTREME, "Created visual rid ", visual_rid, "to pair with ", p_shape_rid, " at ", p_xform.origin, " in ", Time::get_singleton()->get_ticks_usec() - time, " us");
 }
 
-void Terrain3DCollision::_update_visual_instance(const RID &p_shape_rid, const Transform3D &p_xform) {
-	int time = Time::get_singleton()->get_ticks_usec();
-
-	if (!p_shape_rid.is_valid()) {
-		LOG(WARN, "Tried to update visual instance for invalid shape rid");
+void Terrain3DCollision::_update_debug_mesh_instance(const RID &p_shape_rid, const Transform3D &p_xform, const Ref<ArrayMesh> &p_debug_mesh) {
+	const int time = Time::get_singleton()->get_ticks_usec();
+	if (!p_xform.is_finite()) {
+		LOG(WARN, "Transform invalid for shape ", p_shape_rid);
+		LOG(WARN, "xform: ", p_xform);
 		return;
 	}
-
-	if (!_instance_shape_visual_pairs.has(p_shape_rid)) {
-		LOG(WARN, "Visual instance does not exist, skipping");
+	if (!_shape_debug_mesh_pairs.has(p_shape_rid)) {
+		LOG(EXTREME, "Shape RID not paired with a debug mesh instance, skipping");
 		return;
 	}
-
-	RID visual_rid = _instance_shape_visual_pairs[p_shape_rid];
-
+	const RID visual_rid = _shape_debug_mesh_pairs[p_shape_rid];
 	if (!visual_rid.is_valid()) {
-		LOG(WARN, "Visual instance RID for shape ", p_shape_rid, " was invalid, skipping");
+		LOG(WARN, "Debug mesh instance RID for shape ", p_shape_rid, " was invalid, skipping");
 		return;
 	}
-
 	RS->instance_set_transform(visual_rid, p_xform);
-
-	LOG(EXTREME, "Updated visual instance in : ", Time::get_singleton()->get_ticks_usec() - time, " us");
+	RS->instance_set_base(visual_rid, p_debug_mesh->get_rid());
+	LOG(EXTREME, "Updated debug mesh instance in : ", Time::get_singleton()->get_ticks_usec() - time, " us");
 }
 
-void Terrain3DCollision::_destroy_visual_instance(const RID &p_shape_rid) {
-	int time = Time::get_singleton()->get_ticks_usec();
-	if (!_instance_shape_visual_pairs.size()) {
+void Terrain3DCollision::_destroy_debug_mesh_instance(const RID &p_shape_rid) {
+	const int time = Time::get_singleton()->get_ticks_usec();
+	if (!_shape_debug_mesh_pairs.has(p_shape_rid)) {
+		LOG(EXTREME, "Shape RID not paired with a visual instance, skipping");
 		return;
 	}
-
-	if (!_instance_shape_visual_pairs.has(p_shape_rid)) {
-		LOG(EXTREME, "Visual instance does not exist, skipping");
-		return;
-	}
-
-	RID visual_rid = _instance_shape_visual_pairs[p_shape_rid];
-
+	const RID visual_rid = _shape_debug_mesh_pairs[p_shape_rid];
+	_shape_debug_mesh_pairs.erase(p_shape_rid);
 	if (!visual_rid.is_valid()) {
-		LOG(WARN, "Visual instance RID invalid, skipping");
+		LOG(EXTREME, "Debug mesh instance RID invalid, skipping");
 		return;
 	}
-
-	LOG(EXTREME, "Destroying ", visual_rid, " which was paired with shape ", p_shape_rid);
-
 	RS->free_rid(visual_rid);
-	_instance_shape_visual_pairs.erase(p_shape_rid);
-	LOG(EXTREME, "Destroyed visual instance in : ", Time::get_singleton()->get_ticks_usec() - time, " us");
+	LOG(EXTREME, "Destroyed debug mesh instance ", visual_rid, " which was paired with shape ", p_shape_rid, "in : ", Time::get_singleton()->get_ticks_usec() - time, " us");
 }
 
-void Terrain3DCollision::_destroy_visual_instances() {
-	int time = Time::get_singleton()->get_ticks_usec();
-	Array keys = _instance_shape_visual_pairs.keys();
-
+void Terrain3DCollision::_destroy_debug_mesh_instances() {
+	LOG(INFO, "Destroying visual instances");
+	const int time = Time::get_singleton()->get_ticks_usec();
+	const Array keys = _shape_debug_mesh_pairs.keys();
 	for (int i = 0; i < keys.size(); i++) {
-		RID shape_rid = _instance_shape_visual_pairs[keys[i]];
-		_destroy_visual_instance(shape_rid);
+		const RID &shape_rid = RID(keys[i]);
+		_queue_debug_mesh_update(shape_rid, Transform3D(), Ref<ArrayMesh>(), DebugMeshInstanceData::Action::DESTROY);
 	}
-	LOG(EXTREME, "Destroyed all visual instances in : ", Time::get_singleton()->get_ticks_usec() - time, " us");
+	_shape_debug_mesh_pairs.clear();
+	LOG(EXTREME, "Destroyed all debug mesh instances in : ", Time::get_singleton()->get_ticks_usec() - time, " us");
+}
+
+void Terrain3DCollision::_queue_debug_mesh_update(const RID &p_shape_rid, const Transform3D &p_xform, const Ref<ArrayMesh> &p_debug_mesh, const DebugMeshInstanceData::Action &p_action) {
+	DebugMeshInstanceData vi;
+	vi.shape_rid = p_shape_rid;
+	vi.xform = p_xform;
+	vi.debug_mesh = p_debug_mesh;
+	vi.action = p_action;
+	_debug_visual_instance_queue.push_back(vi);
+	if (!RS->is_connected("frame_pre_draw", callable_mp(this, &Terrain3DCollision::_process_debug_mesh_updates))) {
+		LOG(DEBUG, "Connect to RS::frame_pre_draw signal");
+		RS->connect("frame_pre_draw", callable_mp(this, &Terrain3DCollision::_process_debug_mesh_updates));
+	}
+}
+
+void Terrain3DCollision::_process_debug_mesh_updates() {
+	if (_debug_visual_instance_queue.empty()) {
+		if (RS->is_connected("frame_pre_draw", callable_mp(this, &Terrain3DCollision::_process_debug_mesh_updates))) {
+			LOG(DEBUG, "Disconnect from RS::frame_pre_draw signal");
+			RS->disconnect("frame_pre_draw", callable_mp(this, &Terrain3DCollision::_process_debug_mesh_updates));
+		}
+		return;
+	}
+	if (!_terrain->is_inside_tree()) {
+		return;
+	}
+	for (int i = 0; i < _debug_visual_instance_queue.size(); i++) {
+		const DebugMeshInstanceData &vi = _debug_visual_instance_queue[i];
+		if (vi.action == DebugMeshInstanceData::Action::CREATE) {
+			_create_debug_mesh_instance(vi.shape_rid, vi.xform, vi.debug_mesh);
+		} else if (vi.action == DebugMeshInstanceData::Action::UPDATE) {
+			_update_debug_mesh_instance(vi.shape_rid, vi.xform, vi.debug_mesh);
+		} else if (vi.action == DebugMeshInstanceData::Action::DESTROY) {
+			_destroy_debug_mesh_instance(vi.shape_rid);
+		}
+	}
+	_debug_visual_instance_queue.clear();
 }
 
 ///////////////////////////

--- a/src/terrain_3d_collision.cpp
+++ b/src/terrain_3d_collision.cpp
@@ -818,7 +818,15 @@ void Terrain3DCollision::destroy_instance_collision() {
 	LOG(INFO, "Destroying instance collision");
 	const int time = Time::get_singleton()->get_ticks_usec();
 	_destroy_debug_mesh_instances();
-
+	for (const RID &body_rid : _instance_body_rids.values()) {
+		while (PS->body_get_shape_count(body_rid) > 0) {
+			const RID shape_rid = PS->body_get_shape(body_rid, 0);
+			PS->body_remove_shape(body_rid, 0);
+			PS->free_rid(shape_rid);
+			LOG(EXTREME, "Destroyed shape ", shape_rid);
+		}
+	}
+	_instance_body_rids.clear();
 	_active_instance_cells.clear();
 	_last_snapped_pos_instance_collision = V2I_MAX;
 	LOG(EXTREME, "Destroy instance collision update time: ", Time::get_singleton()->get_ticks_usec() - time, " us");

--- a/src/terrain_3d_collision.cpp
+++ b/src/terrain_3d_collision.cpp
@@ -656,7 +656,7 @@ void Terrain3DCollision::_generate_instances(const Dictionary &p_instance_build_
 									}
 									// refresh local unused_shapes for this type
 									if (p_unused_instance_shapes.has(shape_type)) {
-										unused_shapes = p_unused_instance_shapes[shape_type];
+										unused_shapes = TypedArray<RID>(p_unused_instance_shapes[shape_type]);
 									}
 								}
 							}

--- a/src/terrain_3d_collision.cpp
+++ b/src/terrain_3d_collision.cpp
@@ -630,29 +630,29 @@ void Terrain3DCollision::_generate_instances(const Dictionary &p_instance_build_
 						// Check for a shape in the unused shapes pool
 						TypedArray<RID> unused_shapes;
 						if (p_unused_instance_shapes.has(shape_type)) {
-							unused_shapes = p_unused_instance_shapes[shape_type];
+							unused_shapes = TypedArray<RID>(p_unused_instance_shapes[shape_type]);
 						}
 						// If no unused shapes available, attempt to decompose one recyclable full-instance
 						if (unused_shapes.is_empty()) {
 							if (p_recyclable_instances.has(mesh_id)) {
-								Array rec_assets = Array(p_recyclable_instances[mesh_id]);
-								if (!rec_assets.is_empty()) {
+								Array recyclable_instances = Array(p_recyclable_instances[mesh_id]);
+								if (!recyclable_instances.is_empty()) {
 									// Pop one full instance and distribute its member RIDs into the unused pool
-									TypedArray<RID> rec_instance = TypedArray<RID>(rec_assets.pop_back());
-									if (rec_assets.is_empty()) {
+									TypedArray<RID> recyclable_instance = TypedArray<RID>(recyclable_instances.pop_back());
+									if (recyclable_instances.is_empty()) {
 										p_recyclable_instances.erase(mesh_id);
 									} else {
-										p_recyclable_instances[mesh_id] = rec_assets;
+										p_recyclable_instances[mesh_id] = recyclable_instances;
 									}
-									for (const RID &rec_rid : rec_instance) {
-										if (!rec_rid.is_valid()) {
+									for (const RID &recyclable_shape_rid : recyclable_instance) {
+										if (!recyclable_shape_rid.is_valid()) {
 											continue;
 										}
-										int rec_shape_type = PS->shape_get_type(rec_rid);
-										TypedArray<RID> pool = p_unused_instance_shapes[rec_shape_type];
-										pool.push_back(rec_rid);
-										p_unused_instance_shapes[rec_shape_type] = pool;
-										LOG(EXTREME, "Decomposed recyclable instance, stored shape ", rec_rid);
+										const int recyclable_shape_type = PS->shape_get_type(recyclable_shape_rid);
+										TypedArray<RID> pool = p_unused_instance_shapes[recyclable_shape_type];
+										pool.push_back(recyclable_shape_rid);
+										p_unused_instance_shapes[recyclable_shape_type] = pool;
+										LOG(EXTREME, "Decomposed recyclable instance, stored shape ", recyclable_shape_rid);
 									}
 									// refresh local unused_shapes for this type
 									if (p_unused_instance_shapes.has(shape_type)) {

--- a/src/terrain_3d_collision.h
+++ b/src/terrain_3d_collision.h
@@ -46,6 +46,21 @@ private:
 	bool _initialized = false;
 	Vector2i _last_snapped_pos = V2I_MAX;
 
+	// Instance collision data
+	RID _instance_static_body_rid;
+
+	// Stored as {PS_rid:RID} -> RS_rid:RID
+	Dictionary _instance_shape_visual_pairs = {};
+
+	// Stored as {ShapeType:int} -> [shapes] -> [RID, Body_ID]}
+	Dictionary _unused_instance_shapes = {};
+
+	// Stored as {cell_loc:v3} -> {mesh_asset_id:int} -> [instances] -> [shapes] -> [RID, Body_ID]
+	Dictionary _active_instance_cells = {};
+
+	// Stored as {mesh_asset_id:int} -> [shapes] -> [RID, Body_ID]
+	Dictionary _inactive_mesh_asset_instances = {};
+
 	Vector2i _snap_to_grid(const Vector2i &p_pos) const;
 	Vector2i _snap_to_grid(const Vector3 &p_pos) const;
 	Dictionary _get_shape_data(const Vector2i &p_position, const int p_size);
@@ -56,10 +71,35 @@ private:
 	void _shape_set_data(const int p_shape_id, const Dictionary &p_dict);
 
 	void _reload_physics_material();
+	Vector2i _get_cell(const Vector3 &p_global_position, const int p_region_size);
+	void _destroy_unused_shapes();
+
+	void _rebuild_shape_indices();
+
+	void _generate_instance_collision_cell(const Vector3 &cell_origin);
+
+	void _decompose_cells_outside_of_radius(const Vector3 &p_decompose_origin, const real_t p_radius);
+
+	void _decompose_instance_collision_cell(const Vector3 &cell_origin);
+
+	void _decompose_mesh_asset_to_unused_shapes(const int &p_mesh_id, Array &ma_dict);
+
+	void _decompose_inactive_mesh_assets();
+
+	void _add_mesh_asset_instance(const int &p_mesh_asset_id, const Ref<Terrain3DMeshAsset> p_ma, const Transform3D &p_region_transform, const Vector3 &p_cell_origin, const TypedArray<Transform3D> &p_xforms);
+
+	void _update_instance_collision();
+
+	void _destroy_instance_collision();
+
+	void _create_visual_instance(const RID &p_shape_rid, Ref<ArrayMesh> p_debug_mesh, const Transform3D &p_xform);
 
 public:
 	Terrain3DCollision() {}
 	~Terrain3DCollision() { destroy(); }
+	void _update_visual_instance(const RID &p_shape_rid, const Transform3D &p_xform);
+	void _destroy_visual_instance(const RID &p_shape_rid);
+	void _destroy_visual_instances();
 	void initialize(Terrain3D *p_terrain);
 
 	void build();

--- a/src/terrain_3d_collision.h
+++ b/src/terrain_3d_collision.h
@@ -25,12 +25,17 @@ public: // Constants
 		FULL_GAME,
 		FULL_EDITOR,
 	};
+	enum InstanceCollisionMode {
+		INSTANCE_COLLISION_DISABLED,
+		INSTANCE_COLLISION_DYNAMIC_GAME,
+		INSTANCE_COLLISION_DYNAMIC_EDITOR,
+	};
 
 private:
 	Terrain3D *_terrain = nullptr;
 
 	// Public settings
-	CollisionMode _mode = DYNAMIC_GAME;
+	CollisionMode _mode = CollisionMode::DYNAMIC_GAME;
 	uint16_t _shape_size = 16;
 	uint16_t _radius = 64;
 	uint32_t _layer = 1;
@@ -47,12 +52,17 @@ private:
 	Vector2i _last_snapped_pos = V2I_MAX;
 
 	// Instance collision data
+	InstanceCollisionMode _instance_collision_mode = InstanceCollisionMode::INSTANCE_COLLISION_DYNAMIC_GAME;
+	Vector2i _last_snapped_pos_instance_collision = V2I_MAX;
+	real_t _instance_collision_radius = 64.f;
+	bool _instance_collision_is_dirty = false;
+
 	RID _instance_static_body_rid;
 
 	// Stored as {PS_rid:RID} -> RS_rid:RID
 	Dictionary _shape_debug_mesh_pairs = {};
 
-	// Stored as {cell_loc:v3} -> {mesh_asset_id:int} -> [instances [shapes [RID]]]
+	// Stored as {cell_loc:v2} -> {mesh_asset_id:int} -> [instances [shapes [RID]]]
 	Dictionary _active_instance_cells = {};
 
 	// Stored as {rid:RID} -> {PS_body_to_shape_index:int}
@@ -85,15 +95,13 @@ private:
 
 	void _reload_physics_material();
 
-	TypedArray<Vector3> _get_instance_cells_to_build(const Vector2i &p_snapped_pos, const int &p_region_size, const int &p_cell_size, const real_t &p_vertex_spacing);
-	Dictionary _get_recyclable_instances(const Vector2i &p_snapped_pos, const real_t &p_radius);
-	Dictionary _get_instance_build_data(const TypedArray<Vector3> &p_instance_cells_to_build, const int &p_region_size, const real_t &p_vertex_spacing);
+	TypedArray<Vector2> _get_instance_cells_to_build(const Vector2i &p_snapped_pos, const real_t p_radius, const int p_region_size, const int p_cell_size, const real_t p_vertex_spacing);
+	Dictionary _get_recyclable_instances(const Vector2i &p_snapped_pos, const real_t p_radius, const int p_cell_size, const real_t p_vertex_spacing);
+	Dictionary _get_instance_build_data(const TypedArray<Vector2> &p_instance_cells_to_build, const int p_region_size, const int p_cell_size, const real_t p_vertex_spacing);
 	Dictionary _get_unused_instance_shapes(const Dictionary &p_mesh_instance_build_data, Dictionary &p_recyclable_mesh_instance_shapes);
 
 	void _destroy_remaining_instance_shapes(Dictionary &p_unused_instance_shapes);
 	void _generate_instances(const Dictionary &p_instance_build_data, Dictionary &p_recyclable_instances, Dictionary &p_unused_instance_shapes);
-	void _update_instance_collision();
-	void _destroy_instance_collision();
 	void _create_debug_mesh_instance(const RID &p_shape_rid, const Transform3D &p_xform, const Ref<ArrayMesh> &p_debug_mesh);
 	void _update_debug_mesh_instance(const RID &p_shape_rid, const Transform3D &p_xform, const Ref<ArrayMesh> &p_debug_mesh);
 	void _destroy_debug_mesh_instance(const RID &p_shape_rid);
@@ -118,6 +126,17 @@ public:
 	bool is_editor_mode() const { return _mode == DYNAMIC_EDITOR || _mode == FULL_EDITOR; }
 	bool is_dynamic_mode() const { return _mode == DYNAMIC_GAME || _mode == DYNAMIC_EDITOR; }
 
+	void update_instance_collision();
+	void destroy_instance_collision();
+	void set_instance_collision_mode(const InstanceCollisionMode p_mode);
+	InstanceCollisionMode get_instance_collision_mode() const { return _instance_collision_mode; }
+	bool is_instance_collision_enabled() const { return _instance_collision_mode > InstanceCollisionMode::INSTANCE_COLLISION_DISABLED; }
+	bool is_instance_collision_editor_mode() const { return _instance_collision_mode == InstanceCollisionMode::INSTANCE_COLLISION_DYNAMIC_EDITOR; }
+	bool is_instance_collision_dynamic_mode() const { return _instance_collision_mode == InstanceCollisionMode::INSTANCE_COLLISION_DYNAMIC_GAME || _instance_collision_mode == InstanceCollisionMode::INSTANCE_COLLISION_DYNAMIC_EDITOR; }
+	void set_instance_collision_radius(const real_t p_radius);
+	real_t get_instance_collision_radius() const { return _instance_collision_radius; }
+	void set_instance_collision_dirty(const bool p_dirty) { _instance_collision_is_dirty = p_dirty; }
+
 	void set_shape_size(const uint16_t p_size);
 	uint16_t get_shape_size() const { return _shape_size; }
 	void set_radius(const uint16_t p_radius);
@@ -138,6 +157,9 @@ protected:
 
 using CollisionMode = Terrain3DCollision::CollisionMode;
 VARIANT_ENUM_CAST(Terrain3DCollision::CollisionMode);
+
+using InstanceCollisionMode = Terrain3DCollision::InstanceCollisionMode;
+VARIANT_ENUM_CAST(Terrain3DCollision::InstanceCollisionMode);
 
 inline Vector2i Terrain3DCollision::_snap_to_grid(const Vector2i &p_pos) const {
 	return Vector2i(int_round_mult(p_pos.x, int32_t(_shape_size)),

--- a/src/terrain_3d_collision.h
+++ b/src/terrain_3d_collision.h
@@ -57,15 +57,10 @@ private:
 	real_t _instance_collision_radius = 64.f;
 	bool _instance_collision_is_dirty = false;
 
-	RID _instance_static_body_rid;
+	// Per-mesh instance PhysicsServer bodies: {mesh_id:int -> body_rid:RID}
+	Dictionary _instance_body_rids = {};
 
-	// Stored as {PS_rid:RID} -> RS_rid:RID
-	Dictionary _shape_debug_mesh_pairs = {};
-
-	// Stored as {cell_loc:v2} -> {mesh_asset_id:int} -> [instances [shapes [RID]]]
-	Dictionary _active_instance_cells = {};
-
-	// Stored as {rid:RID} -> {PS_body_to_shape_index:int}
+	// Stored as {rid:RID} -> [body_rid:RID, shape_index:int]
 	Dictionary _RID_index_map = {};
 
 	// Debug visualisation queue
@@ -83,6 +78,12 @@ private:
 	};
 
 	std::vector<DebugMeshInstanceData> _debug_visual_instance_queue;
+
+	// Stored as {PS_rid:RID} -> RS_rid:RID
+	Dictionary _shape_debug_mesh_pairs = {};
+
+	// Stored as {cell_loc:v2} -> {mesh_asset_id:int} -> [instances [shapes [RID]]]
+	Dictionary _active_instance_cells = {};
 
 	Vector2i _snap_to_grid(const Vector2i &p_pos) const;
 	Vector2i _snap_to_grid(const Vector3 &p_pos) const;

--- a/src/terrain_3d_collision.h
+++ b/src/terrain_3d_collision.h
@@ -135,7 +135,7 @@ public:
 	bool is_instance_collision_dynamic_mode() const { return _instance_collision_mode == InstanceCollisionMode::INSTANCE_COLLISION_DYNAMIC_GAME || _instance_collision_mode == InstanceCollisionMode::INSTANCE_COLLISION_DYNAMIC_EDITOR; }
 	void set_instance_collision_radius(const real_t p_radius);
 	real_t get_instance_collision_radius() const { return _instance_collision_radius; }
-	void set_instance_collision_dirty(const bool p_dirty) { _instance_collision_is_dirty = p_dirty; }
+	void set_instance_collision_dirty(const bool p_dirty = true) { _instance_collision_is_dirty = p_dirty; }
 
 	void set_shape_size(const uint16_t p_size);
 	uint16_t get_shape_size() const { return _shape_size; }

--- a/src/terrain_3d_collision.h
+++ b/src/terrain_3d_collision.h
@@ -95,9 +95,9 @@ private:
 
 	void _reload_physics_material();
 
-	TypedArray<Vector2> _get_instance_cells_to_build(const Vector2i &p_snapped_pos, const real_t p_radius, const int p_region_size, const int p_cell_size, const real_t p_vertex_spacing);
+	TypedArray<Vector2i> _get_instance_cells_to_build(const Vector2i &p_snapped_pos, const real_t p_radius, const int p_region_size, const int p_cell_size, const real_t p_vertex_spacing);
 	Dictionary _get_recyclable_instances(const Vector2i &p_snapped_pos, const real_t p_radius, const int p_cell_size, const real_t p_vertex_spacing);
-	Dictionary _get_instance_build_data(const TypedArray<Vector2> &p_instance_cells_to_build, const int p_region_size, const int p_cell_size, const real_t p_vertex_spacing);
+	Dictionary _get_instance_build_data(const TypedArray<Vector2i> &p_instance_cells_to_build, const int p_region_size, const int p_cell_size, const real_t p_vertex_spacing);
 	Dictionary _get_unused_instance_shapes(const Dictionary &p_mesh_instance_build_data, Dictionary &p_recyclable_mesh_instance_shapes);
 
 	void _destroy_remaining_instance_shapes(Dictionary &p_unused_instance_shapes);

--- a/src/terrain_3d_instancer.cpp
+++ b/src/terrain_3d_instancer.cpp
@@ -56,6 +56,7 @@ void Terrain3DInstancer::_process_updates() {
 		}
 		_queued_updates.clear();
 		_terrain->get_assets()->load_pending_meshes();
+		_terrain->get_collision() ? _terrain->get_collision()->set_instance_collision_dirty(true) : void();
 		return;
 	}
 
@@ -102,6 +103,7 @@ void Terrain3DInstancer::_process_updates() {
 	}
 	_queued_updates.clear();
 	_terrain->get_assets()->load_pending_meshes();
+	_terrain->get_collision() ? _terrain->get_collision()->set_instance_collision_dirty(true) : void();
 }
 
 void Terrain3DInstancer::_update_mmi_by_region(const Terrain3DRegion *p_region, const int p_mesh_id) {
@@ -113,7 +115,6 @@ void Terrain3DInstancer::_update_mmi_by_region(const Terrain3DRegion *p_region, 
 		LOG(ERROR, "p_mesh_id is out of bounds");
 		return;
 	}
-	_terrain->get_collision() ? _terrain->get_collision()->build() : void();
 
 	Vector2i region_loc = p_region->get_location();
 	Dictionary mesh_inst_dict = p_region->get_instances();

--- a/src/terrain_3d_instancer.cpp
+++ b/src/terrain_3d_instancer.cpp
@@ -113,6 +113,8 @@ void Terrain3DInstancer::_update_mmi_by_region(const Terrain3DRegion *p_region, 
 		LOG(ERROR, "p_mesh_id is out of bounds");
 		return;
 	}
+	_terrain->get_collision() ? _terrain->get_collision()->build() : void();
+
 	Vector2i region_loc = p_region->get_location();
 	Dictionary mesh_inst_dict = p_region->get_instances();
 
@@ -501,15 +503,6 @@ RID Terrain3DInstancer::_create_multimesh(const int p_mesh_id, const int p_lod, 
 		}
 	}
 	return mm;
-}
-
-Vector2i Terrain3DInstancer::_get_cell(const Vector3 &p_global_position, const int p_region_size) const {
-	IS_INIT(V2I_ZERO);
-	real_t vertex_spacing = _terrain->get_vertex_spacing();
-	Vector2i cell;
-	cell.x = UtilityFunctions::posmod(UtilityFunctions::floori(p_global_position.x / vertex_spacing), p_region_size) / CELL_SIZE;
-	cell.y = UtilityFunctions::posmod(UtilityFunctions::floori(p_global_position.z / vertex_spacing), p_region_size) / CELL_SIZE;
-	return cell;
 }
 
 // Get appropriate terrain height. Could find terrain (excluding slope or holes) or optional collision
@@ -982,7 +975,7 @@ void Terrain3DInstancer::append_region(const Ref<Terrain3DRegion> &p_region, con
 	for (int i = 0; i < p_xforms.size(); i++) {
 		Transform3D xform = p_xforms[i];
 		Color col = p_colors[i];
-		Vector2i cell = _get_cell(xform.origin, region_size);
+		Vector2i cell = Util::get_cell(xform.origin, region_size, p_region->get_vertex_spacing(), CELL_SIZE);
 
 		// Get current instance arrays or create if none
 		Array triple = cell_locations[cell];
@@ -1144,7 +1137,7 @@ int Terrain3DInstancer::get_closest_mesh_id(const Vector3 &p_global_position) co
 	}
 	int region_size = region->get_region_size();
 	Vector3 region_global_pos = v2iv3(region_loc) * real_t(region_size) * _terrain->get_vertex_spacing();
-	Vector2i cell = _get_cell(p_global_position, region_size);
+	Vector2i cell = Util::get_cell(p_global_position, region_size, region->get_vertex_spacing(), CELL_SIZE);
 	Dictionary mesh_inst_dict = region->get_instances();
 	if (mesh_inst_dict.is_empty()) {
 		return -1; // No meshes found

--- a/src/terrain_3d_instancer.h
+++ b/src/terrain_3d_instancer.h
@@ -63,7 +63,6 @@ private:
 	void _destroy_mmi_by_cell(const Vector2i &p_region_loc, const int p_mesh_id, const Vector2i p_cell, const int p_lod = INT32_MAX);
 	void _backup_region(const Ref<Terrain3DRegion> &p_region);
 	RID _create_multimesh(const int p_mesh_id, const int p_lod, const TypedArray<Transform3D> &p_xforms = TypedArray<Transform3D>(), const PackedColorArray &p_colors = PackedColorArray()) const;
-	Vector2i _get_cell(const Vector3 &p_global_position, const int p_region_size) const;
 	Array _get_usable_height(const Vector3 &p_global_position, const Vector2 &p_slope_range, const bool p_on_collision, const real_t p_raycast_start) const;
 
 public:

--- a/src/terrain_3d_mesh_asset.cpp
+++ b/src/terrain_3d_mesh_asset.cpp
@@ -174,6 +174,11 @@ void Terrain3DMeshAsset::clear() {
 	_clear_lod_ranges();
 	_fade_margin = 0.f;
 	_thumbnail.unref();
+	// instance collision defaults
+	_instance_collision_layers = 1;
+	_instance_physics_material.unref();
+	_instance_collision_mask = 1;
+	_instance_collision_enabled = true;
 }
 
 void Terrain3DMeshAsset::set_name(const String &p_name) {
@@ -208,6 +213,33 @@ void Terrain3DMeshAsset::set_highlighted(const bool p_highlighted) {
 		_highlight_mat = mat;
 	}
 	LOG(DEBUG, "Emitting instancer_setting_changed, ID: ", _id);
+	emit_signal("instancer_setting_changed", _id);
+}
+
+void Terrain3DMeshAsset::set_instance_collision_enabled(const bool p_enabled) {
+	SET_IF_DIFF(_instance_collision_enabled, p_enabled);
+	LOG(INFO, "MeshAsset ", _id, ": Setting instance collision enabled: ", _instance_collision_enabled);
+	emit_signal("instancer_setting_changed", _id);
+}
+
+void Terrain3DMeshAsset::set_instance_collision_layers(const uint32_t p_layers) {
+	SET_IF_DIFF(_instance_collision_layers, p_layers);
+	LOG(INFO, "MeshAsset ", _id, ": Setting instance collision layers: ", _instance_collision_layers);
+	emit_signal("instancer_setting_changed", _id);
+}
+
+void Terrain3DMeshAsset::set_instance_collision_mask(const uint32_t p_mask) {
+	SET_IF_DIFF(_instance_collision_mask, p_mask);
+	LOG(INFO, "MeshAsset ", _id, ": Setting instance collision mask: ", _instance_collision_mask);
+	emit_signal("instancer_setting_changed", _id);
+}
+
+void Terrain3DMeshAsset::set_instance_physics_material(const Ref<PhysicsMaterial> &p_mat) {
+	if (_instance_physics_material == p_mat) {
+		return;
+	}
+	_instance_physics_material = p_mat;
+	LOG(INFO, "MeshAsset ", _id, ": Setting instance physics material");
 	emit_signal("instancer_setting_changed", _id);
 }
 
@@ -689,6 +721,13 @@ void Terrain3DMeshAsset::_bind_methods() {
 
 	ClassDB::bind_method(D_METHOD("get_instance_count"), &Terrain3DMeshAsset::get_instance_count);
 
+	ClassDB::bind_method(D_METHOD("set_instance_collision_layers", "layers"), &Terrain3DMeshAsset::set_instance_collision_layers);
+	ClassDB::bind_method(D_METHOD("get_instance_collision_layers"), &Terrain3DMeshAsset::get_instance_collision_layers);
+	ClassDB::bind_method(D_METHOD("set_instance_collision_mask", "mask"), &Terrain3DMeshAsset::set_instance_collision_mask);
+	ClassDB::bind_method(D_METHOD("get_instance_collision_mask"), &Terrain3DMeshAsset::get_instance_collision_mask);
+	ClassDB::bind_method(D_METHOD("set_instance_physics_material", "material"), &Terrain3DMeshAsset::set_instance_physics_material);
+	ClassDB::bind_method(D_METHOD("get_instance_physics_material"), &Terrain3DMeshAsset::get_instance_physics_material);
+
 	ADD_PROPERTY(PropertyInfo(Variant::STRING, "name", PROPERTY_HINT_NONE), "set_name", "get_name");
 	ADD_PROPERTY(PropertyInfo(Variant::INT, "id", PROPERTY_HINT_NONE), "set_id", "get_id");
 	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "enabled", PROPERTY_HINT_NONE), "set_enabled", "is_enabled");
@@ -722,4 +761,9 @@ void Terrain3DMeshAsset::_bind_methods() {
 	ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "lod9_range", PROPERTY_HINT_RANGE, "0.,4096.0,.05,or_greater"), "set_lod9_range", "get_lod9_range");
 	// Fade disabled until https://github.com/godotengine/godot/issues/102799 is fixed
 	ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "fade_margin", PROPERTY_HINT_RANGE, "0.,64.0,.05,or_greater", PROPERTY_USAGE_NO_EDITOR), "set_fade_margin", "get_fade_margin");
+
+	ADD_GROUP("Instance Collision", "");
+	ADD_PROPERTY(PropertyInfo(Variant::INT, "collision_layers", PROPERTY_HINT_LAYERS_3D_PHYSICS, "PhysicsLayers"), "set_instance_collision_layers", "get_instance_collision_layers");
+	ADD_PROPERTY(PropertyInfo(Variant::INT, "collision_mask", PROPERTY_HINT_LAYERS_3D_PHYSICS, "PhysicsLayers"), "set_instance_collision_mask", "get_instance_collision_mask");
+	ADD_PROPERTY(PropertyInfo(Variant::OBJECT, "physics_material", PROPERTY_HINT_RESOURCE_TYPE, "PhysicsMaterial"), "set_instance_physics_material", "get_instance_physics_material");
 }

--- a/src/terrain_3d_mesh_asset.cpp
+++ b/src/terrain_3d_mesh_asset.cpp
@@ -160,6 +160,8 @@ void Terrain3DMeshAsset::clear() {
 	_generated_type = TYPE_NONE;
 	_generated_faces = 2;
 	_generated_size = V2(1.f);
+	_shapes.clear();
+	_shape_transforms.clear();
 	_height_offset = 0.f;
 	_density = 0.f;
 	_cast_shadows = SHADOWS_ON;
@@ -311,6 +313,19 @@ void Terrain3DMeshAsset::set_scene_file(const Ref<PackedScene> &p_scene_file) {
 			}
 			_pending_meshes.push_back(mesh);
 		}
+
+		// Read and store phyics shapes
+		TypedArray<Node> collision_shapes = node->find_children("*", "CollisionShape3D");
+		if (collision_shapes.size() > 0) {
+			LOG(INFO, "Found ", collision_shapes.size(), " CollisionShapes in scene file");
+			for (int i = 0; i < collision_shapes.size(); i++) {
+				CollisionShape3D *collision_shape = cast_to<CollisionShape3D>(collision_shapes[i]);
+				Ref<Shape3D> shape = collision_shape->get_shape();
+				Transform3D xform = collision_shape->get_transform();
+				_shapes.push_back(shape);
+				_shape_transforms.push_back(xform);
+			}
+		}
 		node->queue_free();
 	}
 	if (_pending_meshes.size() > 0) {
@@ -363,6 +378,17 @@ Ref<Mesh> Terrain3DMeshAsset::get_mesh(const int p_lod) const {
 	return Ref<Mesh>();
 }
 
+TypedArray<Shape3D> Terrain3DMeshAsset::get_shapes() const {
+	return _shapes;
+}
+
+int Terrain3DMeshAsset::get_shape_count() const {
+	return _shapes.size();
+}
+
+TypedArray<Transform3D> Terrain3DMeshAsset::get_shape_transforms() const {
+	return _shape_transforms;
+}
 void Terrain3DMeshAsset::set_height_offset(const real_t p_offset) {
 	SET_IF_DIFF(_height_offset, CLAMP(p_offset, -50.f, 50.f));
 	LOG(INFO, "ID ", _id, ", ", _name, ": Setting height offset: ", _height_offset);

--- a/src/terrain_3d_mesh_asset.h
+++ b/src/terrain_3d_mesh_asset.h
@@ -7,6 +7,7 @@
 #include <godot_cpp/classes/material.hpp>
 #include <godot_cpp/classes/packed_scene.hpp>
 #include <godot_cpp/classes/resource.hpp>
+#include <godot_cpp/classes/shape3d.hpp>
 #include <godot_cpp/classes/texture2d.hpp>
 
 #include "constants.h"
@@ -72,6 +73,9 @@ private:
 	Ref<Material> _highlight_mat;
 	TypedArray<Mesh> _meshes;
 	TypedArray<Mesh> _pending_meshes; // Queue to avoid warnings from RS on mesh swap
+	TypedArray<Shape3D> _shapes;
+	TypedArray<Transform3D> _shape_transforms;
+	Ref<Texture2D> _thumbnail;
 	uint32_t _instance_count = 0;
 
 	void _clear_lod_ranges();
@@ -111,7 +115,11 @@ public:
 	void set_generated_type(const GenType p_type);
 	GenType get_generated_type() const { return _generated_type; }
 	Ref<Mesh> get_mesh(const int p_lod = 0) const;
+	TypedArray<Shape3D> get_shapes() const;
+	int get_shape_count() const;
 	void set_thumbnail(Ref<Texture2D> p_tex) { _thumbnail = p_tex; }
+	Ref<Texture2D> get_thumbnail() const { return _thumbnail; }
+	TypedArray<Transform3D> get_shape_transforms() const;
 	void set_height_offset(const real_t p_offset);
 	real_t get_height_offset() const { return _height_offset; }
 	void set_density(const real_t p_density);

--- a/src/terrain_3d_mesh_asset.h
+++ b/src/terrain_3d_mesh_asset.h
@@ -99,8 +99,8 @@ public:
 	bool is_highlighted() const override { return _highlighted; }
 	Ref<Material> get_highlight_material() const { return _highlighted ? _highlight_mat : Ref<Material>(); }
 	Color get_highlight_color() const override;
+	void set_thumbnail(Ref<Texture2D> p_tex) { _thumbnail = p_tex; }
 	Ref<Texture2D> get_thumbnail() const override { return _thumbnail; }
-
 	void set_enabled(const bool p_enabled);
 	bool is_enabled() const { return _enabled; }
 
@@ -117,8 +117,6 @@ public:
 	Ref<Mesh> get_mesh(const int p_lod = 0) const;
 	TypedArray<Shape3D> get_shapes() const;
 	int get_shape_count() const;
-	void set_thumbnail(Ref<Texture2D> p_tex) { _thumbnail = p_tex; }
-	Ref<Texture2D> get_thumbnail() const { return _thumbnail; }
 	TypedArray<Transform3D> get_shape_transforms() const;
 	void set_height_offset(const real_t p_offset);
 	real_t get_height_offset() const { return _height_offset; }

--- a/src/terrain_3d_mesh_asset.h
+++ b/src/terrain_3d_mesh_asset.h
@@ -6,6 +6,7 @@
 #include <godot_cpp/classes/array_mesh.hpp>
 #include <godot_cpp/classes/material.hpp>
 #include <godot_cpp/classes/packed_scene.hpp>
+#include <godot_cpp/classes/physics_material.hpp>
 #include <godot_cpp/classes/resource.hpp>
 #include <godot_cpp/classes/shape3d.hpp>
 #include <godot_cpp/classes/texture2d.hpp>
@@ -69,6 +70,12 @@ private:
 	PackedFloat32Array _lod_ranges;
 	real_t _fade_margin = 0.f;
 
+	// Instance collision settings
+	bool _instance_collision_enabled = true;
+	uint32_t _instance_collision_layers = 1;
+	uint32_t _instance_collision_mask = 1;
+	Ref<PhysicsMaterial> _instance_physics_material;
+
 	// Working data
 	Ref<Material> _highlight_mat;
 	TypedArray<Mesh> _meshes;
@@ -131,6 +138,16 @@ public:
 	Ref<Material> get_material_override() const { return _material_override; }
 	void set_material_overlay(const Ref<Material> &p_material);
 	Ref<Material> get_material_overlay() const { return _material_overlay; }
+
+	// Instance collision settings
+	void set_instance_collision_enabled(const bool p_enabled);
+	bool is_instance_collision_enabled() const { return _instance_collision_enabled; }
+	void set_instance_collision_layers(const uint32_t p_layers);
+	uint32_t get_instance_collision_layers() const { return _instance_collision_layers; }
+	void set_instance_collision_mask(const uint32_t p_mask);
+	uint32_t get_instance_collision_mask() const { return _instance_collision_mask; }
+	void set_instance_physics_material(const Ref<PhysicsMaterial> &p_mat);
+	Ref<PhysicsMaterial> get_instance_physics_material() const { return _instance_physics_material; }
 
 	void set_generated_faces(const int p_count);
 	int get_generated_faces() const { return _generated_faces; }

--- a/src/terrain_3d_util.cpp
+++ b/src/terrain_3d_util.cpp
@@ -519,7 +519,7 @@ void Terrain3DUtil::benchmark(Terrain3D *p_terrain) {
 	}
 }
 
-Vector2i Terrain3DUtil::get_cell(const Vector3 &p_global_position, const int &p_region_size, const real_t &p_vertex_spacing, const int &p_cell_size) {
+Vector2i Terrain3DUtil::get_cell(const Vector3 &p_global_position, const int p_region_size, const real_t p_vertex_spacing, const int p_cell_size) {
 	Vector2i cell;
 	cell.x = UtilityFunctions::posmod(UtilityFunctions::floori(p_global_position.x / p_vertex_spacing), p_region_size) / p_cell_size;
 	cell.y = UtilityFunctions::posmod(UtilityFunctions::floori(p_global_position.z / p_vertex_spacing), p_region_size) / p_cell_size;

--- a/src/terrain_3d_util.cpp
+++ b/src/terrain_3d_util.cpp
@@ -519,6 +519,13 @@ void Terrain3DUtil::benchmark(Terrain3D *p_terrain) {
 	}
 }
 
+Vector2i Terrain3DUtil::get_cell(const Vector3 &p_global_position, const int &p_region_size, const real_t &p_vertex_spacing, const int &p_cell_size) {
+	Vector2i cell;
+	cell.x = UtilityFunctions::posmod(UtilityFunctions::floori(p_global_position.x / p_vertex_spacing), p_region_size) / p_cell_size;
+	cell.y = UtilityFunctions::posmod(UtilityFunctions::floori(p_global_position.z / p_vertex_spacing), p_region_size) / p_cell_size;
+	return cell;
+}
+
 ///////////////////////////
 // Protected Functions
 ///////////////////////////

--- a/src/terrain_3d_util.h
+++ b/src/terrain_3d_util.h
@@ -57,7 +57,7 @@ public:
 	static Ref<Image> luminance_to_height(const Ref<Image> &p_src_rgb);
 	static void benchmark(Terrain3D *p_terrain);
 
-	static Vector2i get_cell(const Vector3 &p_global_position, const int &p_region_size, const real_t &p_vertex_spacing, const int &p_cell_size);
+	static Vector2i get_cell(const Vector3 &p_global_position, const int p_region_size, const real_t p_vertex_spacing, const int p_cell_size);
 
 protected:
 	static void _bind_methods();

--- a/src/terrain_3d_util.h
+++ b/src/terrain_3d_util.h
@@ -57,6 +57,8 @@ public:
 	static Ref<Image> luminance_to_height(const Ref<Image> &p_src_rgb);
 	static void benchmark(Terrain3D *p_terrain);
 
+	static Vector2i get_cell(const Vector3 &p_global_position, const int &p_region_size, const real_t &p_vertex_spacing, const int &p_cell_size);
+
 protected:
 	static void _bind_methods();
 };


### PR DESCRIPTION
This PR aims to add collision for the foliage instancer, mentioned in issue #43 

The headlines :

  - **Physics shapes exclusively handled using the PhysicsServer**
  - **Only creates and destroys edge cells**
  - **Provides visualizations via the Rendering Server**
  - **Works for scene files with multiple shapes**
  - **Supports Game and Editor modes**
  - **Allows teleporting**

Some further details:

It will read any CollisionShape3Ds found in the Terrain3DMeshAsset scene file and store their Shape3Ds and transforms.

When terrain collision is rebuilt in Terrain3DCollision it also spawns shapes for the instances using data read from the data/region/instances dictionary and the Shape3D and transforms stored in the MA. 

In Dynamic mode:

1. Build an array of cell positions to build, skipping cells which already exist.

2. Build a dictionary of instances in said cells.

3. Decompose cells outside of the collision radius and store the instances within for recycling.

4. Compare the list of recyclable  instances against the list of instances to build. Decompose unneeded instances to their component shapes, store for recycling.

5. Generate the new instances, preferably:

    A. Recycle an old instance, simply transforming the shapes. Or...
    B. Reuse spare shapes, transform and update base meshes. Or...
    C. Generate brand new shapes.

6. Destroy and remaining shapes and update an internal RID/shape_id map.

Full mode for instance collision was shelved. 

For both Editor and Game modes, the PhysicsServer3D is used. The main reason for this was I kept hitting the 2^18 object limit when stress testing Full mode.

For Editor modes, visualizations are provided via the RenderingServer. 

To test it, add a new Terrain3DMeshAsset and use RockA.tscn as the scene file. Paint some rocks using the foliage instancer and run the scene.

Future plans:

1. Have a body per MA - allow individual layers and other physics settings
2. Manual mode - allow the user to enable and destroy instance collision by cell through the API
3. Roll up of the shape transforms - currently it takes the local transform only
4. Enable update by MA per cell, to improve performance in the editor (if needed)
5. Use hash maps instead of Dictionaries