### PR TITLE
Fix penultimate LOD Billboard visibility gaps addressing #691

### DIFF
--- a/src/terrain_3d_instancer.cpp
+++ b/src/terrain_3d_instancer.cpp
@@ -196,7 +196,12 @@ void Terrain3DInstancer::_setup_mmi_lod_ranges(MultiMeshInstance3D *p_mmi, const
 		p_mmi->set_visibility_range_fade_mode(GeometryInstance3D::VISIBILITY_RANGE_FADE_SELF);
 	} else {
 		p_mmi->set_visibility_range_begin(p_ma->get_lod_range_begin(p_lod));
-		p_mmi->set_visibility_range_end(p_ma->get_lod_range_end(p_lod) * 1.0005f);
+		if (p_lod < p_ma->get_last_lod() - 1) {
+			p_mmi->set_visibility_range_end(p_ma->get_lod_range_end(p_lod) * 1.0005f);
+		
+		} else {
+			p_mmi->set_visibility_range_end(p_ma->get_lod_range_end(p_lod) * 1.0024f);
+		}
 	}
 }
 


### PR DESCRIPTION
Fix penultimate LOD Billboard visibility gaps addressing #691

> MMI visibility ranges have a gap if the edges of ranges are perfectly aligned. They must be overlapped. We expand the far range of the previous lod to overlap and close the gap in terrain_3d_instancer.cpp. The gap gets wider the further out it is, so we multiplied the range by 1.0005 which covers most cases.
> 
> When planes are used as lods, their visibility gap is much further than with 3D meshes. It's likely due to aabbs, but setting a custom reportedly doesn't work. Extending the range further to say 0.3 for 128 (1.0024).