### PR TITLE
Add mesh asset picking support to instancer tool

### DIFF
--- a/project/addons/terrain_3d/src/tool_settings.gd
+++ b/project/addons/terrain_3d/src/tool_settings.gd
@@ -68,107 +68,105 @@ func _ready() -> void:
 		"type":SettingType.LABEL, "list":main_list, "flags":NO_LABEL|NO_SAVE })
 
 	add_setting({ "name":"size", "type":SettingType.SLIDER, "list":main_list, "default":20, "unit":"m",
-								"range":Vector3(0.1, 200, 1), "flags":ALLOW_LARGER|ADD_SPACER })
+							"range":Vector3(0.1, 200, 1), "flags":ALLOW_LARGER|ADD_SPACER })
 		
 	add_setting({ "name":"strength", "type":SettingType.SLIDER, "list":main_list, "default":33, 
-								"unit":"%", "range":Vector3(1, 100, 1), "flags":ALLOW_LARGER })
+							"unit":"%", "range":Vector3(1, 100, 1), "flags":ALLOW_LARGER })
 
 	add_setting({ "name":"height", "type":SettingType.SLIDER, "list":main_list, "default":20, 
-								"unit":"m", "range":Vector3(-500, 500, 0.1), "flags":ALLOW_OUT_OF_BOUNDS })
-	add_setting({ "name":"height_picker", "type":SettingType.PICKER, "list":main_list, 
-								"default":Terrain3DEditor.HEIGHT, "flags":NO_LABEL, "tooltip":"Height Picker." })
+							"unit":"m", "range":Vector3(-500, 500, 0.1), "flags":ALLOW_OUT_OF_BOUNDS })
+	add_setting({ "name":"height_picker", "type":SettingType.PICKER, "list":main_list, "default":Terrain3DEditor.HEIGHT,
+							"flags":NO_LABEL, "tooltip":"Pick Height from the terrain." })
 	
 	add_setting({ "name":"color", "type":SettingType.COLOR_SELECT, "list":main_list, 
-								"default":Color.WHITE, "flags":ADD_SEPARATOR })
-	add_setting({ "name":"color_picker", "type":SettingType.PICKER, "list":main_list, 
-								"default":Terrain3DEditor.COLOR, "flags":NO_LABEL, "tooltip":"Color Picker." })
+							"default":Color.WHITE, "flags":ADD_SEPARATOR })
+	add_setting({ "name":"color_picker", "type":SettingType.PICKER, "list":main_list, "default":Terrain3DEditor.COLOR,
+							"flags":NO_LABEL, "tooltip":"Pick Color from the terrain." })
 
 	add_setting({ "name":"roughness", "type":SettingType.SLIDER, "list":main_list, "default":-65,
-								"unit":"%", "range":Vector3(-100, 100, 1), "flags":ADD_SEPARATOR })
-	add_setting({ "name":"roughness_picker", "type":SettingType.PICKER, "list":main_list, 
-								"default":Terrain3DEditor.ROUGHNESS, "flags":NO_LABEL, "tooltip":"Roughness Picker." })
+							"unit":"%", "range":Vector3(-100, 100, 1), "flags":ADD_SEPARATOR })
+	add_setting({ "name":"roughness_picker", "type":SettingType.PICKER, "list":main_list, "default":Terrain3DEditor.ROUGHNESS,
+							"flags":NO_LABEL, "tooltip":"Pick Wetness from the terrain." })
 
 	add_setting({ "name":"enable_texture", "label":"Texture", "type":SettingType.CHECKBOX, 
-								"list":main_list, "default":true, "flags":ADD_SEPARATOR })
+							"list":main_list, "default":true, "flags":ADD_SEPARATOR })
 
-	add_setting({ "name":"texture_picker", "type":SettingType.PICKER, "list":main_list, 
-								"default":Terrain3DEditor.TEXTURE, "flags":NO_LABEL, "tooltip":"Texture Picker." })
+	add_setting({ "name":"texture_picker", "type":SettingType.PICKER, "list":main_list, "default":Terrain3DEditor.TEXTURE,
+							"flags":NO_LABEL, "tooltip":"Pick Texture from the terrain." })
 
 	add_setting({ "name":"texture_filter", "label":"Texture Filter", "type":SettingType.CHECKBOX, 
-								"list":main_list, "default":false, "flags":ADD_SEPARATOR })
+							"list":main_list, "default":false, "flags":ADD_SEPARATOR })
 
 	add_setting({ "name":"margin", "type":SettingType.SLIDER, "list":main_list, "default":0, 
-								"unit":"", "range":Vector3(-50, 50, 1), "flags":ALLOW_OUT_OF_BOUNDS })
+							"unit":"", "range":Vector3(-50, 50, 1), "flags":ALLOW_OUT_OF_BOUNDS })
 
 	# Slope painting filter
-	add_setting({ "name":"slope", "type":SettingType.DOUBLE_SLIDER, "list":main_list, "default":Vector2(0, 90), 
-								"unit":"°", "range":Vector3(0, 90, 1), "flags":ADD_SEPARATOR })
+	add_setting({ "name":"slope", "type":SettingType.DOUBLE_SLIDER, "list":main_list, "default":Vector2(0, 90),
+							"unit":"°", "range":Vector3(0, 90, 1), "flags":ADD_SEPARATOR })
 	
 	add_setting({ "name":"enable_angle", "label":"Angle", "type":SettingType.CHECKBOX, 
-								"list":main_list, "default":true, "flags":ADD_SEPARATOR })
+							"list":main_list, "default":true, "flags":ADD_SEPARATOR })
 	add_setting({ "name":"angle", "type":SettingType.SLIDER, "list":main_list, "default":0,
-								"unit":"%", "range":Vector3(0, 337.5, 22.5), "flags":NO_LABEL })
-	add_setting({ "name":"angle_picker", "type":SettingType.PICKER, "list":main_list, 
-								"default":Terrain3DEditor.ANGLE, "flags":NO_LABEL, "tooltip":"Angle Picker." })
+							"unit":"%", "range":Vector3(0, 337.5, 22.5), "flags":NO_LABEL })
+	add_setting({ "name":"angle_picker", "type":SettingType.PICKER, "list":main_list, "default":Terrain3DEditor.ANGLE,
+							"flags":NO_LABEL, "tooltip":"Pick Angle from the terrain." })
 	add_setting({ "name":"dynamic_angle", "label":"Dynamic", "type":SettingType.CHECKBOX, 
-								"list":main_list, "default":false, "flags":ADD_SPACER })
+							"list":main_list, "default":false, "flags":ADD_SPACER })
 	
 	add_setting({ "name":"enable_scale", "label":"Scale", "type":SettingType.CHECKBOX, 
-								"list":main_list, "default":true, "flags":ADD_SEPARATOR })
+							"list":main_list, "default":true, "flags":ADD_SEPARATOR })
 	add_setting({ "name":"scale", "label":"±", "type":SettingType.SLIDER, "list":main_list, "default":0,
-								"unit":"%", "range":Vector3(-60, 80, 20), "flags":NO_LABEL })
-	add_setting({ "name":"scale_picker", "type":SettingType.PICKER, "list":main_list, 
-								"default":Terrain3DEditor.SCALE, "flags":NO_LABEL,"tooltip":"Scale Picker." })
+							"unit":"%", "range":Vector3(-60, 80, 20), "flags":NO_LABEL })
+	add_setting({ "name":"scale_picker", "type":SettingType.PICKER, "list":main_list, "default":Terrain3DEditor.SCALE,
+							"flags":NO_LABEL, "tooltip":"Pick Scale from the terrain." })
 
 	## Slope sculpting brush
 	add_setting({ "name":"gradient_points", "type":SettingType.MULTI_PICKER, "label":"Points", 
-								"list":main_list, "default":Terrain3DEditor.SCULPT, "flags":ADD_SEPARATOR })
+							"list":main_list, "default":Terrain3DEditor.SCULPT, "flags":ADD_SEPARATOR })
 	add_setting({ "name":"drawable", "type":SettingType.CHECKBOX, "list":main_list, "default":false, 
-								"flags":ADD_SEPARATOR })
+							"flags":ADD_SEPARATOR })
 	settings["drawable"].toggled.connect(_on_drawable_toggled)
 	
 	## Instancer
+	add_setting({ "name":"mesh_picker", "type":SettingType.PICKER, "list":main_list,
+							"default":Terrain3DEditor.INSTANCER, "flags":NO_LABEL|ADD_SEPARATOR,
+							"tooltip":"Pick a Mesh asset from the terrain, within an instancer cell. (See overlays.)" })
+
 	height_list = create_submenu(main_list, "Height", Layout.VERTICAL)
 	add_setting({ "name":"height_offset", "type":SettingType.SLIDER, "list":height_list, "default":0, 
-								"unit":"m", "range":Vector3(-10, 10, 0.05), "flags":ALLOW_OUT_OF_BOUNDS })
-	add_setting({ "name":"random_height", "label":"Random Height ±", "type":SettingType.SLIDER, 
-								"list":height_list, "default":0, "unit":"m", "range":Vector3(0, 10, 0.05),
-								"flags":ALLOW_OUT_OF_BOUNDS })
+							"unit":"m", "range":Vector3(-10, 10, 0.05), "flags":ALLOW_OUT_OF_BOUNDS })
+	add_setting({ "name":"random_height", "label":"Random Height ±", "type":SettingType.SLIDER, "list":height_list,
+							"default":0, "unit":"m", "range":Vector3(0, 10, 0.05), "flags":ALLOW_OUT_OF_BOUNDS })
 
 	scale_list = create_submenu(main_list, "Scale", Layout.VERTICAL)
 	add_setting({ "name":"fixed_scale", "type":SettingType.SLIDER, "list":scale_list, "default":100, 
-								"unit":"%", "range":Vector3(1, 1000, 1), "flags":ALLOW_OUT_OF_BOUNDS })
+							"unit":"%", "range":Vector3(1, 1000, 1), "flags":ALLOW_OUT_OF_BOUNDS })
 	add_setting({ "name":"random_scale", "label":"Random Scale ±", "type":SettingType.SLIDER, "list":scale_list, 
-								"default":20, "unit":"%", "range":Vector3(0, 99, 1), "flags":ALLOW_OUT_OF_BOUNDS })
+							"default":20, "unit":"%", "range":Vector3(0, 99, 1), "flags":ALLOW_OUT_OF_BOUNDS })
 
 	rotation_list = create_submenu(main_list, "Rotation", Layout.VERTICAL)
 	add_setting({ "name":"fixed_spin", "label":"Fixed Spin (Around Y)", "type":SettingType.SLIDER, "list":rotation_list, 
-								"default":0, "unit":"°", "range":Vector3(0, 360, 1) })
+							"default":0, "unit":"°", "range":Vector3(0, 360, 1) })
 	add_setting({ "name":"random_spin", "type":SettingType.SLIDER, "list":rotation_list, "default":360, 
-								"unit":"°", "range":Vector3(0, 360, 1) })
+							"unit":"°", "range":Vector3(0, 360, 1) })
 	add_setting({ "name":"fixed_tilt", "label":"Fixed Tilt", "type":SettingType.SLIDER, "list":rotation_list, 
-								"default":0, "unit":"°", "range":Vector3(-85, 85, 1), "flags":ALLOW_OUT_OF_BOUNDS })
+							"default":0, "unit":"°", "range":Vector3(-85, 85, 1), "flags":ALLOW_OUT_OF_BOUNDS })
 	add_setting({ "name":"random_tilt", "label":"Random Tilt ±", "type":SettingType.SLIDER, "list":rotation_list, 
-								"default":10, "unit":"°", "range":Vector3(0, 85, 1), "flags":ALLOW_OUT_OF_BOUNDS })
+							"default":10, "unit":"°", "range":Vector3(0, 85, 1), "flags":ALLOW_OUT_OF_BOUNDS })
 	add_setting({ "name":"align_to_normal", "type":SettingType.CHECKBOX, "list":rotation_list, "default":false })
 	
 	color_list = create_submenu(main_list, "Color", Layout.VERTICAL)
 	add_setting({ "name":"vertex_color", "type":SettingType.COLOR_SELECT, "list":color_list, 
-								"default":Color.WHITE })
+							"default":Color.WHITE })
 	add_setting({ "name":"random_hue", "label":"Random Hue Shift ±", "type":SettingType.SLIDER, 
-								"list":color_list, "default":0, "unit":"°", "range":Vector3(0, 360, 1) })
+							"list":color_list, "default":0, "unit":"°", "range":Vector3(0, 360, 1) })
 	add_setting({ "name":"random_darken", "type":SettingType.SLIDER, "list":color_list, "default":50, 
-								"unit":"%", "range":Vector3(0, 100, 1) })
-	add_setting({ "name":"mesh_picker", "type":SettingType.PICKER, "list":main_list, 
-								"default":Terrain3DEditor.INSTANCER, "flags":NO_LABEL, "tooltip":"Mesh Picker." })
-	#add_setting({ "name":"blend_mode", "type":SettingType.OPTION, "list":color_list, "default":0, 
-								#"range":Vector3(0, 3, 1) })
-
+							"unit":"%", "range":Vector3(0, 100, 1) })
 	collision_list = create_submenu(main_list, "Collision", Layout.VERTICAL)
 	add_setting({ "name":"on_collision", "label":"On Collision", "type":SettingType.CHECKBOX, "list":collision_list,
-								"default":true })
+							"default":true })
 	add_setting({ "name":"raycast_height", "label":"Raycast Height", "type":SettingType.SLIDER, 
-								"list":collision_list, "default":10, "unit":"m", "range":Vector3(0, 200, .25) })
+							"list":collision_list, "default":10, "unit":"m", "range":Vector3(0, 200, .25) })
 
 	if DisplayServer.is_touchscreen_available():
 		add_setting({ "name":"invert", "label":"Invert", "type":SettingType.CHECKBOX, "list":main_list, "default":false, "flags":ADD_SEPARATOR })
@@ -180,16 +178,14 @@ func _ready() -> void:
 	## Advanced Settings Menu
 	advanced_list = create_submenu(main_list, "", Layout.VERTICAL, false)
 	add_setting({ "name":"auto_regions", "label":"Add regions while sculpting", "type":SettingType.CHECKBOX, 
-								"list":advanced_list, "default":true })
+							"list":advanced_list, "default":true })
 	advanced_list.add_child(HSeparator.new(), true)
-	add_setting({ "name":"show_brush_texture", "type":SettingType.CHECKBOX, "list":advanced_list, 
-								"default":true })
-	add_setting({ "name":"align_to_view", "type":SettingType.CHECKBOX, "list":advanced_list, 
-								"default":true })
+	add_setting({ "name":"show_brush_texture", "type":SettingType.CHECKBOX, "list":advanced_list, "default":true })
+	add_setting({ "name":"align_to_view", "type":SettingType.CHECKBOX, "list":advanced_list, "default":true })
 	add_setting({ "name":"brush_spin_speed", "type":SettingType.SLIDER, "list":advanced_list, "default":50, 
-								"unit":"%", "range":Vector3(0, 100, 1) })
+							"unit":"%", "range":Vector3(0, 100, 1) })
 	add_setting({ "name":"gamma", "type":SettingType.SLIDER, "list":advanced_list, "default":1.0, 
-								"unit":"γ", "range":Vector3(0.1, 2.0, 0.01) })
+							"unit":"γ", "range":Vector3(0.1, 2.0, 0.01) })
 
 
 func create_submenu(p_parent: Control, p_button_name: String, p_layout: Layout, p_hover_pop: bool = true) -> Container:
@@ -375,11 +371,11 @@ func _on_picked(p_type: Terrain3DEditor.Tool, p_color: Color, p_global_position:
 		Terrain3DEditor.INSTANCER:
 			if p_color.r < 0:
 				return
-			plugin.asset_dock.set_selected_by_resource_id(p_color.r)
+			plugin.asset_dock.set_selected_by_asset_id(p_color.r)
 		Terrain3DEditor.TEXTURE:
 			if p_color.r < 0:
 				return
-			plugin.asset_dock.set_selected_by_resource_id(p_color.r)
+			plugin.asset_dock.set_selected_by_asset_id(p_color.r)
 	_on_setting_changed()
 
 

--- a/project/addons/terrain_3d/src/ui.gd
+++ b/project/addons/terrain_3d/src/ui.gd
@@ -29,6 +29,7 @@ const COLOR_HOLES := Color(0.1, 0.1, 0.1) # Near-black
 const COLOR_NAVIGATION := Color(0.5, 0.2, 0.5) # Purple
 const COLOR_INSTANCE := Color(0.863, 0.08, 0.235) # Crimson
 const COLOR_UNINSTANCE := Color(0.2, 0.9, 0.6) # Cyan-green
+const COLOR_PICK := Color.WHITE
 
 const OP_NONE: int = 0x0
 const OP_POSITIVE_ONLY: int = 0x01
@@ -198,7 +199,7 @@ func _on_tool_changed(p_tool: Terrain3DEditor.Tool, p_operation: Terrain3DEditor
 			to_show.push_back("dynamic_angle")
 			to_show.push_back("enable_scale")
 			to_show.push_back("scale")
-			to_show.push_back("scale_picker")			
+			to_show.push_back("scale_picker")
 
 		Terrain3DEditor.COLOR:
 			to_show.push_back("brush")
@@ -231,6 +232,7 @@ func _on_tool_changed(p_tool: Terrain3DEditor.Tool, p_operation: Terrain3DEditor
 			to_show.push_back("size")
 			to_show.push_back("strength")
 			to_show.push_back("slope")
+			to_show.push_back("mesh_picker")
 			set_menu_visibility(tool_settings.height_list, true)
 			to_show.push_back("height_offset")
 			to_show.push_back("random_height")
@@ -251,7 +253,6 @@ func _on_tool_changed(p_tool: Terrain3DEditor.Tool, p_operation: Terrain3DEditor
 			to_show.push_back("on_collision")
 			to_show.push_back("raycast_height")
 			to_show.push_back("invert")
-			to_show.push_back("mesh_picker")
 
 		_:
 			pass
@@ -274,7 +275,7 @@ func _on_setting_changed(p_setting: Variant = null) -> void:
 	if not plugin.asset_dock: # Skip function if not _ready()
 		return
 	brush_data = tool_settings.get_settings()
-	brush_data["asset_id"] = plugin.asset_dock.current_list.get_selected_resource_id()
+	brush_data["asset_id"] = plugin.asset_dock.current_list.get_selected_asset_id()
 	if plugin.debug:
 		print("Terrain3DUI: _on_setting_changed: selected resource ID: ", brush_data["asset_id"])
 	if plugin.editor:
@@ -401,9 +402,8 @@ func update_decal() -> void:
 	## Picking
 	elif picking != Terrain3DEditor.TOOL_MAX:
 		editor_decal_part[0] = false # Hide brush
-		editor_decal_size[0] = 1. * plugin.terrain.get_vertex_spacing()
-		if picking == Terrain3DEditor.COLOR:
-				editor_decal_color[0] = Color.WHITE
+		editor_decal_size[0] = plugin.terrain.get_vertex_spacing()
+		editor_decal_color[0] = COLOR_PICK
 		editor_decal_color[0].a = 1.0
 
 	## Brushing Operations
@@ -606,13 +606,13 @@ func pick(p_global_position: Vector3) -> void:
 			Terrain3DEditor.SCALE:
 				color = Color(plugin.terrain.data.get_control_scale(p_global_position), 0., 0., 1.)
 			Terrain3DEditor.INSTANCER:
-				var mesh_asset_id: int = plugin.terrain.instancer.get_closest_asset_id(p_global_position)
+				var mesh_asset_id: int = plugin.terrain.instancer.get_closest_mesh_id(p_global_position)
 				color = Color(mesh_asset_id, 0., 0., 1.)
 			Terrain3DEditor.TEXTURE:
 				var texture_blend_data: Vector3 = plugin.terrain.data.get_texture_id(p_global_position)
 				if not texture_blend_data.is_finite():
 					return
-				if texture_blend_data.z < 0.5:
+				if texture_blend_data.z < 0.65:
 					color = Color(texture_blend_data.x, 0., 0., 1.)
 				else:
 					color = Color(texture_blend_data.y, 0., 0., 1.)

--- a/src/terrain_3d_asset_resource.h
+++ b/src/terrain_3d_asset_resource.h
@@ -24,9 +24,14 @@ public:
 	virtual void set_id(const int p_id) = 0;
 	virtual int get_id() const = 0;
 
+	virtual void set_highlighted(const bool p_highlighted) = 0;
+	virtual bool is_highlighted() const = 0;
+	virtual Color get_highlight_color() const = 0;
+
 protected:
 	String _name;
 	int _id = 0;
+	bool _highlighted = false;
 };
 
 #endif // TERRAIN3D_ASSET_RESOURCE_CLASS_H

--- a/src/terrain_3d_assets.cpp
+++ b/src/terrain_3d_assets.cpp
@@ -355,7 +355,11 @@ void Terrain3DAssets::_update_texture_settings() {
 			if (texture_set.is_null()) {
 				continue;
 			}
-			_texture_colors.push_back(texture_set->get_albedo_color());
+			if (texture_set->is_highlighted()) {
+				_texture_colors.push_back(texture_set->get_highlight_color());
+			} else {
+				_texture_colors.push_back(texture_set->get_albedo_color());
+			}
 			_texture_normal_depths.push_back(texture_set->get_normal_depth());
 			_texture_ao_strengths.push_back(texture_set->get_ao_strength());
 			_texture_roughness_mods.push_back(texture_set->get_roughness());

--- a/src/terrain_3d_instancer.h
+++ b/src/terrain_3d_instancer.h
@@ -72,7 +72,7 @@ public:
 	void append_region(const Ref<Terrain3DRegion> &p_region, const int p_mesh_id, const TypedArray<Transform3D> &p_xforms,
 			const PackedColorArray &p_colors, const bool p_update = true);
 	void update_transforms(const AABB &p_aabb);
-	int get_closest_asset_id(const Vector3 &p_picker_location) const;
+	int get_closest_mesh_id(const Vector3 &p_global_position) const;
 	void copy_paste_dfr(const Terrain3DRegion *p_src_region, const Rect2i &p_src_rect, const Terrain3DRegion *p_dst_region);
 
 	void swap_ids(const int p_src_id, const int p_dst_id);

--- a/src/terrain_3d_mesh_asset.h
+++ b/src/terrain_3d_mesh_asset.h
@@ -54,7 +54,6 @@ private:
 	real_t _fade_margin = 0.f;
 
 	// Working data
-	bool _highlighted = false;
 	Ref<Material> _highlight_mat;
 	TypedArray<Mesh> _meshes;
 	Ref<Texture2D> _thumbnail;
@@ -74,6 +73,11 @@ public:
 	String get_name() const override { return _name; }
 	void set_id(const int p_new_id) override;
 	int get_id() const override { return _id; }
+	void set_highlighted(const bool p_highlighted) override;
+	bool is_highlighted() const override { return _highlighted; }
+	Ref<Material> get_highlight_material() const { return _highlighted ? _highlight_mat : Ref<Material>(); }
+	Color get_highlight_color() const override;
+
 	void set_enabled(const bool p_enabled);
 	bool is_enabled() const { return _enabled; }
 
@@ -98,11 +102,6 @@ public:
 	Ref<Material> get_material_override() const { return _material_override; }
 	void set_material_overlay(const Ref<Material> &p_material);
 	Ref<Material> get_material_overlay() const { return _material_overlay; }
-
-	void set_highlighted(const bool p_highlighted);
-	bool is_highlighted() const { return _highlighted; }
-	Ref<Material> get_highlight_material() const { return _highlighted ? _highlight_mat : Ref<Material>(); }
-	Color get_highlight_color() const;
 
 	void set_generated_faces(const int p_count);
 	int get_generated_faces() const { return _generated_faces; }

--- a/src/terrain_3d_texture_asset.cpp
+++ b/src/terrain_3d_texture_asset.cpp
@@ -37,6 +37,8 @@ bool Terrain3DTextureAsset::_is_valid_format(const Ref<Texture2D> &p_texture) co
 void Terrain3DTextureAsset::clear() {
 	_name = "New Texture";
 	_id = 0;
+	_highlighted = false;
+	_highlight_color = Color();
 	_albedo_color = Color(1.0f, 1.0f, 1.0f, 1.0f);
 	_albedo_texture.unref();
 	_normal_texture.unref();
@@ -62,6 +64,18 @@ void Terrain3DTextureAsset::set_id(const int p_new_id) {
 	LOG(INFO, "Setting texture id: ", _id);
 	LOG(DEBUG, "Emitting id_changed, ", Terrain3DAssets::TYPE_TEXTURE, ", ", old_id, ", ", _id);
 	emit_signal("id_changed", Terrain3DAssets::TYPE_TEXTURE, old_id, _id);
+}
+
+void Terrain3DTextureAsset::set_highlighted(const bool p_highlighted) {
+	if (p_highlighted == _highlighted) {
+		return; // No change
+	}
+	_highlighted = p_highlighted;
+	LOG(INFO, "Set mesh ID ", _id, " highlight: ", p_highlighted);
+	real_t random_float = real_t(rand()) / real_t(RAND_MAX);
+	_highlight_color.set_hsv(random_float, 1.f, 1.f, 1.f);
+	LOG(DEBUG, "Emitting setting_changed");
+	emit_signal("setting_changed");
 }
 
 void Terrain3DTextureAsset::set_albedo_color(const Color &p_color) {
@@ -168,25 +182,6 @@ void Terrain3DTextureAsset::set_detiling_shift(const real_t p_detiling_shift) {
 	emit_signal("setting_changed");
 }
 
-void Terrain3DTextureAsset::set_highlighted(const bool p_highlighted) {
-	if (p_highlighted == _highlighted) {
-		return; // No change
-	}
-	_highlighted = p_highlighted;
-	LOG(INFO, "Set mesh ID ", _id, " highlight: ", p_highlighted);
-	real_t random_float = real_t(rand()) / real_t(RAND_MAX);
-	_highight_color.set_hsv(random_float, 1.f, 1.f, 1.f);
-	LOG(DEBUG, "Emitting setting_changed");
-	emit_signal("setting_changed");
-}
-
-Color Terrain3DTextureAsset::get_highlight_color() const {
-	if (_highlighted) {
-		return _highight_color;
-	}
-	return COLOR_WHITE;
-}
-
 ///////////////////////////
 // Protected Functions
 ///////////////////////////
@@ -201,6 +196,9 @@ void Terrain3DTextureAsset::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("get_name"), &Terrain3DTextureAsset::get_name);
 	ClassDB::bind_method(D_METHOD("set_id", "id"), &Terrain3DTextureAsset::set_id);
 	ClassDB::bind_method(D_METHOD("get_id"), &Terrain3DTextureAsset::get_id);
+	ClassDB::bind_method(D_METHOD("set_highlighted", "highlight_state"), &Terrain3DTextureAsset::set_highlighted);
+	ClassDB::bind_method(D_METHOD("is_highlighted"), &Terrain3DTextureAsset::is_highlighted);
+	ClassDB::bind_method(D_METHOD("get_highlight_color"), &Terrain3DTextureAsset::get_highlight_color);
 	ClassDB::bind_method(D_METHOD("set_albedo_color", "color"), &Terrain3DTextureAsset::set_albedo_color);
 	ClassDB::bind_method(D_METHOD("get_albedo_color"), &Terrain3DTextureAsset::get_albedo_color);
 	ClassDB::bind_method(D_METHOD("set_albedo_texture", "texture"), &Terrain3DTextureAsset::set_albedo_texture);
@@ -221,8 +219,6 @@ void Terrain3DTextureAsset::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("get_detiling_rotation"), &Terrain3DTextureAsset::get_detiling_rotation);
 	ClassDB::bind_method(D_METHOD("set_detiling_shift", "detiling_shift"), &Terrain3DTextureAsset::set_detiling_shift);
 	ClassDB::bind_method(D_METHOD("get_detiling_shift"), &Terrain3DTextureAsset::get_detiling_shift);
-	ClassDB::bind_method(D_METHOD("set_highlighted", "highlight_state"), &Terrain3DTextureAsset::set_highlighted);
-	ClassDB::bind_method(D_METHOD("get_highlighted"), &Terrain3DTextureAsset::get_highlighted);
 
 	ADD_PROPERTY(PropertyInfo(Variant::STRING, "name", PROPERTY_HINT_NONE), "set_name", "get_name");
 	ADD_PROPERTY(PropertyInfo(Variant::INT, "id", PROPERTY_HINT_NONE), "set_id", "get_id");

--- a/src/terrain_3d_texture_asset.h
+++ b/src/terrain_3d_texture_asset.h
@@ -25,9 +25,8 @@ class Terrain3DTextureAsset : public Terrain3DAssetResource {
 	bool _vertical_projection = false;
 	real_t _detiling_rotation = 0.0f;
 	real_t _detiling_shift = 0.0f;
+	Color _highlight_color = Color();
 
-	bool _highlighted = false;
-	Color _highight_color = Color();
 	bool _is_valid_format(const Ref<Texture2D> &p_texture) const;
 
 public:
@@ -42,8 +41,12 @@ public:
 	void set_id(const int p_new_id) override;
 	int get_id() const override { return _id; }
 
+	void set_highlighted(const bool p_highlighted) override;
+	bool is_highlighted() const override { return _highlighted; }
+	Color get_highlight_color() const override { return _highlighted ? _highlight_color : COLOR_WHITE; }
+
 	void set_albedo_color(const Color &p_color);
-	Color get_albedo_color() const { return _highlighted ? get_highlight_color() : _albedo_color; }
+	Color get_albedo_color() const { return _albedo_color; }
 
 	void set_albedo_texture(const Ref<Texture2D> &p_texture);
 	Ref<Texture2D> get_albedo_texture() const { return _albedo_texture; }
@@ -71,11 +74,6 @@ public:
 
 	void set_detiling_shift(const real_t p_detiling_shift);
 	real_t get_detiling_shift() const { return _detiling_shift; }
-
-	void set_highlighted(const bool p_highlighted);
-	bool get_highlighted() const { return _highlighted; }
-
-	Color get_highlight_color() const;
 
 protected:
 	static void _bind_methods();


### PR DESCRIPTION
Implements the ability to pick mesh assets directly from the terrain using the instancer tool. Adds a mesh asset picker setting, updates the UI to show it for the instancer tool, and introduces a method to find the closest mesh asset at a given position.

Currently only finds the closest instance in the cell you picked. Could be expanded to check neighbouring cells.

---
Partial implementation #43 
Fixes #775 