### PR TITLE
Reconfigure free_editor_textures

### DIFF
--- a/doc/api/class_terrain3d.rst
+++ b/doc/api/class_terrain3d.rst
@@ -530,7 +530,7 @@ The verbosity of debug messages printed to the console. Errors and warnings are 
 - |void| **set_free_editor_textures**\ (\ value\: ``bool``\ )
 - ``bool`` **get_free_editor_textures**\ (\ )
 
-Frees ground textures used for editing at the start of the game. These textures are used to generate the TextureArrays, so if you don't change any :ref:`Terrain3DTextureAsset<class_Terrain3DTextureAsset>` settings in game, this can be enabled. Calls :ref:`Terrain3DAssets.clear_textures()<class_Terrain3DAssets_method_clear_textures>`.
+Frees ground textures used for editing in _ready(). These textures are used to generate the TextureArrays, so if you don't change any :ref:`Terrain3DTextureAsset<class_Terrain3DTextureAsset>` settings in game, this can be enabled. Also reloads the texture asset list in _enter_tree() in case you load scenes via code and need the textures again. Calls :ref:`Terrain3DAssets.clear_textures()<class_Terrain3DAssets_method_clear_textures>`.
 
 .. rst-class:: classref-item-separator
 

--- a/doc/doc_classes/Terrain3D.xml
+++ b/doc/doc_classes/Terrain3D.xml
@@ -146,7 +146,7 @@
 			The verbosity of debug messages printed to the console. Errors and warnings are always printed. This can also be set via command line using [code skip-lint]--terrain3d-debug=LEVEL[/code] where [code skip-lint]LEVEL[/code] is one of [code skip-lint]ERROR, INFO, DEBUG, EXTREME[/code]. The last includes continuously recurring messages like position updates for the mesh as the camera moves around.
 		</member>
 		<member name="free_editor_textures" type="bool" setter="set_free_editor_textures" getter="get_free_editor_textures" default="true">
-			Frees ground textures used for editing at the start of the game. These textures are used to generate the TextureArrays, so if you don't change any [Terrain3DTextureAsset] settings in game, this can be enabled. Calls [method Terrain3DAssets.clear_textures].
+			Frees ground textures used for editing in _ready(). These textures are used to generate the TextureArrays, so if you don't change any [Terrain3DTextureAsset] settings in game, this can be enabled. Also reloads the texture asset list in _enter_tree() in case you load scenes via code and need the textures again. Calls [method Terrain3DAssets.clear_textures].
 		</member>
 		<member name="gi_mode" type="int" setter="set_gi_mode" getter="get_gi_mode" enum="GeometryInstance3D.GIMode" default="1">
 			Tells the renderer which global illumination mode to use for Terrain3D. This sets [code skip-lint]GeometryInstance3D.gi_mode[/code] in the engine.

--- a/doc/docs/tips.md
+++ b/doc/docs/tips.md
@@ -55,6 +55,7 @@ To use it:
 * `WorldBackground` as `Noise` exposes additional shader settings, such as octaves and LOD. You can adjust these settings for performance. However this world generating noise is expensive. Consider not using it at all in a commercial game, and instead obscure your background with meshes, or use an HDR skybox with mountains built in.
 * Reduce the size of the mesh and levels of detail by reducing `Mesh/Size` (`mesh_size`) or `Mesh/Lods` (`mesh_lods`) in the `Terrain3D` node.
 * Don't use `Renderer/Cull Margin`. It should only be needed if using the noise background. Otherwise the AABB should be correctly calculated via editing, so there is no need to expand the cull margin. Keeping it enabled can cost more processing time.
+* Experiment with `Renderer/free_editor_textures`, which is enabled by default. It saves VRAM by removing the initial textures used to generate the texture arrays.
 
 
 ## Shaders

--- a/src/terrain_3d.cpp
+++ b/src/terrain_3d.cpp
@@ -851,6 +851,11 @@ void Terrain3D::_notification(const int p_what) {
 			set_notify_transform(true);
 			set_meta("_edit_lock_", true);
 			_setup_mouse_picking();
+			if (_free_editor_textures && !IS_EDITOR && _assets.is_valid()) {
+				LOG(INFO, "free_editor_textures enabled, reloading Assets path: ", _assets->get_path());
+				_assets = ResourceLoader::get_singleton()->load(_assets->get_path(), "", ResourceLoader::CACHE_MODE_IGNORE);
+			}
+
 			_initialize(); // Rebuild anything freed: meshes, collision, instancer
 			set_physics_process(true);
 			break;
@@ -860,6 +865,7 @@ void Terrain3D::_notification(const int p_what) {
 			// Node is ready
 			LOG(INFO, "NOTIFICATION_READY");
 			if (_free_editor_textures && !IS_EDITOR && _assets.is_valid()) {
+				LOG(INFO, "free_editor_textures enabled, clearing texture assets");
 				_assets->clear_textures();
 			}
 			break;


### PR DESCRIPTION
* Disables `free_editor_textures` by default
* If enabled it:
  * Force reloads the asset list on `_enter_tree()` (Only the list; textures are loaded only if not already loaded)
  * Generates the texture array on `_enter_tree()`
  * Unreferences the editor textures on `_ready()` (Godot unloads textures if not used elsewhere)

The demo has two demonstrations. 
1. If `free_editor_texture` is disabled, it prints the vram used at start, then manually clears the editor texture list, then prints the difference. This is the standard use case for beginning devs with one terrain in one scene.
2. If `free_editor_textures` is enabled, it removes Terrain3D, then a second later, loads and adds it to the scene as a scene loader would. Previously this would cause textures to be missing since they are cleared on the first _ready.

Using Godot's performance metrics, both of these tests result in a 5.3mb savings (4 textures @ 1.33mb).
Using Windows Task manager, the VRAM usage may appear higher or unchanged. I assume this is because of OS allocations Godot is managing. I am debating whether to leave this option enabled or disabled by default. Thoughts?

Would like a review and testing before I remove the debugging stuff.