### PR TITLE
Shader performance pass

### DIFF
--- a/doc/docs/shader_design.md
+++ b/doc/docs/shader_design.md
@@ -84,7 +84,7 @@ Generating normals in the shader works fine, and modern GPUs can easily handle t
 
 The control maps are queried for each of the 4 adjacent grid points (aka vertices and indices) and stored in `control[0]`-`control[3]`.
 
-The control map bits, as defined in [Controlmap Format](controlmap_format.md), are parsed into an array of control_data structs, which include the decoded `texture_id`, `texture_weight`, `blend`, `scale`, and `angle` values.
+The control map bits, are decoded when needed, as defined in [Controlmap Format](controlmap_format.md).
 
 If the Autoshader is enabled, the control_data for each of the 4 grid points is overwritten with the autoshader ids and blend value calculated from the terrain normal and height.
 

--- a/project/addons/terrain_3d/extras/shaders/lightweight.gdshader
+++ b/project/addons/terrain_3d/extras/shaders/lightweight.gdshader
@@ -75,16 +75,6 @@ uniform vec2 noise1_offset = vec2(0.5);
 uniform float noise2_scale : hint_range(0.001, 1.) = 0.076; // Used for macro variation 2. Scaled up 10x
 
 // Varyings & Types
-
-// This struct contains data that requires accessing multiple times across potential branches
-// or iterations, and/or can change after the intial decode, such as via the autoshader.
-struct control_data {
-	ivec2 texture_id;
-	float blend;
-};
-// control_data constructor
-#define CONTROL_DATA(control) control_data(ivec2(DECODE_BASE(control), DECODE_OVER(control)), DECODE_BLEND(control))
-
 varying vec3 v_normal;
 varying vec3 v_vertex;
 varying mat3 TBN;
@@ -200,16 +190,6 @@ mat2 rotate_plane(float angle) {
 	return mat2(vec2(c, s), vec2(-s, c));
 }
 
-// Computes total accumulated weight for a given texture_id across all 4 indices.
-float accumulate_weight(int texture_id, control_data data[4], vec4 weights) {
-	float w = 0.0;
-	for (int i = 0; i < 4; i++) {
-		w += weights[i] * (1.0 - data[i].blend) * float(data[i].texture_id[0] == texture_id);
-		w += weights[i] * data[i].blend * float(data[i].texture_id[1] == texture_id);
-	}
-	return w;
-}
-
 void fragment() {
 	// Recover UVs
 	vec2 uv = UV;
@@ -265,34 +245,53 @@ void fragment() {
 		float total_weight = 0.;
 		float sharpness = fma(56., blend_sharpness, 8.);
 
-		// Get index control map data
-		// 4 lookups
-		uint control[4] = {
-			floatBitsToUint(texelFetch(_control_maps, index[0], 0).r),
-			floatBitsToUint(texelFetch(_control_maps, index[1], 0).r),
-			floatBitsToUint(texelFetch(_control_maps, index[2], 0).r),
-			floatBitsToUint(texelFetch(_control_maps, index[3], 0).r)
-		};
+		// Get index control data
+		// 1 - 4 lookups
+		uvec4 control = floatBitsToUint(vec4(
+			texelFetch(_control_maps, index[0], 0).r,
+			texelFetch(_control_maps, index[1], 0).r,
+			texelFetch(_control_maps, index[2], 0).r,
+			texelFetch(_control_maps, index[3], 0).r));
 
-		// Parse control data
-		control_data data[4] = {
-			CONTROL_DATA(control[0]),
-			CONTROL_DATA(control[1]),
-			CONTROL_DATA(control[2]),
-			CONTROL_DATA(control[3])
-		};
-
-		// Enable Autoshader if outside regions or painted in regions, otherwise manual painted
-		float auto_blend = clamp((auto_slope * 2. * (v_normal.y - 1.) + 1.)
-				- auto_height_reduction * .01 * v_vertex.y // Reduce as vertices get higher
-				, 0., 1.);
-		for (int i = 0; i < 4; i++) {
-			if (index[i].z < 0 || DECODE_AUTO(control[i])) {
-				data[i].texture_id[0] = auto_base_texture;
-				data[i].texture_id[1] = auto_overlay_texture;
-				data[i].blend = auto_blend;
-			}
+		{
+			// Auto blend calculation
+			float auto_blend = clamp(fma(auto_slope * 2.0, (v_normal.y - 1.0), 1.0)
+				- auto_height_reduction * 0.01 * v_vertex.y, 0.0, 1.0);
+			// Enable Autoshader if outside regions or painted in regions, otherwise manual painted
+			uvec4 is_auto = (control & uvec4(0x1u)) | uvec4(uint(region_uv.z < 0.0));
+			uint u_auto = 
+				((uint(auto_base_texture) & 0x1Fu) << 27u) |
+				((uint(auto_overlay_texture) & 0x1Fu) << 22u) |
+				((uint(fma(auto_blend, 255.0 , 0.5)) & 0xFFu) << 14u);
+			control = control * (1u - is_auto) + u_auto * is_auto;
 		}
+
+
+		// Texture weights
+		// Vectorised Deocode of all texture IDs, then swizzle to per index mapping.
+		ivec4 t_id[2] = {ivec4(control >> uvec4(27u) & uvec4(0x1Fu)),
+			ivec4(control >> uvec4(22u) & uvec4(0x1Fu))};
+		ivec2 texture_ids[4] = ivec2[4](
+			ivec2(t_id[0].x, t_id[1].x),
+			ivec2(t_id[0].y, t_id[1].y),
+			ivec2(t_id[0].z, t_id[1].z),
+			ivec2(t_id[0].w, t_id[1].w));
+
+		// interpolated weights.
+		vec4 weights_id_1 = vec4(control >> uvec4(14u) & uvec4(0xFFu)) * DIV_255 * weights;
+		vec4 weights_id_0 = weights - weights_id_1;
+		vec2 t_weights[4] = {vec2(0), vec2(0), vec2(0), vec2(0)};
+		for (int i = 0; i < 4; i++) {
+				vec2 w_0 = vec2(weights_id_0[i]);
+				vec2 w_1 = vec2(weights_id_1[i]);
+				ivec2 id_0 = texture_ids[i].xx;
+				ivec2 id_1 = texture_ids[i].yy;
+				t_weights[0] += fma(w_0, vec2(equal(texture_ids[0], id_0)), w_1 * vec2(equal(texture_ids[0], id_1)));
+				t_weights[1] += fma(w_0, vec2(equal(texture_ids[1], id_0)), w_1 * vec2(equal(texture_ids[1], id_1)));
+				t_weights[2] += fma(w_0, vec2(equal(texture_ids[2], id_0)), w_1 * vec2(equal(texture_ids[2], id_1)));
+				t_weights[3] += fma(w_0, vec2(equal(texture_ids[3], id_0)), w_1 * vec2(equal(texture_ids[3], id_1)));
+		}
+
 
 		// Process control data to determine each texture ID present, so that only
 		// a single sample will be needed later, as all id are contiguous when features
@@ -305,17 +304,17 @@ void fragment() {
 		uv *= _vertex_spacing;
 		for (int i = 0; i < 4; i++) {
 			for (int t = 0; t < 2; t++) {
-				int id = data[i].texture_id[t];
+				int id = texture_ids[i][t];
 				uint mask = 1u << uint(id);
 				if ((id_read & mask) == 0u) {
 					// Set this id bit
 					id_read |= mask;
-					float id_w = accumulate_weight(id, data, weights);
+					float id_w = t_weights[i][t];
 					float id_scale = _texture_uv_scale_array[id] * 0.5;
-					vec2 id_uv = uv * id_scale;
+					vec2 id_uv = fma(uv, vec2(id_scale), vec2(0.5));
 					vec4 i_dd = base_dd * id_scale;
 					vec4 alb = textureGrad(_texture_array_albedo, vec3(id_uv, float(id)), i_dd.xy, i_dd.zw);
-					float world_normal = clamp((TBN * normalize(nrm.xyz)).y, 0., 1.);
+					float world_normal = clamp(fma(TBN[0], vec3(nrm.x), fma(TBN[1], vec3(nrm.z), v_normal * vec3(nrm.y))).y, 0., 1.);
 					nrm = textureGrad(_texture_array_normal, vec3(id_uv, float(id)), i_dd.xy, i_dd.zw);
 					alb.rgb *= _texture_color_array[id].rgb;
 					nrm.a = clamp(nrm.a + _texture_roughness_mod_array[id], 0., 1.);
@@ -361,9 +360,8 @@ void fragment() {
 	NORMAL_MAP_DEPTH = normal_map_depth;
 
 	// Higher and/or facing up, less occluded.
-	// Higher and/or facing up, less occluded.
 	float ao = (1. - (albedo_height.a * log(2.1 - ao_strength))) * (1. - normal_rough.y);
 	AO = clamp(1. - ao * ao_strength, albedo_height.a, 1.0);
-	AO_LIGHT_AFFECT = (1.0 - albedo_height.a) * normal_rough.y;
+	AO_LIGHT_AFFECT = (1.0 - albedo_height.a) * clamp(normal_rough.y, 0., 1.);
 
 }

--- a/project/demo/Demo.tscn
+++ b/project/demo/Demo.tscn
@@ -34,11 +34,11 @@ noise = SubResource("FastNoiseLite_d8lcj")
 _shader_parameters = {
 "_mouse_layer": 2147483648,
 "auto_base_texture": 0,
-"auto_height_reduction": 0.0,
+"auto_height_reduction": 0.05,
 "auto_overlay_texture": 1,
-"auto_slope": 1.0,
+"auto_slope": 0.45,
 "bias_distance": 512.0,
-"blend_sharpness": 0.87,
+"blend_sharpness": 0.5,
 "depth_blur": 0.0,
 "dual_scale_far": 170.0,
 "dual_scale_near": 100.0,
@@ -46,7 +46,7 @@ _shader_parameters = {
 "dual_scale_texture": 0,
 "enable_macro_variation": true,
 "enable_projection": true,
-"height_blending": true,
+&"flat_terrain_normals": false,
 "macro_variation1": Color(0.855, 0.8625, 0.9, 1),
 "macro_variation2": Color(0.9, 0.885, 0.81, 1),
 "macro_variation_slope": 0.333,
@@ -55,10 +55,8 @@ _shader_parameters = {
 "noise1_offset": Vector2(0.5, 0.5),
 "noise1_scale": 0.04,
 "noise2_scale": 0.076,
-"noise3_scale": 0.225,
 "noise_texture": SubResource("NoiseTexture2D_bov7h"),
-"projection_angular_division": 1.0,
-"projection_threshold": 0.8,
+"projection_threshold": 0.87,
 "tri_scale_reduction": 0.3,
 "world_noise_fragment_normals": false,
 "world_noise_height": 34.0,
@@ -67,8 +65,7 @@ _shader_parameters = {
 "world_noise_min_octaves": 2,
 "world_noise_offset": Vector3(2.17, -1.225, 1.9),
 "world_noise_region_blend": 0.33,
-"world_noise_scale": 9.85,
-"world_space_normal_blend": true
+"world_noise_scale": 9.85
 }
 world_background = 2
 auto_shader = true

--- a/src/shaders/dual_scaling.glsl
+++ b/src/shaders/dual_scaling.glsl
@@ -17,43 +17,58 @@ uniform float dual_scale_near : hint_range(0,1000) = 100.0;
 			i_pos *= tri_scale_reduction;
 		}
 
-		// dual scaling
-		float far_factor = clamp(smoothstep(dual_scale_near, dual_scale_far, length(v_vertex - _camera_pos)), 0.0, 1.0);
-		vec4 far_alb = vec4(0.);
-		vec4 far_nrm = vec4(0.);
-		if (far_factor > 0. && (data.texture_id[0] == dual_scale_texture || data.texture_id[1] == dual_scale_texture)) {
-			float far_scale = _texture_uv_scale_array[dual_scale_texture] * dual_scale_reduction;
-			vec2 far_uv = i_uv * far_scale;
-			vec4 far_dd = i_dd * far_scale;
+	// dual scaling
+	float far_factor = clamp(smoothstep(dual_scale_near, dual_scale_far, length(v_vertex - _camera_pos)), 0.0, 1.0);
+	vec4 far_alb = vec4(0.);
+	vec4 far_nrm = vec4(0.);
+	if (far_factor > 0. && any(equal(texture_id, ivec2(dual_scale_texture)))) {
+		float far_scale = _texture_uv_scale_array[dual_scale_texture] * dual_scale_reduction;
+		vec4 far_dd = i_dd * far_scale;
 
-			// Detiling and Control map rotation
-			vec2 uv_center = floor(i_pos * far_scale + 0.5);
-			float detile = fma(random(uv_center), 2.0, -1.0) * TAU;
-			vec2 detile_shift = vec2(_texture_detile_array[dual_scale_texture].y * detile);
-			// Detile rotation matrix
-			mat2 far_align = rotate_plane(detile * _texture_detile_array[dual_scale_texture].x);
-			// Apply rotation and shift around pivot, offset to center UV over pivot.
-			far_uv = far_align * (far_uv - uv_center + detile_shift) + uv_center + 0.5;
-			// Transpose to rotate derivatives and normals counter to uv rotation, include control map rotation.
-			far_align = transpose(far_align) * c_align;
-			// Align derivatives for correct anisotropic filtering
-			far_dd.xy *= far_align;
-			far_dd.zw *= far_align;
+		// Detiling and Control map rotation
+		vec2 uv_center = floor(fma(i_pos, vec2(far_scale), vec2(0.5)));
+		vec2 far_detile = fma(random(uv_center), 2.0, -1.0) * _texture_detile_array[dual_scale_texture] * TAU;
+		vec2 far_cs_angle = vec2(cos(far_detile.x), sin(far_detile.x));
+		// Apply UV rotation and shift around pivot.
+		vec2 far_uv = rotate_vec2(fma(i_uv, vec2(far_scale), -uv_center), far_cs_angle) + uv_center + far_detile.y - 0.5;
+		// Manual transpose to rotate derivatives and normals counter to uv rotation whilst also
+		// including control map rotation. avoids extra matrix op, and sin/cos calls.
+		far_cs_angle = vec2(
+			fma(far_cs_angle.x, c_cs_angle.x, -far_cs_angle.y * c_cs_angle.y),
+			fma(far_cs_angle.y, c_cs_angle.x, far_cs_angle.x * c_cs_angle.y));
+		// Align derivatives for correct anisotropic filtering
+		far_dd.xy = rotate_vec2(far_dd.xy, far_cs_angle);
+		far_dd.zw = rotate_vec2(far_dd.zw, far_cs_angle);
 
-			far_alb = textureGrad(_texture_array_albedo, vec3(far_uv, float(dual_scale_texture)), far_dd.xy, far_dd.zw);
-			far_nrm = textureGrad(_texture_array_normal, vec3(far_uv, float(dual_scale_texture)), far_dd.xy, far_dd.zw);
-			far_alb.rgb *= _texture_color_array[dual_scale_texture].rgb;
-			far_nrm.a = clamp(far_nrm.a + _texture_roughness_mod_array[dual_scale_texture], 0., 1.);
-			// Unpack normal map rotation and blending.
-			far_nrm.xyz = fma(far_nrm.xzy, vec3(2.0), vec3(-1.0));
-			far_nrm.xz *= far_align;
+		far_alb = textureGrad(_texture_array_albedo, vec3(far_uv, float(dual_scale_texture)), far_dd.xy, far_dd.zw);
+		far_nrm = textureGrad(_texture_array_normal, vec3(far_uv, float(dual_scale_texture)), far_dd.xy, far_dd.zw);
+		far_alb.rgb *= _texture_color_array[dual_scale_texture].rgb;
+		far_nrm.a = clamp(far_nrm.a + _texture_roughness_mod_array[dual_scale_texture], 0., 1.);
+		// Unpack and rotate normal map.
+		far_nrm.xyz = fma(far_nrm.xzy, vec3(2.0), vec3(-1.0));
+		far_nrm.xz = rotate_vec2(far_nrm.xz, far_cs_angle) * p_align;
+		
+		// apply weighting when far_factor == 1.0 as the later lookup will be skipped.
+		if (far_factor == 1.0) {
+			float id_w = texture_id[0] == dual_scale_texture ? texture_weight[0] : texture_weight[1];
+			float id_weight = exp2(sharpness * log2(weight + id_w + far_alb.a)) * weight;
+			world_normal = FAST_WORLD_NORMAL(far_nrm).y;
+			mat.albedo_height = fma(far_alb, vec4(id_weight), mat.albedo_height);
+			mat.normal_rough = fma(far_nrm, vec4(id_weight), mat.normal_rough);
+			mat.normal_map_depth = fma(_texture_normal_depth_array[dual_scale_texture], id_weight, mat.normal_map_depth);
+			mat.ao_strength = fma(_texture_ao_strength_array[dual_scale_texture], id_weight, mat.ao_strength);
+			mat.total_weight += id_weight;
 		}
+	}
 
+//INSERT: DUAL_SCALING_CONDITION_0
+		&& !(far_factor == 1.0 && texture_id[0] == dual_scale_texture)
+//INSERT: DUAL_SCALING_CONDITION_1
+		&& !(far_factor == 1.0 && texture_id[1] == dual_scale_texture)
 //INSERT: DUAL_SCALING_MIX
-			// If dual scaling, apply to overlay texture
-			if (id == dual_scale_texture && far_factor > 0.) {
-				alb = mix(alb, far_alb, far_factor);
-				nrm = mix(nrm, far_nrm, far_factor);
-			}
-
+		// If dual scaling, apply to overlay texture
+		if (id == dual_scale_texture && far_factor > 0.) {
+			alb = mix(alb, far_alb, far_factor);
+			nrm = mix(nrm, far_nrm, far_factor);
+		}
 )"

--- a/src/shaders/world_noise.glsl
+++ b/src/shaders/world_noise.glsl
@@ -49,8 +49,9 @@ float hashv2(vec2 v) {
 vec3 noise2D(vec2 x) {
     vec2 f = fract(x);
     // Quintic Hermine Curve.  Similar to SmoothStep()
-    vec2 u = f*f*f*(f*(f*6.0-15.0)+10.0);
-    vec2 du = 30.0*f*f*(f*(f-2.0)+1.0);
+	vec2 f2 = f * f, f3 = f2 * f, s = f - 1.0, s2 = s * s;
+	vec2 u = f3 * fma(vec2(6.0), f2, fma(vec2(-15.0), f, vec2(10.0)));
+	vec2 du = 30.0 * f2 * s2;
 
     vec2 p = floor(x);
 
@@ -64,9 +65,9 @@ vec3 noise2D(vec2 x) {
     float k0 =   a;
     float k1 =   b - a;
     float k2 =   c - a;
-    float k3 =   a - b - c + d;
-    return vec3( k0 + k1 * u.x + k2 * u.y + k3 * u.x * u.y,
-                du * ( vec2(k1, k2) + k3 * u.yx) );
+    float k3 =   d - (b + k2);
+	return vec3(fma(k2, u.y, fma(u.x, fma(k3, u.y, k1), k0)),
+		 du * fma(vec2(k3), u.yx, vec2(k1, k2)));
 }
 
 float world_noise(vec2 p) {

--- a/src/terrain_3d_material.cpp
+++ b/src/terrain_3d_material.cpp
@@ -140,6 +140,8 @@ String Terrain3DMaterial::_generate_shader_code() const {
 	if (!_dual_scaling) {
 		excludes.push_back("DUAL_SCALING_UNIFORMS");
 		excludes.push_back("DUAL_SCALING");
+		excludes.push_back("DUAL_SCALING_CONDITION_0");
+		excludes.push_back("DUAL_SCALING_CONDITION_1");
 		excludes.push_back("DUAL_SCALING_MIX");
 	}
 	String shader = _apply_inserts(_shader_code["main"], excludes);


### PR DESCRIPTION
closes #704 

Vectorised a lot of math where possible.
Removed the control data struct.
Reduced operation count by a decent amount, including more fma() use, as well as reusing / avoiding additonal sin/cos calls, and intermediate values.

note: In compatibility, the fma() override requires all nested fma()'s to be on a single line.

Overall faster, and brings mobile back to 95-98% on my Samsung S23 Ultra.