### PR TITLE
Fix wetness

### DIFF
--- a/project/addons/terrain_3d/extras/shaders/lightweight.gdshader
+++ b/project/addons/terrain_3d/extras/shaders/lightweight.gdshader
@@ -349,8 +349,8 @@ void fragment() {
 		macrov = mix(vec3(1.0), macrov, clamp(v_normal.y + macro_variation_slope, 0., 1.));
 	}
 
-	// Wetness/roughness modifier, converting 0 - 1 range to -1 to 1 range
-	float roughness = fma(color_map.a - 0.5, 2.0, normal_rough.a);
+	// Wetness/roughness modifier, converting 0 - 1 range to -1 to 1 range, clamped to Godot roughness values 
+	float roughness = clamp(fma(color_map.a - 0.5, 2.0, normal_rough.a), 0., 1.);
 
 	// Apply PBR
 	ALBEDO = albedo_height.rgb * color_map.rgb * macrov;

--- a/project/addons/terrain_3d/src/tool_settings.gd
+++ b/project/addons/terrain_3d/src/tool_settings.gd
@@ -346,12 +346,13 @@ func _on_pick(p_type: Terrain3DEditor.Tool) -> void:
 func _on_picked(p_type: Terrain3DEditor.Tool, p_color: Color, p_global_position: Vector3) -> void:
 	match p_type:
 		Terrain3DEditor.HEIGHT:
-			settings["height"].value = p_color.r if not is_nan(p_color.r) else 0
+			settings["height"].value = p_color.r if not is_nan(p_color.r) else 0.
 		Terrain3DEditor.COLOR:
 			settings["color"].color = p_color if not is_nan(p_color.r) else Color.WHITE
 		Terrain3DEditor.ROUGHNESS:
-			# 200... -.5 converts 0,1 to -100,100
-			settings["roughness"].value = round(200 * (p_color.a - 0.5)) if not is_nan(p_color.r) else 0.499
+			# This converts 0,1 to -100,100
+			# It also quantizes explicitly so picked values matches painted values
+			settings["roughness"].value = round(200. * float(int(p_color.a * 255.) / 255. - .5)) if not is_nan(p_color.r) else 0.
 		Terrain3DEditor.ANGLE:
 			settings["angle"].value = p_color.r
 		Terrain3DEditor.SCALE:

--- a/src/shaders/main.glsl
+++ b/src/shaders/main.glsl
@@ -508,8 +508,8 @@ void fragment() {
 		macrov = mix(vec3(1.0), macrov, clamp(w_normal.y + macro_variation_slope, 0., 1.));
 	}
 	
-	// Wetness/roughness modifier, converting 0 - 1 range to -1 to 1 range
-	float roughness = fma(color_map.a - 0.5, 2.0, mat.normal_rough.a);
+	// Wetness/roughness modifier, converting 0 - 1 range to -1 to 1 range, clamped to Godot roughness values 
+	float roughness = clamp(fma(color_map.a - 0.5, 2.0, mat.normal_rough.a), 0., 1.);
 	
 	// Apply PBR
 	ALBEDO = mat.albedo_height.rgb * color_map.rgb * macrov;

--- a/src/terrain_3d_data.cpp
+++ b/src/terrain_3d_data.cpp
@@ -1170,7 +1170,7 @@ void Terrain3DData::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("get_control_maps"), &Terrain3DData::get_control_maps);
 	ClassDB::bind_method(D_METHOD("get_color_maps"), &Terrain3DData::get_color_maps);
 	ClassDB::bind_method(D_METHOD("get_maps", "map_type"), &Terrain3DData::get_maps);
-	ClassDB::bind_method(D_METHOD("update_maps", "map_type", "all_maps ", "generate_mipmaps"), &Terrain3DData::update_maps, DEFVAL(TYPE_MAX), DEFVAL(true), DEFVAL(false));
+	ClassDB::bind_method(D_METHOD("update_maps", "map_type", "all_regions", "generate_mipmaps"), &Terrain3DData::update_maps, DEFVAL(TYPE_MAX), DEFVAL(true), DEFVAL(false));
 	ClassDB::bind_method(D_METHOD("get_height_maps_rid"), &Terrain3DData::get_height_maps_rid);
 	ClassDB::bind_method(D_METHOD("get_control_maps_rid"), &Terrain3DData::get_control_maps_rid);
 	ClassDB::bind_method(D_METHOD("get_color_maps_rid"), &Terrain3DData::get_color_maps_rid);

--- a/src/terrain_3d_editor.cpp
+++ b/src/terrain_3d_editor.cpp
@@ -509,9 +509,12 @@ void Terrain3DEditor::_operate_map(const Vector3 &p_global_position, const real_
 						 * We round the final amount in tool_settings.gd:_on_picked().
 						 */
 						if (_operation == ADD) {
-							dest.a = Math::lerp(real_t(src.a), real_t(.5f + .5f * roughness), brush_alpha * strength);
+							real_t target = .5f + .5f * roughness;
+							dest.a = Math::lerp(real_t(src.a), target, brush_alpha * strength);
+							dest.a = float(int(dest.a * 255.f)) / 255.f; // Quantize explicitly so picked values match painted values
 						} else {
 							dest.a = Math::lerp(real_t(src.a), real_t(.5f), brush_alpha * strength);
+							dest.a = float(int(dest.a * 255.f)) / 255.f;
 						}
 						break;
 					default:


### PR DESCRIPTION
* Clamps roughness in the shader. Previously range was about -1 to 3. Sub zero broke the reflections in wetness.
* Explicitly quantizes roughness so that what is painted and what is picked are the same.
Grok picked this one up.

Still planning on #303 in the future, maybe in 1.1.

---
Grok's Explanation of Quantization Code
Both code snippets address the issue of 8-bit quantization when storing dest.a (alpha channel, 0.0 to 1.0) in terrain_3d_editor.cpp and retrieving it in tool_settings.gd. They ensure the stored value aligns with the 8-bit precision (0 to 255) used by Godot, minimizing precision errors.

1. C++: float(int(dest.a * 255.0)) / 255.0; // Quantize explicitly
* Purpose: Forces dest.a (0.0 to 1.0) to the nearest value representable in 8-bit precision (multiples of 1/255).
* How it works:
  * dest.a * 255.0: Scales dest.a (0.0 to 1.0) to 0 to 255.
  * int(...): Truncates to the nearest integer (e.g., 127.6 → 127).
  * float(int(...)) / 255.0: Converts back to 0.0 to 1.0 (e.g., 127 → 127/255 ≈ 0.498039).
  * This mimics Godot’s 8-bit storage, ensuring dest.a matches what’s actually stored.
* Why: Without this, floating-point dest.a values (e.g., 0.5) may not align with 8-bit steps, causing slight offsets when read back (e.g., 0.5 → 0.498).

2. GDScript: float(int(p_color.a * 255.0)) / 255.0 - 0.5 in settings["roughness"].value = round(200 * (...))
* Purpose: Converts the stored p_color.a (0.0 to 1.0) back to the UI roughness range (-100 to 100) while accounting for 8-bit quantization.
* How it works:
  * p_color.a * 255.0: Scales p_color.a to 0 to 255.
  * int(...): Truncates to the nearest integer (mimics 8-bit storage).
  * float(int(...)) / 255.0: Converts back to 0.0 to 1.0 (e.g., 127 → 0.498039).
  * -0.5: Shifts to -0.5 to 0.5.
  * 200 * (...): Scales to -100 to 100 for the UI slider.
  * round(...): Ensures the UI value is an integer, avoiding fractional UI values.
* Why: Ensures the UI slider reflects the quantized value stored in p_color.a, preventing discrepancies (e.g., 0.498 → -0.4 instead of 0).
