### PR TITLE
Highlight selected MMI on select in asset dock

### DIFF
--- a/project/addons/terrain_3d/src/asset_dock.gd
+++ b/project/addons/terrain_3d/src/asset_dock.gd
@@ -292,7 +292,6 @@ func _on_meshes_pressed() -> void:
 
 func _on_tool_changed(p_tool: Terrain3DEditor.Tool, p_operation: Terrain3DEditor.Operation) -> void:
 	remove_all_highlights()
-	
 	if p_tool == Terrain3DEditor.INSTANCER:
 		_on_meshes_pressed()
 	elif p_tool in [ Terrain3DEditor.TEXTURE, Terrain3DEditor.COLOR, Terrain3DEditor.ROUGHNESS ]:
@@ -319,12 +318,11 @@ func update_assets() -> void:
 func remove_all_highlights():
 	if not plugin.terrain:
 		return
-		
 	for i: int in mesh_list.entries.size():
-		var resource: Terrain3DMeshAsset = mesh_list.entries[i].resource 
+		var resource: Terrain3DMeshAsset = mesh_list.entries[i].resource
 		if resource:
 			resource.set_highlighted(false)
-	
+
 
 ## Window Management
 
@@ -656,7 +654,6 @@ class ListEntry extends VBoxContainer:
 	var is_hovered: bool = false
 	var is_selected: bool = false
 	var is_highlighted: bool = false
-		
 	var asset_list: Terrain3DAssets
 	
 	@onready var button_row := HBoxContainer.new()
@@ -669,10 +666,7 @@ class ListEntry extends VBoxContainer:
 	@onready var edit_icon: Texture2D = get_theme_icon("Edit", "EditorIcons")
 	@onready var enabled_icon: Texture2D = get_theme_icon("GuiVisibilityVisible", "EditorIcons")
 	@onready var disabled_icon: Texture2D = get_theme_icon("GuiVisibilityHidden", "EditorIcons")
-	@onready var enable_highlight_icon: Texture2D = get_theme_icon("PreviewSun", "EditorIcons")
-	@onready var disable_highlight_icon: Texture2D = get_theme_icon("DirectionalLight3D", "EditorIcons")
-
-
+	@onready var highlight_icon: Texture2D = get_theme_icon("PreviewSun", "EditorIcons")
 	var name_label: Label
 	@onready var add_icon: Texture2D = get_theme_icon("Add", "EditorIcons")
 	@onready var background: StyleBox = get_theme_stylebox("pressed", "Button")
@@ -681,7 +675,7 @@ class ListEntry extends VBoxContainer:
 
 	func _ready() -> void:
 		if resource is Terrain3DMeshAsset:
-			is_highlighted = resource.get_highlighted()
+			is_highlighted = resource.is_highlighted()
 		setup_buttons()
 		setup_label()
 		focus_style.set_border_width_all(2)
@@ -708,20 +702,21 @@ class ListEntry extends VBoxContainer:
 			button_enabled.set_custom_minimum_size(icon_size)
 			button_enabled.set_h_size_flags(Control.SIZE_SHRINK_END)
 			button_enabled.set_visible(resource != null)
-			button_enabled.tooltip_text = "Enable/Disable"
+			button_enabled.tooltip_text = "Enable Instances"
 			button_enabled.toggle_mode = true
 			button_enabled.mouse_filter = Control.MOUSE_FILTER_PASS
+			button_enabled.mouse_default_cursor_shape = Control.CURSOR_POINTING_HAND
 			button_enabled.pressed.connect(enable)
 			button_row.add_child(button_enabled)
 			
-			button_highlight.set_texture_normal(enable_highlight_icon)
-			button_highlight.set_texture_pressed(disable_highlight_icon)
+			button_highlight.set_texture_normal(highlight_icon)
 			button_highlight.set_custom_minimum_size(icon_size)
 			button_highlight.set_h_size_flags(Control.SIZE_SHRINK_END)
 			button_highlight.set_visible(resource != null)
 			button_highlight.tooltip_text = "Highlight Instances"
 			button_highlight.toggle_mode = true
 			button_highlight.mouse_filter = Control.MOUSE_FILTER_PASS
+			button_highlight.mouse_default_cursor_shape = Control.CURSOR_POINTING_HAND
 			button_highlight.set_pressed_no_signal(is_highlighted)
 			button_highlight.pressed.connect(highlight)
 			button_row.add_child(button_highlight)
@@ -730,8 +725,9 @@ class ListEntry extends VBoxContainer:
 		button_edit.set_custom_minimum_size(icon_size)
 		button_edit.set_h_size_flags(Control.SIZE_SHRINK_END)
 		button_edit.set_visible(resource != null)
-		button_edit.tooltip_text = "Edit"
+		button_edit.tooltip_text = "Edit Asset"
 		button_edit.mouse_filter = Control.MOUSE_FILTER_PASS
+		button_edit.mouse_default_cursor_shape = Control.CURSOR_POINTING_HAND
 		button_edit.pressed.connect(edit)
 		button_row.add_child(button_edit)
 
@@ -743,8 +739,9 @@ class ListEntry extends VBoxContainer:
 		button_clear.set_custom_minimum_size(icon_size)
 		button_clear.set_h_size_flags(Control.SIZE_SHRINK_END)
 		button_clear.set_visible(resource != null)
-		button_clear.tooltip_text = "Clear"
+		button_clear.tooltip_text = "Clear Asset"
 		button_clear.mouse_filter = Control.MOUSE_FILTER_PASS
+		button_clear.mouse_default_cursor_shape = Control.CURSOR_POINTING_HAND
 		button_clear.pressed.connect(clear)
 		button_row.add_child(button_clear)
 
@@ -797,6 +794,8 @@ class ListEntry extends VBoxContainer:
 						else:
 							draw_rect(rect, Color(.15, .15, .15, 1.))
 						button_enabled.set_pressed_no_signal(!resource.is_enabled())
+						button_highlight.self_modulate = Color("FC7F7F") if is_highlighted else Color.WHITE
+						self_modulate = resource.get_highlight_color()
 				name_label.add_theme_font_size_override("font_size", 4 + rect.size.x/10)
 				if drop_data:
 					draw_style_box(focus_style, rect)

--- a/src/terrain_3d_instancer.cpp
+++ b/src/terrain_3d_instancer.cpp
@@ -154,15 +154,20 @@ void Terrain3DInstancer::_update_mmis(const Vector2i &p_region_loc, const int p_
 					mmi->set_multimesh(mm);
 					mmi->set_cast_shadows_setting(ma->get_lod_cast_shadows(lod));
 					_setup_mmi_lod_ranges(mmi, ma, lod);
-					Ref<Material> mat = ma->get_material_override();
+					// Setup materials
+					Ref<Material> mat = ma->get_highlight_material();
 					if (mat.is_valid()) {
 						mmi->set_material_override(mat);
+					} else {
+						mat = ma->get_material_override();
+						if (mat.is_valid()) {
+							mmi->set_material_override(mat);
+						}
+						mat = ma->get_material_overlay();
+						if (mat.is_valid()) {
+							mmi->set_material_overlay(mat);
+						}
 					}
-					mat = ma->get_material_overlay_internal();
-					if (mat.is_valid()) {
-						mmi->set_material_overlay(mat);
-					}
-
 					// Reposition the MMI to its region location
 					Transform3D t = Transform3D();
 					int region_size = region->get_region_size();

--- a/src/terrain_3d_instancer.cpp
+++ b/src/terrain_3d_instancer.cpp
@@ -158,7 +158,7 @@ void Terrain3DInstancer::_update_mmis(const Vector2i &p_region_loc, const int p_
 					if (mat.is_valid()) {
 						mmi->set_material_override(mat);
 					}
-					mat = ma->get_material_overlay();
+					mat = ma->get_material_overlay_internal();
 					if (mat.is_valid()) {
 						mmi->set_material_overlay(mat);
 					}

--- a/src/terrain_3d_mesh_asset.cpp
+++ b/src/terrain_3d_mesh_asset.cpp
@@ -118,6 +118,7 @@ Ref<Material> Terrain3DMeshAsset::_get_material() {
 
 Terrain3DMeshAsset::Terrain3DMeshAsset() {
 	clear();
+	set_highlighted(false);
 }
 
 void Terrain3DMeshAsset::clear() {
@@ -334,6 +335,13 @@ void Terrain3DMeshAsset::set_material_overlay(const Ref<Material> &p_material) {
 	emit_signal("instancer_setting_changed");
 }
 
+void Terrain3DMeshAsset::set_material_overlay_internal(const Ref<Material> &p_material) {
+	LOG(INFO, _name, ": Setting material overlay: ", p_material);
+	_material_overlay_internal = p_material;
+	LOG(DEBUG, "Emitting setting_changed");
+	emit_signal("instancer_setting_changed");
+}
+
 void Terrain3DMeshAsset::set_generated_faces(const int p_count) {
 	if (_generated_faces != p_count) {
 		_generated_faces = CLAMP(p_count, 1, 3);
@@ -433,6 +441,30 @@ void Terrain3DMeshAsset::set_fade_margin(const real_t p_fade_margin) {
 	emit_signal("instancer_setting_changed");
 }
 
+void Terrain3DMeshAsset::set_highlighted(const bool p_highlighted) {
+	_highlighted = p_highlighted;
+	if (p_highlighted) {
+		LOG(INFO, "Highlighting mesh: ", _name);
+		if (!_highlight_mat.is_valid()) {
+			_highlight_mat.instantiate();
+			_highlight_mat->set_grow_enabled(true);
+			_highlight_mat->set_grow(0.01);
+			Color color;
+			real_t random_float = real_t(rand()) / RAND_MAX;
+			color.set_hsv(random_float, 1.0, 1.0, 1.0);
+			_highlight_mat->set_albedo(color);
+		}
+		if (!_highlight_mat.is_valid()) {
+			LOG(ERROR, "Failed to get or instantiate highlight material");
+			return;
+		}
+		set_material_overlay_internal(_highlight_mat);
+	} else {
+		LOG(INFO, "Unhighlighting mesh: ", _name);
+		set_material_overlay_internal(get_material_overlay());
+	}
+}
+
 ///////////////////////////
 // Protected Functions
 ///////////////////////////
@@ -527,6 +559,9 @@ void Terrain3DMeshAsset::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("get_lod9_range"), &Terrain3DMeshAsset::get_lod9_range);
 	ClassDB::bind_method(D_METHOD("set_fade_margin", "distance"), &Terrain3DMeshAsset::set_fade_margin);
 	ClassDB::bind_method(D_METHOD("get_fade_margin"), &Terrain3DMeshAsset::get_fade_margin);
+
+	ClassDB::bind_method(D_METHOD("set_highlighted", "highlight_state"), &Terrain3DMeshAsset::set_highlighted);
+	ClassDB::bind_method(D_METHOD("get_highlighted"), &Terrain3DMeshAsset::get_highlighted);
 
 	ADD_PROPERTY(PropertyInfo(Variant::STRING, "name", PROPERTY_HINT_NONE), "set_name", "get_name");
 	ADD_PROPERTY(PropertyInfo(Variant::INT, "id", PROPERTY_HINT_NONE), "set_id", "get_id");

--- a/src/terrain_3d_mesh_asset.h
+++ b/src/terrain_3d_mesh_asset.h
@@ -8,6 +8,7 @@
 #include <godot_cpp/classes/material.hpp>
 #include <godot_cpp/classes/packed_scene.hpp>
 #include <godot_cpp/classes/resource.hpp>
+#include <godot_cpp/classes/standard_material3d.hpp>
 #include <godot_cpp/classes/texture2d.hpp>
 
 #include "constants.h"
@@ -45,6 +46,9 @@ private:
 	ShadowCasting _cast_shadows = SHADOWS_ON;
 	Ref<Material> _material_override;
 	Ref<Material> _material_overlay;
+	Ref<Material> _material_overlay_internal;
+
+	bool _highlighted = false;
 	int _generated_faces = 2;
 	Vector2 _generated_size = Vector2(1.f, 1.f);
 	int _last_lod = MAX_LOD_COUNT - 1;
@@ -52,6 +56,8 @@ private:
 	int _shadow_impostor = 0;
 	PackedFloat32Array _lod_ranges;
 	real_t _fade_margin = 0.f;
+
+	Ref<StandardMaterial3D> _highlight_mat;
 
 	// Working data
 	TypedArray<Mesh> _meshes;
@@ -90,7 +96,9 @@ public:
 	void set_material_override(const Ref<Material> &p_material);
 	Ref<Material> get_material_override() const { return _material_override; }
 	void set_material_overlay(const Ref<Material> &p_material);
+	void set_material_overlay_internal(const Ref<Material> &p_material);
 	Ref<Material> get_material_overlay() const { return _material_overlay; }
+	Ref<Material> get_material_overlay_internal() const { return _material_overlay_internal; }
 
 	void set_generated_faces(const int p_count);
 	int get_generated_faces() const { return _generated_faces; }
@@ -130,6 +138,8 @@ public:
 	void set_lod9_range(const real_t p_distance) { set_lod_range(9, p_distance); }
 	real_t get_lod9_range() const { return _lod_ranges[9]; }
 	void set_fade_margin(const real_t p_fade_margin);
+	void set_highlighted(const bool p_highlighted);
+	bool get_highlighted() const { return _highlighted; }
 	real_t get_fade_margin() const { return _fade_margin; };
 
 protected:

--- a/src/terrain_3d_mesh_asset.h
+++ b/src/terrain_3d_mesh_asset.h
@@ -8,7 +8,6 @@
 #include <godot_cpp/classes/material.hpp>
 #include <godot_cpp/classes/packed_scene.hpp>
 #include <godot_cpp/classes/resource.hpp>
-#include <godot_cpp/classes/standard_material3d.hpp>
 #include <godot_cpp/classes/texture2d.hpp>
 
 #include "constants.h"
@@ -46,9 +45,6 @@ private:
 	ShadowCasting _cast_shadows = SHADOWS_ON;
 	Ref<Material> _material_override;
 	Ref<Material> _material_overlay;
-	Ref<Material> _material_overlay_internal;
-
-	bool _highlighted = false;
 	int _generated_faces = 2;
 	Vector2 _generated_size = Vector2(1.f, 1.f);
 	int _last_lod = MAX_LOD_COUNT - 1;
@@ -57,9 +53,9 @@ private:
 	PackedFloat32Array _lod_ranges;
 	real_t _fade_margin = 0.f;
 
-	Ref<StandardMaterial3D> _highlight_mat;
-
 	// Working data
+	bool _highlighted = false;
+	Ref<Material> _highlight_mat;
 	TypedArray<Mesh> _meshes;
 	Ref<Texture2D> _thumbnail;
 
@@ -96,9 +92,12 @@ public:
 	void set_material_override(const Ref<Material> &p_material);
 	Ref<Material> get_material_override() const { return _material_override; }
 	void set_material_overlay(const Ref<Material> &p_material);
-	void set_material_overlay_internal(const Ref<Material> &p_material);
 	Ref<Material> get_material_overlay() const { return _material_overlay; }
-	Ref<Material> get_material_overlay_internal() const { return _material_overlay_internal; }
+
+	void set_highlighted(const bool p_highlighted);
+	bool is_highlighted() const { return _highlighted; }
+	Ref<Material> get_highlight_material() const { return _highlighted ? _highlight_mat : Ref<Material>(); }
+	Color get_highlight_color() const;
 
 	void set_generated_faces(const int p_count);
 	int get_generated_faces() const { return _generated_faces; }
@@ -138,8 +137,6 @@ public:
 	void set_lod9_range(const real_t p_distance) { set_lod_range(9, p_distance); }
 	real_t get_lod9_range() const { return _lod_ranges[9]; }
 	void set_fade_margin(const real_t p_fade_margin);
-	void set_highlighted(const bool p_highlighted);
-	bool get_highlighted() const { return _highlighted; }
 	real_t get_fade_margin() const { return _fade_margin; };
 
 protected:


### PR DESCRIPTION
Adds a new icon to the asset dock mesh entry container. When checked the selected mesh asset will be highlighted on the ground in a random, highly saturated colour.

It temporarily swaps out the geometry instance overlay material (if it exists) and restores it when no longer highlighting this asset.
