### PR TITLE
Add instance on all collision

### DIFF
--- a/Terrain3D.vcxproj.filters
+++ b/Terrain3D.vcxproj.filters
@@ -250,6 +250,9 @@
     <None Include="src\shaders\overlays.glsl">
       <Filter>4. Shaders</Filter>
     </None>
+    <None Include="doc\docs\keyboard_shortcuts.md">
+      <Filter>2. Docs</Filter>
+    </None>
   </ItemGroup>
   <ItemGroup>
     <Text Include=".readthedocs.yaml">

--- a/project/addons/terrain_3d/src/tool_settings.gd
+++ b/project/addons/terrain_3d/src/tool_settings.gd
@@ -157,9 +157,8 @@ func _ready() -> void:
 	#add_setting({ "name":"blend_mode", "type":SettingType.OPTION, "list":color_list, "default":0, 
 								#"range":Vector3(0, 3, 1) })
 
-	add_setting({ "name":"on_collision", "label":"On Collsion", "type":SettingType.CHECKBOX, "list":main_list, "default":false,"flags":ADD_SPACER  })
-
-
+	add_setting({ "name":"on_collision", "label":"On Collision", "type":SettingType.CHECKBOX, "list":main_list,
+								"default":true, "flags":ADD_SPACER  })
 
 	if DisplayServer.is_touchscreen_available():
 		add_setting({ "name":"invert", "label":"Invert", "type":SettingType.CHECKBOX, "list":main_list, "default":false, "flags":ADD_SEPARATOR })

--- a/project/addons/terrain_3d/src/tool_settings.gd
+++ b/project/addons/terrain_3d/src/tool_settings.gd
@@ -157,6 +157,10 @@ func _ready() -> void:
 	#add_setting({ "name":"blend_mode", "type":SettingType.OPTION, "list":color_list, "default":0, 
 								#"range":Vector3(0, 3, 1) })
 
+	add_setting({ "name":"on_collision", "label":"On Collsion", "type":SettingType.CHECKBOX, "list":main_list, "default":false,"flags":ADD_SPACER  })
+
+
+
 	if DisplayServer.is_touchscreen_available():
 		add_setting({ "name":"invert", "label":"Invert", "type":SettingType.CHECKBOX, "list":main_list, "default":false, "flags":ADD_SEPARATOR })
 

--- a/project/addons/terrain_3d/src/ui.gd
+++ b/project/addons/terrain_3d/src/ui.gd
@@ -248,8 +248,8 @@ func _on_tool_changed(p_tool: Terrain3DEditor.Tool, p_operation: Terrain3DEditor
 			to_show.push_back("vertex_color")
 			to_show.push_back("random_darken")
 			to_show.push_back("random_hue")
-			to_show.push_back("invert")
 			to_show.push_back("on_collision")
+			to_show.push_back("invert")
 
 		_:
 			pass

--- a/project/addons/terrain_3d/src/ui.gd
+++ b/project/addons/terrain_3d/src/ui.gd
@@ -249,6 +249,7 @@ func _on_tool_changed(p_tool: Terrain3DEditor.Tool, p_operation: Terrain3DEditor
 			to_show.push_back("random_darken")
 			to_show.push_back("random_hue")
 			to_show.push_back("invert")
+			to_show.push_back("on_collision")
 
 		_:
 			pass

--- a/src/terrain_3d.cpp
+++ b/src/terrain_3d.cpp
@@ -16,6 +16,8 @@
 #include <godot_cpp/classes/viewport.hpp>
 #include <godot_cpp/classes/viewport_texture.hpp>
 #include <godot_cpp/classes/world3d.hpp>
+#include <godot_cpp/classes/physics_direct_space_state3d.hpp>
+#include <godot_cpp/classes/physics_ray_query_parameters3d.hpp>
 
 #include "logger.h"
 #include "terrain_3d.h"
@@ -736,6 +738,20 @@ Vector3 Terrain3D::get_intersection(const Vector3 &p_src_pos, const Vector3 &p_d
 	}
 
 	return point;
+}
+
+/* Returns the results of a physics ray cast
+ *	p_src_pos (camera position)
+ *	p_direction (camera direction)
+ */
+Dictionary Terrain3D::get_raycast_result(const Vector3 &p_src_pos, const Vector3 &p_direction, const real_t &p_distance) {
+
+    // Replace the problematic line with the following code to access the PhysicsDirectSpaceState3D correctly:
+    Ref<World3D> world = get_world_3d();
+    PhysicsDirectSpaceState3D *space_state = world->get_direct_space_state();
+	Ref<PhysicsRayQueryParameters3D> query = PhysicsRayQueryParameters3D::create(p_src_pos, p_src_pos + p_direction * p_distance);
+
+	 return space_state->intersect_ray(query);
 }
 
 /**

--- a/src/terrain_3d.cpp
+++ b/src/terrain_3d.cpp
@@ -7,6 +7,8 @@
 #include <godot_cpp/classes/height_map_shape3d.hpp>
 #include <godot_cpp/classes/label3d.hpp>
 #include <godot_cpp/classes/os.hpp>
+#include <godot_cpp/classes/physics_direct_space_state3d.hpp>
+#include <godot_cpp/classes/physics_ray_query_parameters3d.hpp>
 #include <godot_cpp/classes/project_settings.hpp>
 #include <godot_cpp/classes/quad_mesh.hpp>
 #include <godot_cpp/classes/rendering_server.hpp>
@@ -16,8 +18,6 @@
 #include <godot_cpp/classes/viewport.hpp>
 #include <godot_cpp/classes/viewport_texture.hpp>
 #include <godot_cpp/classes/world3d.hpp>
-#include <godot_cpp/classes/physics_direct_space_state3d.hpp>
-#include <godot_cpp/classes/physics_ray_query_parameters3d.hpp>
 
 #include "logger.h"
 #include "terrain_3d.h"
@@ -740,18 +740,20 @@ Vector3 Terrain3D::get_intersection(const Vector3 &p_src_pos, const Vector3 &p_d
 	return point;
 }
 
-/* Returns the results of a physics ray cast
- *	p_src_pos (camera position)
- *	p_direction (camera direction)
+/* Returns the results of a physics ray cast, optionally excluding the terrain
+ *	p_src_pos (ray start position)
+ *	p_direction (ray direction * magnitude)
  */
-Dictionary Terrain3D::get_raycast_result(const Vector3 &p_src_pos, const Vector3 &p_direction, const real_t &p_distance) {
-
-    // Replace the problematic line with the following code to access the PhysicsDirectSpaceState3D correctly:
-    Ref<World3D> world = get_world_3d();
-    PhysicsDirectSpaceState3D *space_state = world->get_direct_space_state();
-	Ref<PhysicsRayQueryParameters3D> query = PhysicsRayQueryParameters3D::create(p_src_pos, p_src_pos + p_direction * p_distance);
-
-	 return space_state->intersect_ray(query);
+Dictionary Terrain3D::get_raycast_result(const Vector3 &p_src_pos, const Vector3 &p_destination, const bool p_exclude_self) const {
+	if (!_is_inside_world) {
+		return Dictionary();
+	}
+	PhysicsDirectSpaceState3D *space_state = get_world_3d()->get_direct_space_state();
+	Ref<PhysicsRayQueryParameters3D> query = PhysicsRayQueryParameters3D::create(p_src_pos, p_src_pos + p_destination);
+	if (_collision && p_exclude_self) {
+		query->set_exclude(TypedArray<RID>(_collision->get_rid()));
+	}
+	return space_state->intersect_ray(query);
 }
 
 /**

--- a/src/terrain_3d.h
+++ b/src/terrain_3d.h
@@ -123,7 +123,7 @@ public:
 
 	Terrain3D();
 	~Terrain3D() {}
-	bool is_inside_world() { return _is_inside_world; }
+	bool is_inside_world() const { return _is_inside_world; }
 
 	// Terrain
 	String get_version() const { return _version; }
@@ -187,7 +187,7 @@ public:
 
 	// Utility
 	Vector3 get_intersection(const Vector3 &p_src_pos, const Vector3 &p_direction, const bool p_gpu_mode = false);
-	Dictionary get_raycast_result(const Vector3 &p_src_pos, const Vector3 &p_direction, const real_t &distance);
+	Dictionary get_raycast_result(const Vector3 &p_src_pos, const Vector3 &p_destination, const bool p_exclude_self = true) const;
 	Ref<Mesh> bake_mesh(const int p_lod, const Terrain3DData::HeightFilter p_filter = Terrain3DData::HEIGHT_FILTER_NEAREST) const;
 	PackedVector3Array generate_nav_mesh_source_geometry(const AABB &p_global_aabb, const bool p_require_nav = true) const;
 

--- a/src/terrain_3d.h
+++ b/src/terrain_3d.h
@@ -187,6 +187,7 @@ public:
 
 	// Utility
 	Vector3 get_intersection(const Vector3 &p_src_pos, const Vector3 &p_direction, const bool p_gpu_mode = false);
+	Dictionary get_raycast_result(const Vector3 &p_src_pos, const Vector3 &p_direction, const real_t &distance);
 	Ref<Mesh> bake_mesh(const int p_lod, const Terrain3DData::HeightFilter p_filter = Terrain3DData::HEIGHT_FILTER_NEAREST) const;
 	PackedVector3Array generate_nav_mesh_source_geometry(const AABB &p_global_aabb, const bool p_require_nav = true) const;
 

--- a/src/terrain_3d_editor.h
+++ b/src/terrain_3d_editor.h
@@ -103,6 +103,7 @@ public:
 	Terrain3D *get_terrain() const { return _terrain; }
 
 	void set_brush_data(const Dictionary &p_data);
+	Dictionary get_brush_data() const { return _brush_data; };
 	void set_tool(const Tool p_tool);
 	Tool get_tool() const { return _tool; }
 	void set_operation(const Operation p_operation) { _operation = CLAMP(p_operation, Operation(0), OP_MAX); }

--- a/src/terrain_3d_instancer.h
+++ b/src/terrain_3d_instancer.h
@@ -43,13 +43,14 @@ private:
 	uint32_t _get_density_count(const real_t p_density);
 
 	void _update_mmis(const Vector2i &p_region_loc = V2I_MAX, const int p_mesh_id = -1);
+	void _setup_mmi_lod_ranges(MultiMeshInstance3D *p_mmi, const Ref<Terrain3DMeshAsset> &p_ma, const int p_lod);
 	void _update_vertex_spacing(const real_t p_vertex_spacing);
 	void _destroy_mmi_by_cell(const Vector2i &p_region_loc, const int p_mesh_id, const Vector2i p_cell);
 	void _destroy_mmi_by_location(const Vector2i &p_region_loc, const int p_mesh_id);
 	void _backup_region(const Ref<Terrain3DRegion> &p_region);
 	Ref<MultiMesh> _create_multimesh(const int p_mesh_id, const int p_lod, const TypedArray<Transform3D> &p_xforms = TypedArray<Transform3D>(), const PackedColorArray &p_colors = PackedColorArray()) const;
 	Vector2i _get_cell(const Vector3 &p_global_position, const int p_region_size);
-	void _setup_mmi_lod_ranges(MultiMeshInstance3D *p_mmi, const Ref<Terrain3DMeshAsset> &p_ma, const int p_lod);
+	Array _get_usable_height(const Vector3 &p_global_position, const Vector2 &p_slope_range, const bool p_invert, const bool p_on_collision) const;
 
 public:
 	Terrain3DInstancer() {}


### PR DESCRIPTION
This PR allows you to paint foliage instances on collision shapes. 

Added a checkbox to instancer tool settings to toggle paint on all collision 
Add physics raycast intersection functions
If checkbox is toggled on, check for physics intersection at the position and instance at that height. We check from 100m to - 100m in y only.
If physics intersection fails, we fall back to using _terrain->get_height() as normal.
Works with align to normal

As discussed, if a collision shape is moved after painting then we will have floating instances, which may not be what was intended! In this case the smooth tool can be used at low strength to snap the instances back to the terrain.


---
Partially implements foliage tracker #43