### PR TITLE
Fix #705 - free_editor_textures doesn't work w/ local assets

### DIFF
--- a/src/terrain_3d.cpp
+++ b/src/terrain_3d.cpp
@@ -852,11 +852,10 @@ void Terrain3D::_notification(const int p_what) {
 			set_notify_transform(true);
 			set_meta("_edit_lock_", true);
 			_setup_mouse_picking();
-			if (_free_editor_textures && !IS_EDITOR && _assets.is_valid()) {
+			if (_free_editor_textures && !IS_EDITOR && _assets.is_valid() && !_assets->get_path().contains("Terrain3DAssets")) {
 				LOG(INFO, "free_editor_textures enabled, reloading Assets path: ", _assets->get_path());
 				_assets = ResourceLoader::get_singleton()->load(_assets->get_path(), "", ResourceLoader::CACHE_MODE_IGNORE);
 			}
-
 			_initialize(); // Rebuild anything freed: meshes, collision, instancer
 			set_physics_process(true);
 			break;
@@ -866,8 +865,12 @@ void Terrain3D::_notification(const int p_what) {
 			// Node is ready
 			LOG(INFO, "NOTIFICATION_READY");
 			if (_free_editor_textures && !IS_EDITOR && _assets.is_valid()) {
-				LOG(INFO, "free_editor_textures enabled, clearing texture assets");
-				_assets->clear_textures();
+				if (_assets->get_path().contains("Terrain3DAssets")) {
+					LOG(WARN, "free_editor_textures requires `Assets` be saved to a file. Do so, or disable the former to turn off this warning");
+				} else {
+					LOG(INFO, "free_editor_textures enabled, clearing texture assets");
+					_assets->clear_textures();
+				}
 			}
 			break;
 		}


### PR DESCRIPTION
* Fixes error by skipipng free_editor_textures with a local Assets.
* Warn to change one if both are set


Fixes #705