### PR TITLE
Region undo bugs

### DIFF
--- a/src/terrain_3d_data.cpp
+++ b/src/terrain_3d_data.cpp
@@ -76,9 +76,9 @@ TypedArray<Terrain3DRegion> Terrain3DData::get_regions_active(const bool p_copy,
 	TypedArray<Terrain3DRegion> region_arr;
 	for (int i = 0; i < _region_locations.size(); i++) {
 		Vector2i region_loc = _region_locations[i];
-		Terrain3DRegion *region = get_region_ptr(region_loc);
-		if (region) {
-			region_arr.push_back((p_copy) ? region->duplicate(p_deep) : region);
+		Ref<Terrain3DRegion> region = get_region(region_loc);
+		if (region.is_valid()) {
+			region_arr.push_back(p_copy ? region->duplicate(p_deep) : region);
 		}
 	}
 	return region_arr;
@@ -125,7 +125,7 @@ void Terrain3DData::change_region_size(int p_new_size) {
 	Dictionary new_region_points;
 	Array locs = _regions.keys();
 	for (int i = 0; i < locs.size(); i++) {
-		Terrain3DRegion *region = get_region_ptr(locs[i]);
+		Terrain3DRegion *region = get_region_ptr(Vector2i(locs[i]));
 		if (region && !region->is_deleted()) {
 			Point2i region_position = region->get_location() * _region_size;
 			Rect2i location_bounds(V2I_DIVIDE_FLOOR(region_position, p_new_size), V2I_DIVIDE_CEIL(_region_sizev, p_new_size));
@@ -492,13 +492,14 @@ void Terrain3DData::update_maps(const MapType p_map_type, const bool p_all_regio
 		Array locs = _regions.keys();
 		int region_id = 0;
 		for (int i = 0; i < locs.size(); i++) {
-			Terrain3DRegion *region = cast_to<Terrain3DRegion>(_regions[locs[i]]);
+			Vector2i region_loc = locs[i];
+			Terrain3DRegion *region = get_region_ptr(region_loc);
 			if (region && !region->is_deleted()) {
 				region_id += 1; // Begin at 1 since 0 = no region
-				int map_index = get_region_map_index(region->get_location());
+				int map_index = get_region_map_index(region_loc);
 				if (map_index >= 0) {
 					_region_map[map_index] = region_id;
-					_region_locations.push_back(region->get_location());
+					_region_locations.push_back(region_loc);
 				}
 			}
 		}
@@ -512,7 +513,7 @@ void Terrain3DData::update_maps(const MapType p_map_type, const bool p_all_regio
 		_height_maps.clear();
 		for (int i = 0; i < _region_locations.size(); i++) {
 			Vector2i region_loc = _region_locations[i];
-			Terrain3DRegion *region = cast_to<Terrain3DRegion>(_regions[region_loc]);
+			Terrain3DRegion *region = get_region_ptr(region_loc);
 			if (region) {
 				_height_maps.push_back(region->get_height_map());
 			} else {
@@ -533,7 +534,7 @@ void Terrain3DData::update_maps(const MapType p_map_type, const bool p_all_regio
 		_control_maps.clear();
 		for (int i = 0; i < _region_locations.size(); i++) {
 			Vector2i region_loc = _region_locations[i];
-			Terrain3DRegion *region = cast_to<Terrain3DRegion>(_regions[region_loc]);
+			Terrain3DRegion *region = get_region_ptr(region_loc);
 			if (region) {
 				_control_maps.push_back(region->get_control_map());
 			}
@@ -549,7 +550,7 @@ void Terrain3DData::update_maps(const MapType p_map_type, const bool p_all_regio
 		_color_maps.clear();
 		for (int i = 0; i < _region_locations.size(); i++) {
 			Vector2i region_loc = _region_locations[i];
-			Terrain3DRegion *region = cast_to<Terrain3DRegion>(_regions[region_loc]);
+			Terrain3DRegion *region = get_region_ptr(region_loc);
 			if (region) {
 				_color_maps.push_back(region->get_color_map());
 			}
@@ -564,7 +565,7 @@ void Terrain3DData::update_maps(const MapType p_map_type, const bool p_all_regio
 	if (!any_changed) {
 		for (int i = 0; i < _region_locations.size(); i++) {
 			Vector2i region_loc = _region_locations[i];
-			Terrain3DRegion *region = cast_to<Terrain3DRegion>(_regions[region_loc]);
+			Terrain3DRegion *region = get_region_ptr(region_loc);
 			if (region && region->is_edited()) {
 				int region_id = get_region_id(region_loc);
 				switch (p_map_type) {

--- a/src/terrain_3d_data.cpp
+++ b/src/terrain_3d_data.cpp
@@ -506,7 +506,7 @@ void Terrain3DData::update_maps(const MapType p_map_type, const bool p_all_regio
 		emit_signal("region_map_changed");
 	}
 
-	// Rebulid height maps if dirty
+	// Rebuild height maps if dirty
 	if (_generated_height_maps.is_dirty()) {
 		LOG(EXTREME, "Regenerating height texture array from regions");
 		_height_maps.clear();

--- a/src/terrain_3d_data.h
+++ b/src/terrain_3d_data.h
@@ -236,7 +236,7 @@ inline Ref<Terrain3DRegion> Terrain3DData::get_region(const Vector2i &p_region_l
 }
 
 inline Terrain3DRegion *Terrain3DData::get_region_ptr(const Vector2i &p_region_loc) const {
-	if (has_region(p_region_loc)) {
+	if (_regions.has(p_region_loc)) {
 		return cast_to<Terrain3DRegion>(_regions[p_region_loc]);
 	}
 	return nullptr;

--- a/src/terrain_3d_editor.h
+++ b/src/terrain_3d_editor.h
@@ -86,7 +86,7 @@ private:
 	uint64_t _last_pen_tick = 0;
 
 	void _send_region_aabb(const Vector2i &p_region_loc, const Vector2 &p_height_range = Vector2());
-	Terrain3DRegion *_operate_region(const Vector2i &p_region_loc);
+	Ref<Terrain3DRegion> _operate_region(const Vector2i &p_region_loc);
 	void _operate_map(const Vector3 &p_global_position, const real_t p_camera_direction);
 	MapType _get_map_type() const;
 	bool _is_in_bounds(const Point2i &p_pixel, const Point2i &p_size) const;

--- a/src/terrain_3d_instancer.cpp
+++ b/src/terrain_3d_instancer.cpp
@@ -322,14 +322,10 @@ void Terrain3DInstancer::_destroy_mmi_by_location(const Vector2i &p_region_loc, 
 	}
 }
 
-void Terrain3DInstancer::_backup_regionl(const Vector2i &p_region_loc) {
-	if (_terrain && _terrain->get_data()) {
-		Ref<Terrain3DRegion> region = _terrain->get_data()->get_region(p_region_loc);
-		_backup_region(region);
-	}
-}
-
 void Terrain3DInstancer::_backup_region(const Ref<Terrain3DRegion> &p_region) {
+	if (p_region.is_null()) {
+		return;
+	}
 	if (_terrain && _terrain->get_editor() && _terrain->get_editor()->is_operating()) {
 		_terrain->get_editor()->backup_region(p_region);
 	} else {
@@ -591,8 +587,8 @@ void Terrain3DInstancer::remove_instances(const Vector3 &p_global_position, cons
 
 	for (int r = 0; r < region_queue.size(); r++) {
 		Vector2i region_loc = region_queue[r];
-		Terrain3DRegion *region = data->get_region_ptr(region_loc);
-		if (!region) {
+		Ref<Terrain3DRegion> region = data->get_region(region_loc);
+		if (region.is_null()) {
 			LOG(WARN, "Errant null region found at: ", region_loc);
 			continue;
 		}

--- a/src/terrain_3d_instancer.h
+++ b/src/terrain_3d_instancer.h
@@ -46,7 +46,6 @@ private:
 	void _update_vertex_spacing(const real_t p_vertex_spacing);
 	void _destroy_mmi_by_cell(const Vector2i &p_region_loc, const int p_mesh_id, const Vector2i p_cell);
 	void _destroy_mmi_by_location(const Vector2i &p_region_loc, const int p_mesh_id);
-	void _backup_regionl(const Vector2i &p_region_loc);
 	void _backup_region(const Ref<Terrain3DRegion> &p_region);
 	Ref<MultiMesh> _create_multimesh(const int p_mesh_id, const int p_lod, const TypedArray<Transform3D> &p_xforms = TypedArray<Transform3D>(), const PackedColorArray &p_colors = PackedColorArray()) const;
 	Vector2i _get_cell(const Vector3 &p_global_position, const int p_region_size);

--- a/src/terrain_3d_util.cpp
+++ b/src/terrain_3d_util.cpp
@@ -26,8 +26,9 @@ void Terrain3DUtil::print_arr(const String &p_name, const Array &p_arr, const in
 				break;
 			}
 			case Variant::OBJECT: {
-				String inst = "Object#" + String::num_uint64(cast_to<Object>(var)->get_instance_id());
-				LOG(p_level, i, ": ", inst);
+				Object *obj = cast_to<Object>(var);
+				String str = "Object#" + String::num_uint64(obj->get_instance_id()) + ", " + ptr_to_str(obj);
+				LOG(p_level, i, ": ", str);
 				break;
 			}
 			default: {
@@ -53,8 +54,9 @@ void Terrain3DUtil::print_dict(const String &p_name, const Dictionary &p_dict, c
 				break;
 			}
 			case Variant::OBJECT: {
-				String inst = "Object#" + String::num_uint64(cast_to<Object>(var)->get_instance_id());
-				LOG(p_level, "\"", keys[i], "\": ", inst);
+				Object *obj = cast_to<Object>(var);
+				String str = "Object#" + String::num_uint64(obj->get_instance_id()) + ", " + ptr_to_str(obj);
+				LOG(p_level, "\"", keys[i], "\": ", str);
 				break;
 			}
 			default: {

--- a/src/terrain_3d_util.h
+++ b/src/terrain_3d_util.h
@@ -284,4 +284,8 @@ _FORCE_INLINE_ bool is_instance_valid(const uint64_t p_instance_id, Object *p_ob
 	}
 }
 
+_FORCE_INLINE_ String ptr_to_str(const void *p_ptr) {
+	return "0x" + String::num_uint64(uint64_t(p_ptr), 16, true);
+}
+
 #endif // TERRAIN3D_UTIL_CLASS_H


### PR DESCRIPTION
Changes:

* Remove region, undo resulted in errors and didn't work. Caused by a regression in 3e98700f13dca5f2a98e98452a6328cbad24d2d5. get_region() returns any region regardless of modified or deleted. get_region_ptr() only looked at active regions. Now it looks at all regions.

* Adding a new blank region did not get placed in the redo set, so when going through the sequences below it wouldn't replace the blank region and instead used the old region and unmarked it for delete.

    * Remove region, replace it with a blank, undo, redo -> Correctly have the new blank region in place.
    * Remove region, replace it with a blank, undo twice (original state), redo twice -> Should have the new blank region, but instead shows the original region. The blank region has disappeared. **(fixed)**
    * Sculpt 1, 2, 3, 4 and undo/redo -> Works fine going forward and backwards in history repeatedly.

* Edited regions were retaining a deleted flag in some cases and needed to be marked undeleted


Fixes #731