### PR TITLE
Add foliage instance counter to asset dock as noted in #43

### DIFF
--- a/project/addons/terrain_3d/src/asset_dock.tscn
+++ b/project/addons/terrain_3d/src/asset_dock.tscn
@@ -1,6 +1,6 @@
 [gd_scene load_steps=2 format=3 uid="uid://dkb6hii5e48m2"]
 
-[ext_resource type="Script" path="res://addons/terrain_3d/src/asset_dock.gd" id="1_e23pg"]
+[ext_resource type="Script" uid="uid://bgoifepft1hjw" path="res://addons/terrain_3d/src/asset_dock.gd" id="1_e23pg"]
 
 [node name="Terrain3D" type="PanelContainer"]
 custom_minimum_size = Vector2(256, 95)
@@ -43,6 +43,7 @@ size_flags_vertical = 0
 selected = 7
 item_count = 9
 popup/item_0/text = "Left_UL"
+popup/item_0/id = 0
 popup/item_1/text = "Left_BL"
 popup/item_1/id = 1
 popup/item_2/text = "Left_UR"
@@ -66,7 +67,7 @@ layout_mode = 2
 size_flags_horizontal = 3
 min_value = 66.0
 max_value = 230.0
-value = 83.0
+value = 90.0
 
 [node name="Floating" type="Button" parent="Box/Buttons"]
 layout_mode = 2

--- a/project/demo/assets/models/LODExample.tscn
+++ b/project/demo/assets/models/LODExample.tscn
@@ -34,6 +34,7 @@ radial_segments = 4
 
 [sub_resource type="StandardMaterial3D" id="StandardMaterial3D_xl2nj"]
 cull_mode = 2
+albedo_color = Color(0.6205, 0.31, 1, 1)
 
 [node name="TestMultimesh" type="Node3D"]
 

--- a/src/terrain_3d_instancer.cpp
+++ b/src/terrain_3d_instancer.cpp
@@ -138,11 +138,9 @@ void Terrain3DInstancer::_update_mmis(const Vector2i &p_region_loc, const int p_
 					// Create MM and assign to MMI
 					mmi = cell_mmi_dict[cell];
 
-					// Update count : Subtract previous count for this cell
-					if (ma.is_valid() && mmi->get_multimesh().is_valid()) {
-						if (lod == ma->get_last_lod()) {
-							ma->update_instance_count(-mmi->get_multimesh()->get_instance_count());
-						}
+					// Update instance count: Subtract previous count for this cell
+					if (mmi->get_multimesh().is_valid() && lod == ma->get_last_lod()) {
+						ma->update_instance_count(-mmi->get_multimesh()->get_instance_count());
 					}
 					Ref<MultiMesh> mm;
 					if (lod == Terrain3DMeshAsset::SHADOW_LOD_ID) {
@@ -182,12 +180,9 @@ void Terrain3DInstancer::_update_mmis(const Vector2i &p_region_loc, const int p_
 					t.origin.x += region_loc.x * region_size * vertex_spacing;
 					t.origin.z += region_loc.y * region_size * vertex_spacing;
 					mmi->set_global_transform(t);
-
-					// Update count : Add current count for this cell
-					if (ma.is_valid() && mmi->get_multimesh().is_valid()) {
-						if (lod == ma->get_last_lod()) {
-							ma->update_instance_count(mmi->get_multimesh()->get_instance_count());
-						}
+					// Update instance count: Add current count for this cell
+					if (lod == ma->get_last_lod()) {
+						ma->update_instance_count(mm->get_instance_count());
 					}
 					// Clear the cell modified state
 					triple[2] = false;
@@ -310,7 +305,7 @@ void Terrain3DInstancer::_destroy_mmi_by_cell(const Vector2i &p_region_loc, cons
 		}
 
 		MultiMeshInstance3D *mmi = cell_mmi_dict[p_cell];
-		if (ma.is_valid() && mmi->get_multimesh().is_valid()) {
+		if (ma.is_valid() && mmi && mmi->get_multimesh().is_valid()) {
 			if (lod == ma->get_last_lod()) {
 				ma->update_instance_count(-mmi->get_multimesh()->get_instance_count());
 			}

--- a/src/terrain_3d_mesh_asset.cpp
+++ b/src/terrain_3d_mesh_asset.cpp
@@ -170,8 +170,7 @@ void Terrain3DMeshAsset::update_instance_count(const uint32_t p_amount) {
 }
 
 void Terrain3DMeshAsset::set_instance_count(const uint32_t p_amount) {
-	uint64_t new_count = p_amount;
-	_instance_count = CLAMP(new_count, 0, UINT32_MAX);
+	_instance_count = CLAMP(p_amount, 0, UINT32_MAX);
 	emit_signal("instance_count_changed");
 }
 

--- a/src/terrain_3d_mesh_asset.cpp
+++ b/src/terrain_3d_mesh_asset.cpp
@@ -163,6 +163,18 @@ void Terrain3DMeshAsset::set_enabled(const bool p_enabled) {
 	emit_signal("instancer_setting_changed");
 }
 
+void Terrain3DMeshAsset::update_instance_count(const uint32_t p_amount) {
+	uint64_t new_count = _instance_count + p_amount;
+	_instance_count = CLAMP(new_count, 0, UINT32_MAX);
+	emit_signal("instance_count_changed");
+}
+
+void Terrain3DMeshAsset::set_instance_count(const uint32_t p_amount) {
+	uint64_t new_count = p_amount;
+	_instance_count = CLAMP(new_count, 0, UINT32_MAX);
+	emit_signal("instance_count_changed");
+}
+
 void Terrain3DMeshAsset::set_scene_file(const Ref<PackedScene> &p_scene_file) {
 	LOG(INFO, "Setting scene file and instantiating node: ", p_scene_file);
 	_packed_scene = p_scene_file;
@@ -489,6 +501,7 @@ void Terrain3DMeshAsset::_bind_methods() {
 	ADD_SIGNAL(MethodInfo("file_changed"));
 	ADD_SIGNAL(MethodInfo("setting_changed"));
 	ADD_SIGNAL(MethodInfo("instancer_setting_changed"));
+	ADD_SIGNAL(MethodInfo("instance_count_changed"));
 
 	ClassDB::bind_method(D_METHOD("clear"), &Terrain3DMeshAsset::clear);
 	ClassDB::bind_method(D_METHOD("set_name", "name"), &Terrain3DMeshAsset::set_name);
@@ -556,6 +569,8 @@ void Terrain3DMeshAsset::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("get_lod9_range"), &Terrain3DMeshAsset::get_lod9_range);
 	ClassDB::bind_method(D_METHOD("set_fade_margin", "distance"), &Terrain3DMeshAsset::set_fade_margin);
 	ClassDB::bind_method(D_METHOD("get_fade_margin"), &Terrain3DMeshAsset::get_fade_margin);
+
+	ClassDB::bind_method(D_METHOD("get_instance_count"), &Terrain3DMeshAsset::get_instance_count);
 
 	ADD_PROPERTY(PropertyInfo(Variant::STRING, "name", PROPERTY_HINT_NONE), "set_name", "get_name");
 	ADD_PROPERTY(PropertyInfo(Variant::INT, "id", PROPERTY_HINT_NONE), "set_id", "get_id");

--- a/src/terrain_3d_mesh_asset.h
+++ b/src/terrain_3d_mesh_asset.h
@@ -58,6 +58,7 @@ private:
 	Ref<Material> _highlight_mat;
 	TypedArray<Mesh> _meshes;
 	Ref<Texture2D> _thumbnail;
+	uint32_t _instance_count = 0;
 
 	void _clear_lod_ranges();
 	static bool _sort_lod_nodes(const Node *a, const Node *b);
@@ -75,6 +76,10 @@ public:
 	int get_id() const override { return _id; }
 	void set_enabled(const bool p_enabled);
 	bool is_enabled() const { return _enabled; }
+
+	void update_instance_count(const uint32_t p_amount);
+	void set_instance_count(const uint32_t p_amount);
+	uint32_t get_instance_count() const { return _instance_count; }
 
 	void set_scene_file(const Ref<PackedScene> &p_scene_file);
 	Ref<PackedScene> get_scene_file() const { return _packed_scene; }


### PR DESCRIPTION
Admin edit: Closes #546

Adds a counter label to the asset dock.

![image](https://github.com/user-attachments/assets/0a08f588-626b-4b9e-be1d-5b262fcb7960)
