### PR TITLE
Fix #729 - Touch screen inverted setting

### DIFF
--- a/project/addons/terrain_3d/src/editor_plugin.gd
+++ b/project/addons/terrain_3d/src/editor_plugin.gd
@@ -284,7 +284,13 @@ func _read_input(p_event: InputEvent = null) -> AfterGUIInput:
 
 	## Determine modifiers pressed
 	modifier_shift = Input.is_key_pressed(KEY_SHIFT)
-	modifier_ctrl = Input.is_key_pressed(KEY_META) if _use_meta else Input.is_key_pressed(KEY_CTRL)
+	
+	# Editor responds to modifier_ctrl so we must register touchscreen Invert 
+	if _use_meta:
+		modifier_ctrl = Input.is_key_pressed(KEY_META) || ui.inverted_input
+	else:
+		modifier_ctrl = Input.is_key_pressed(KEY_CTRL) || ui.inverted_input
+	
 	# Keybind enum: Alt,Space,Meta,Capslock
 	var alt_key: int
 	match get_setting("terrain3d/config/alt_key_bind", 0):
@@ -312,7 +318,7 @@ func _read_input(p_event: InputEvent = null) -> AfterGUIInput:
 		ui.brush_data["modifier_shift"] = modifier_shift
 		ui.brush_data["modifier_ctrl"] = modifier_ctrl
 		ui.brush_data["modifier_alt"] = modifier_alt
-		ui.update_modifiers()
+		ui.set_active_operation()
 
 	## Continue processing input
 	return AFTER_GUI_INPUT_CUSTOM

--- a/project/addons/terrain_3d/src/tool_settings.gd
+++ b/project/addons/terrain_3d/src/tool_settings.gd
@@ -2,8 +2,8 @@
 # Tool settings bar for Terrain3D
 extends PanelContainer
 
-signal picking(type, callback)
-signal setting_changed
+signal picking(type: Terrain3DEditor.Tool, callback: Callable)
+signal setting_changed(setting: Variant)
 
 enum Layout {
 	HORIZONTAL,
@@ -622,19 +622,19 @@ func show_settings(p_settings: PackedStringArray) -> void:
 			select_brush_button.show()
 
 
-func _on_setting_changed(p_object: Variant = null) -> void:
+func _on_setting_changed(p_setting: Variant = null) -> void:
 	# If a brush was selected
-	if p_object is Button and p_object.get_parent().name == "BrushList":
-		_generate_brush_texture(p_object)
+	if p_setting is Button and p_setting.get_parent().name == "BrushList":
+		_generate_brush_texture(p_setting)
 		# Optionally Set selected brush texture in main brush button
 		if select_brush_button:
-			select_brush_button.set_button_icon(p_object.get_button_icon())
+			select_brush_button.set_button_icon(p_setting.get_button_icon())
 		# Hide popup
-		p_object.get_parent().get_parent().set_visible(false)
+		p_setting.get_parent().get_parent().set_visible(false)
 		# Hide label
-		if p_object.get_child_count() > 0:
-			p_object.get_child(0).visible = false
-	emit_signal("setting_changed")
+		if p_setting.get_child_count() > 0:
+			p_setting.get_child(0).visible = false
+	emit_signal("setting_changed", p_setting)
 
 
 func _generate_brush_texture(p_btn: Button) -> void:

--- a/project/addons/terrain_3d/src/tool_settings.gd
+++ b/project/addons/terrain_3d/src/tool_settings.gd
@@ -158,7 +158,7 @@ func _ready() -> void:
 								#"range":Vector3(0, 3, 1) })
 
 	if DisplayServer.is_touchscreen_available():
-		add_setting({ "name":"remove", "label":"Invert", "type":SettingType.CHECKBOX, "list":main_list, "default":false, "flags":ADD_SEPARATOR })
+		add_setting({ "name":"invert", "label":"Invert", "type":SettingType.CHECKBOX, "list":main_list, "default":false, "flags":ADD_SEPARATOR })
 
 	var spacer: Control = Control.new()
 	spacer.size_flags_horizontal = Control.SIZE_EXPAND_FILL

--- a/project/addons/terrain_3d/src/toolbar.gd
+++ b/project/addons/terrain_3d/src/toolbar.gd
@@ -151,5 +151,4 @@ func _on_tool_selected(p_button: BaseButton) -> void:
 	var id: int = p_button.get_meta("ID", -2)
 	for button in change_group.get_buttons():
 		button.set_pressed_no_signal(button.get_meta("ID", -1) == id)
-	
 	emit_signal("tool_changed", p_button.get_meta("Tool", Terrain3DEditor.TOOL_MAX), p_button.get_meta("Operation", Terrain3DEditor.OP_MAX))

--- a/project/addons/terrain_3d/src/ui.gd
+++ b/project/addons/terrain_3d/src/ui.gd
@@ -191,6 +191,7 @@ func _on_tool_changed(p_tool: Terrain3DEditor.Tool, p_operation: Terrain3DEditor
 			to_show.push_back("enable_texture")
 			if _selected_operation == Terrain3DEditor.ADD:
 				to_show.push_back("strength")
+				to_show.push_back("invert")
 			to_show.push_back("slope")
 			to_show.push_back("enable_angle")
 			to_show.push_back("angle")
@@ -270,14 +271,16 @@ func _on_tool_changed(p_tool: Terrain3DEditor.Tool, p_operation: Terrain3DEditor
 	plugin.update_region_grid()
 
 
-func _on_setting_changed() -> void:
-	if not plugin.asset_dock: # Necessary check to verify we're _ready()
+func _on_setting_changed(p_setting: Variant = null) -> void:
+	if not plugin.asset_dock: # Skip function if not _ready()
 		return
 	brush_data = tool_settings.get_settings()
 	brush_data["asset_id"] = plugin.asset_dock.get_current_list().get_selected_id()
 	if plugin.editor:
 		plugin.editor.set_brush_data(brush_data)
 	inverted_input = brush_data.get("invert", false)
+	if p_setting is CheckBox and p_setting.name == &"Invert":
+		plugin._read_input() # Revalidate keyboard input for modifier_ctrl
 	set_active_operation()
 	update_decal()
 
@@ -523,7 +526,7 @@ func set_decal_rotation(p_rot: float) -> void:
 		RenderingServer.material_set_param(mat_rid, "_editor_decal_rotation", editor_decal_rotation)
 
 
-func _on_picking(p_type: int, p_callback: Callable) -> void:
+func _on_picking(p_type: Terrain3DEditor.Tool, p_callback: Callable) -> void:
 	picking = p_type
 	picking_callback = p_callback
 	update_decal()

--- a/project/addons/terrain_3d/src/ui.gd
+++ b/project/addons/terrain_3d/src/ui.gd
@@ -49,8 +49,11 @@ var picking: int = Terrain3DEditor.TOOL_MAX
 var picking_callback: Callable
 var brush_data: Dictionary
 var operation_builder: OperationBuilder
-var last_tool: Terrain3DEditor.Tool
-var last_operation: Terrain3DEditor.Operation
+var active_tool: Terrain3DEditor.Tool
+var _selected_tool: Terrain3DEditor.Tool
+var active_operation: Terrain3DEditor.Operation
+var _selected_operation: Terrain3DEditor.Operation
+var inverted_input: bool = false
 
 # Editor decals, indices; 0 = main brush, 1 = slope point A, 2 = slope point B
 var mat_rid: RID
@@ -131,10 +134,10 @@ func set_visible(p_visible: bool, p_menu_only: bool = false) -> void:
 		tool_settings.set_visible(p_visible)
 		update_decal()
 
-	if(plugin.editor):
-		if(p_visible):
+	if plugin.editor:
+		if p_visible:
 			await get_tree().create_timer(.01).timeout # Won't work, otherwise
-			_on_tool_changed(last_tool, last_operation)
+			_on_tool_changed(_selected_tool, _selected_operation)
 		else:
 			plugin.editor.set_tool(Terrain3DEditor.TOOL_MAX)
 			plugin.editor.set_operation(Terrain3DEditor.OP_MAX)
@@ -146,6 +149,8 @@ func set_menu_visibility(p_list: Control, p_visible: bool) -> void:
 	
 
 func _on_tool_changed(p_tool: Terrain3DEditor.Tool, p_operation: Terrain3DEditor.Operation) -> void:
+	_selected_tool = p_tool
+	_selected_operation = p_operation
 	clear_picking()
 	set_menu_visibility(tool_settings.advanced_list, true)
 	set_menu_visibility(tool_settings.scale_list, false)
@@ -156,19 +161,19 @@ func _on_tool_changed(p_tool: Terrain3DEditor.Tool, p_operation: Terrain3DEditor
 	# Select which settings to show. Options in tool_settings.gd:_ready
 	var to_show: PackedStringArray = []
 	
-	match p_tool:
+	match _selected_tool:
 		Terrain3DEditor.REGION:
 			to_show.push_back("instructions")
-			to_show.push_back("remove")
+			to_show.push_back("invert")
 			set_menu_visibility(tool_settings.advanced_list, false)
 
 		Terrain3DEditor.SCULPT:
 			to_show.push_back("brush")
 			to_show.push_back("size")
 			to_show.push_back("strength")
-			if p_operation in [Terrain3DEditor.ADD, Terrain3DEditor.SUBTRACT]:
-					to_show.push_back("remove")
-			elif p_operation == Terrain3DEditor.GRADIENT:
+			if _selected_operation in [Terrain3DEditor.ADD, Terrain3DEditor.SUBTRACT]:
+					to_show.push_back("invert")
+			elif _selected_operation == Terrain3DEditor.GRADIENT:
 				to_show.push_back("gradient_points")
 				to_show.push_back("drawable")
 
@@ -178,12 +183,13 @@ func _on_tool_changed(p_tool: Terrain3DEditor.Tool, p_operation: Terrain3DEditor
 			to_show.push_back("strength")
 			to_show.push_back("height")
 			to_show.push_back("height_picker")
+			to_show.push_back("invert")
 
 		Terrain3DEditor.TEXTURE:
 			to_show.push_back("brush")
 			to_show.push_back("size")
 			to_show.push_back("enable_texture")
-			if p_operation == Terrain3DEditor.ADD:
+			if _selected_operation == Terrain3DEditor.ADD:
 				to_show.push_back("strength")
 			to_show.push_back("slope")
 			to_show.push_back("enable_angle")
@@ -203,7 +209,7 @@ func _on_tool_changed(p_tool: Terrain3DEditor.Tool, p_operation: Terrain3DEditor
 			to_show.push_back("slope")
 			to_show.push_back("texture_filter")
 			to_show.push_back("margin")
-			to_show.push_back("remove")
+			to_show.push_back("invert")
 
 		Terrain3DEditor.ROUGHNESS:
 			to_show.push_back("brush")
@@ -214,12 +220,12 @@ func _on_tool_changed(p_tool: Terrain3DEditor.Tool, p_operation: Terrain3DEditor
 			to_show.push_back("slope")
 			to_show.push_back("texture_filter")
 			to_show.push_back("margin")
-			to_show.push_back("remove")
+			to_show.push_back("invert")
 
 		Terrain3DEditor.AUTOSHADER, Terrain3DEditor.HOLES, Terrain3DEditor.NAVIGATION:
 			to_show.push_back("brush")
 			to_show.push_back("size")
-			to_show.push_back("remove")
+			to_show.push_back("invert")
 
 		Terrain3DEditor.INSTANCER:
 			to_show.push_back("size")
@@ -241,7 +247,7 @@ func _on_tool_changed(p_tool: Terrain3DEditor.Tool, p_operation: Terrain3DEditor
 			to_show.push_back("vertex_color")
 			to_show.push_back("random_darken")
 			to_show.push_back("random_hue")
-			to_show.push_back("remove")
+			to_show.push_back("invert")
 
 		_:
 			pass
@@ -256,63 +262,57 @@ func _on_tool_changed(p_tool: Terrain3DEditor.Tool, p_operation: Terrain3DEditor
 	tool_settings.show_settings(to_show)
 
 	operation_builder = null
-	if p_operation == Terrain3DEditor.GRADIENT:
+	if _selected_operation == Terrain3DEditor.GRADIENT:
 		operation_builder = GradientOperationBuilder.new()
 		operation_builder.tool_settings = tool_settings
-
-	if plugin.editor:
-		plugin.editor.set_tool(p_tool)
-		plugin.editor.set_operation(_modify_operation(p_operation))
-		last_tool = p_tool
-		last_operation = p_operation
 
 	_on_setting_changed()
 	plugin.update_region_grid()
 
 
 func _on_setting_changed() -> void:
-	if not plugin.asset_dock:
+	if not plugin.asset_dock: # Necessary check to verify we're _ready()
 		return
 	brush_data = tool_settings.get_settings()
 	brush_data["asset_id"] = plugin.asset_dock.get_current_list().get_selected_id()
-	plugin.editor.set_brush_data(brush_data)
-	plugin.editor.set_operation(_modify_operation(plugin.editor.get_operation()))
+	if plugin.editor:
+		plugin.editor.set_brush_data(brush_data)
+	inverted_input = brush_data.get("invert", false)
+	set_active_operation()
 	update_decal()
 
 
-func update_modifiers() -> void:
-	toolbar.show_add_buttons(not plugin.modifier_ctrl)
+# Change tool/operation based on modifiers. Called from:
+# * editor_plugin.gd:_read_input() - when a modifier key is pressed
+# * _on_tool_changed() via:
+# * _on_setting_changed() eg. Touchscreen Invert
+func set_active_operation() -> void:
+	var inverted: bool = plugin.modifier_ctrl || inverted_input
 
-	if plugin.modifier_shift and not plugin.modifier_ctrl:
-		plugin.editor.set_tool(Terrain3DEditor.SCULPT)
-		plugin.editor.set_operation(Terrain3DEditor.AVERAGE)
+	# Toggle toolbar buttons
+	toolbar.show_add_buttons(not inverted)
+	
+	# If Shift, Smoothness 
+	if plugin.modifier_shift and not inverted:
+		active_tool = Terrain3DEditor.SCULPT
+		active_operation = Terrain3DEditor.AVERAGE	
+	
+	# Else if Ctrl/Invert checked, opposite
+	elif _selected_operation == Terrain3DEditor.ADD and inverted:
+		active_tool = _selected_tool
+		active_operation = Terrain3DEditor.SUBTRACT
+	elif _selected_operation == Terrain3DEditor.SUBTRACT and not inverted:
+		active_tool = _selected_tool
+		active_operation = Terrain3DEditor.ADD
+
+	# Else use default and set
 	else:
-		plugin.editor.set_tool(last_tool)
-		if plugin.modifier_ctrl:
-			plugin.editor.set_operation(_modify_operation(last_operation))
-		else:
-			plugin.editor.set_operation(last_operation)
+		active_tool = _selected_tool
+		active_operation = _selected_operation
 
-
-func _modify_operation(p_operation: Terrain3DEditor.Operation) -> Terrain3DEditor.Operation:
-	var remove_checked: bool = false
-	if DisplayServer.is_touchscreen_available():
-		var removable_tools := [Terrain3DEditor.REGION, Terrain3DEditor.SCULPT, Terrain3DEditor.HEIGHT, Terrain3DEditor.AUTOSHADER,
-			Terrain3DEditor.HOLES, Terrain3DEditor.INSTANCER, Terrain3DEditor.NAVIGATION, 
-			Terrain3DEditor.COLOR, Terrain3DEditor.ROUGHNESS]
-		remove_checked = brush_data.get("remove", false) && plugin.editor.get_tool() in removable_tools
-		
-	if plugin.modifier_ctrl or remove_checked:
-		return _invert_operation(p_operation, OP_NEGATIVE_ONLY)
-	return _invert_operation(p_operation, OP_POSITIVE_ONLY)
-
-
-func _invert_operation(p_operation: Terrain3DEditor.Operation, flags: int = OP_NONE) -> Terrain3DEditor.Operation:
-	if p_operation == Terrain3DEditor.ADD and ! (flags & OP_POSITIVE_ONLY):
-		return Terrain3DEditor.SUBTRACT
-	elif p_operation == Terrain3DEditor.SUBTRACT and ! (flags & OP_NEGATIVE_ONLY):
-		return Terrain3DEditor.ADD
-	return p_operation
+	if plugin.editor:
+		plugin.editor.set_tool(active_tool)
+		plugin.editor.set_operation(active_operation)
 
 
 func update_decal() -> void:
@@ -352,12 +352,12 @@ func update_decal() -> void:
 		if !(loc.x < 0 or loc.x > map_size - 1 or loc.y < 0 or loc.y > map_size - 1):
 			var index: int = clampi(loc.y * map_size + loc.x, 0, map_size * map_size - 1)
 			if plugin.terrain.material.get_world_background() == Terrain3DMaterial.WorldBackground.NONE:
-				if r_map[index] == 0 and plugin.editor.get_operation() == Terrain3DEditor.ADD:
+				if r_map[index] == 0 and active_operation == Terrain3DEditor.ADD:
 					r_map[index] = -index - 1
 				else:
 					r_map[index] = r_map[index]
 			
-			match plugin.editor.get_operation():
+			match active_operation:
 				Terrain3DEditor.ADD:
 					if r_map[index] <= 0:
 						editor_decal_color[0] = Color.WHITE
@@ -396,7 +396,7 @@ func update_decal() -> void:
 				editor_decal_rotation[0] = 0.
 		match plugin.editor.get_tool():
 			Terrain3DEditor.SCULPT:
-				match plugin.editor.get_operation():
+				match active_operation:
 					Terrain3DEditor.ADD:
 						if plugin.modifier_alt:
 							editor_decal_color[0] = COLOR_LIFT
@@ -421,7 +421,7 @@ func update_decal() -> void:
 				editor_decal_color[0] = COLOR_HEIGHT
 				editor_decal_color[0].a = clamp(brush_data["strength"], .2, .5) + .25
 			Terrain3DEditor.TEXTURE:
-				match plugin.editor.get_operation():
+				match active_operation:
 					Terrain3DEditor.REPLACE:
 						editor_decal_color[0] = COLOR_PAINT
 						editor_decal_color[0].a = .6
@@ -454,7 +454,7 @@ func update_decal() -> void:
 	editor_decal_visible[1] = false
 	editor_decal_visible[2] = false
 	
-	if plugin.editor.get_operation() == Terrain3DEditor.GRADIENT:
+	if active_operation == Terrain3DEditor.GRADIENT:
 		var point1: Vector3 = brush_data["gradient_points"][0]
 		if point1 != Vector3.ZERO:
 			editor_decal_color[1] = COLOR_SLOPE


### PR DESCRIPTION
Fixes #729 

* Fixes touch screen inverted setting
* Enables Invert for the height tool

@Saul2022 please test normal operations


To test for reviewers:
1. Normal operations of raise, lower (ctrl), smooth (shift) - operations work, decals change
2. Simulated a touch screen:
    * tool_settings.gd:160 `	if true: #DisplayServer.is_touchscreen_available():`
    * test the above using the Invert setting. 
3. Leave Invert checked and restart so it is enabled on start and test again.


