### PR TITLE
Fix instancer data loss, crashes

### DIFF
--- a/project/addons/terrain_3d/src/asset_dock.gd
+++ b/project/addons/terrain_3d/src/asset_dock.gd
@@ -530,7 +530,7 @@ class ListContainer extends Container:
 		# Select Paint tool if clicking a texture
 		if type == Terrain3DAssets.TYPE_TEXTURE and \
 				not plugin.editor.get_tool() in [ Terrain3DEditor.TEXTURE, Terrain3DEditor.COLOR, Terrain3DEditor.ROUGHNESS ]:
-			var paint_btn: Button = plugin.ui.toolbar.get_node_or_null("PaintBaseTexture")
+			var paint_btn: Button = plugin.ui.toolbar.get_node_or_null("PaintTexture")
 			if paint_btn:
 				paint_btn.set_pressed(true)
 				plugin.ui._on_tool_changed(Terrain3DEditor.TEXTURE, Terrain3DEditor.REPLACE)

--- a/project/addons/terrain_3d/src/toolbar.gd
+++ b/project/addons/terrain_3d/src/toolbar.gd
@@ -117,7 +117,7 @@ func add_tool_button(p_params: Dictionary) -> void:
 	if p_params.has("sub_text"):
 		button2 = Button.new()
 		name_str = p_params.get("sub_text", "blank").get_slice('(', 0).to_pascal_case()
-		button.set_name(name_str)
+		button2.set_name(name_str)
 		button2.set_meta("Tool", p_params.get("tool", 0))
 		button2.set_meta("Operation", p_params.get("sub_op", 0))
 		button2.set_meta("ID", button.get_meta("ID"))

--- a/src/terrain_3d_instancer.cpp
+++ b/src/terrain_3d_instancer.cpp
@@ -328,7 +328,7 @@ void Terrain3DInstancer::_backup_regionl(const Vector2i &p_region_loc) {
 }
 
 void Terrain3DInstancer::_backup_region(const Ref<Terrain3DRegion> &p_region) {
-	if (_terrain && _terrain->get_editor()) {
+	if (_terrain && _terrain->get_editor() && _terrain->get_editor()->is_operating()) {
 		_terrain->get_editor()->backup_region(p_region);
 	} else {
 		p_region->set_modified(true);


### PR DESCRIPTION
* Fixes asset dock selecting Paint or Instancer tools
* When clearing instances in bulk, by mesh type or region, regions were not being marked as modified so weren't saving.

The combination of this PR and #709 (clearing thumbnail creation RIDs) seems to have fixed the thumbnail related crash, but it needs more testing.

@CavemanIke, please test this PR and see if you can identify any more crashes from the instancer or thumbnail creation.

Fixes #701 