### PR TITLE
Dynamic collision and clipmap target overrides

### DIFF
--- a/Terrain3D.vcxproj
+++ b/Terrain3D.vcxproj
@@ -141,6 +141,7 @@
   <ItemGroup>
     <ClInclude Include="src\constants.h" />
     <ClInclude Include="src\generated_texture.h" />
+    <ClInclude Include="src\target_node_3d.h" />
     <ClInclude Include="src\terrain_3d_mesher.h" />
     <ClInclude Include="src\register_types.h" />
     <ClInclude Include="src\terrain_3d.h" />

--- a/Terrain3D.vcxproj.filters
+++ b/Terrain3D.vcxproj.filters
@@ -75,6 +75,9 @@
     <ClInclude Include="src\terrain_3d_collision.h">
       <Filter>5. Headers</Filter>
     </ClInclude>
+    <ClInclude Include="src\target_node_3d.h">
+      <Filter>5. Headers</Filter>
+    </ClInclude>
   </ItemGroup>
   <ItemGroup>
     <ClCompile Include="src\terrain_3d_mesher.cpp">

--- a/src/target_node_3d.h
+++ b/src/target_node_3d.h
@@ -1,0 +1,56 @@
+// Copyright © 2025 Cory Petkovsek, Roope Palmroos, and Contributors.
+
+#ifndef TARGET_NODE3D_CLASS_H
+#define TARGET_NODE3D_CLASS_H
+
+#include <godot_cpp/classes/node3d.hpp>
+
+using namespace godot;
+
+class TargetNode3D {
+	CLASS_NAME_STATIC("Terrain3DTargetNode3D");
+
+private:
+	uint64_t _instance_id = 0;
+	Node3D *_target = nullptr;
+
+public:
+	void clear() {
+		_instance_id = 0;
+		_target = nullptr;
+	}
+
+	void set_target(Node3D *p_node_3d) {
+		if (p_node_3d) {
+			_target = p_node_3d;
+			_instance_id = p_node_3d->get_instance_id();
+		} else {
+			clear();
+		}
+	}
+
+	Node3D *ptr() const {
+		return _target;
+	}
+
+	Node3D *get_target() const {
+		return _target;
+	}
+
+	bool is_valid() const {
+		if (_target && _instance_id > 0) {
+			return _target == ObjectDB::get_instance(_instance_id);
+		}
+		return false;
+	}
+
+	bool is_null() const {
+		return !is_valid();
+	}
+
+	bool is_inside_tree() const {
+		return is_valid() && _target->is_inside_tree();
+	}
+};
+
+#endif // TARGET_NODE3D_CLASS_H

--- a/src/terrain_3d_collision.cpp
+++ b/src/terrain_3d_collision.cpp
@@ -296,7 +296,7 @@ void Terrain3DCollision::update(const bool p_rebuild) {
 
 	if (is_dynamic_mode()) {
 		// Snap descaled position to a _shape_size grid (eg. multiples of 16)
-		Vector2i snapped_pos = _snap_to_grid(_terrain->get_snapped_position() / spacing);
+		Vector2i snapped_pos = _snap_to_grid(_terrain->get_collision_target_position() / spacing);
 		LOG(EXTREME, "Updating collision at ", snapped_pos);
 
 		// Skip if location hasn't moved to next step

--- a/src/terrain_3d_mesher.h
+++ b/src/terrain_3d_mesher.h
@@ -12,8 +12,7 @@ class Terrain3D;
 class Terrain3DMesher {
 	CLASS_NAME_STATIC("Terrain3DMesher");
 
-// Constants
-public:
+public: // Constants
 	enum MeshType {
 		TILE,
 		EDGE_A,
@@ -29,15 +28,7 @@ public:
 
 private:
 	Terrain3D *_terrain = nullptr;
-
-	void _generate_mesh_types(const int p_mesh_size);
-	RID _generate_mesh(const Vector2i &p_size, const bool p_standard_grid = false);
-	RID _instantiate_mesh(const PackedVector3Array &p_vertices, const PackedInt32Array &p_indices, const AABB &p_aabb);
-	void _generate_clipmap(const int p_size, const int p_lods, const RID &scenario);
-	void _generate_offset_data(const int p_mesh_size);
-	
-	void _clear_clipmap();
-	void _clear_mesh_types();
+	Vector2 _last_target_position = V2_MAX;
 
 	Array _mesh_rids;
 	// LODs -> MeshTypes -> Instances
@@ -58,6 +49,15 @@ private:
 	real_t _offset_c = 0.f;
 	PackedVector3Array _edge_pos;
 
+	void _generate_mesh_types(const int p_mesh_size);
+	RID _generate_mesh(const Vector2i &p_size, const bool p_standard_grid = false);
+	RID _instantiate_mesh(const PackedVector3Array &p_vertices, const PackedInt32Array &p_indices, const AABB &p_aabb);
+	void _generate_clipmap(const int p_size, const int p_lods, const RID &scenario);
+	void _generate_offset_data(const int p_mesh_size);
+
+	void _clear_clipmap();
+	void _clear_mesh_types();
+
 public:
 	Terrain3DMesher() {}
 	~Terrain3DMesher() { destroy(); }
@@ -65,10 +65,10 @@ public:
 	void initialize(Terrain3D *p_terrain);
 	void destroy();
 
-	void snap(const Vector3 &p_tracked_pos);
+	void snap();
+	void reset_target_position() { _last_target_position = V2_MAX; }
 	void update();
 	void update_aabbs();
-
 };
 // Inline Functions
 

--- a/src/terrain_3d_util.h
+++ b/src/terrain_3d_util.h
@@ -267,18 +267,6 @@ _FORCE_INLINE_ bool remove_from_tree(Node *p_node) {
 	return false;
 }
 
-// UtilityFunctions::is_instance_valid() is faulty and shouldn't be used.
-// Use this version instead on objects that might be freed by the user.
-// See https://github.com/godotengine/godot-cpp/issues/1390#issuecomment-1937570699
-_FORCE_INLINE_ bool is_instance_valid(const uint64_t p_instance_id, Object *p_object = nullptr) {
-	Object *obj = ObjectDB::get_instance(p_instance_id);
-	if (p_object) {
-		return p_instance_id > 0 && p_object == obj;
-	} else {
-		return p_instance_id > 0 && obj;
-	}
-}
-
 _FORCE_INLINE_ String ptr_to_str(const void *p_ptr) {
 	return "0x" + String::num_uint64(uint64_t(p_ptr), 16, true);
 }


### PR DESCRIPTION
Fixes #703

Added the ability to select any Node3D to act as the clipmap and dynamic collision targets.

If no node is assigned, falls back to using the camera.

![image](https://github.com/user-attachments/assets/ac280920-29f8-4a1c-a5ad-32058a96fffa)


