### PR TITLE
Duplicate meshes on create Terrain3DMeshAssets from scene file

### DIFF
--- a/src/terrain_3d_mesh_asset.cpp
+++ b/src/terrain_3d_mesh_asset.cpp
@@ -215,7 +215,8 @@ void Terrain3DMeshAsset::set_scene_file(const Ref<PackedScene> &p_scene_file) {
 				_name = _packed_scene->get_path().get_file().get_basename();
 				LOG(INFO, "Setting name based on filename: ", _name);
 			}
-			Ref<Mesh> mesh = mi->get_mesh();
+			// Duplicate the mesh to make each Terrain3DMeshAsset unique
+			Ref<Mesh> mesh = mi->get_mesh()->duplicate();
 			// Apply the active material from the scene to the mesh, including MI or Geom overrides
 			for (int j = 0; j < mi->get_surface_override_material_count(); j++) {
 				Ref<Material> mat = mi->get_active_material(j);


### PR DESCRIPTION
This solves a bug where MeshAssets could swap materials with other MeshAssets which share the same mesh resource. 

![image](https://github.com/user-attachments/assets/569a7b08-d124-4370-a6e2-d4d6abe28731)

These were my steps:

1. Add RockA.tscn in slot 3
2. Add RockB.tscn in slot 4
3. Add RockC.tscn in slot 5
4. Add CrystalC.tscn in slot 6
5. Hover mouse over slot 5 