### PR TITLE
Add fade to slope range tool settings when out of range

### DIFF
--- a/src/terrain_3d_data.h
+++ b/src/terrain_3d_data.h
@@ -168,7 +168,7 @@ public:
 	bool get_control_auto(const Vector3 &p_global_position) const;
 
 	Vector3 get_normal(const Vector3 &p_global_position) const;
-	bool is_in_slope(const Vector3 &p_global_position, const Vector2 &p_slope_range, const bool p_invert = false) const;
+	real_t is_in_slope(const Vector3 &p_global_position, const Vector2 &p_slope_range, const bool p_invert = false) const;
 	Vector3 get_texture_id(const Vector3 &p_global_position) const;
 	Vector3 get_mesh_vertex(const int32_t p_lod, const HeightFilter p_filter, const Vector3 &p_global_position) const;
 

--- a/src/terrain_3d_instancer.cpp
+++ b/src/terrain_3d_instancer.cpp
@@ -420,7 +420,7 @@ Array Terrain3DInstancer::_get_usable_height(const Vector3 &p_global_position, c
 		height = raycast_height;
 	}
 	// No hole or collision, use height if in slope or quit
-	else if (!data->is_in_slope(p_global_position, p_slope_range, p_invert)) {
+	else if (!(data->is_in_slope(p_global_position, p_slope_range, p_invert) >= 0.999f)) {
 		return Array();
 	}
 	Array triple;
@@ -715,7 +715,7 @@ void Terrain3DInstancer::remove_instances(const Vector3 &p_global_position, cons
 					Vector3 height_offset = t.basis.get_column(1) * mesh_height_offset;
 					if (radial_distance < radius &&
 							UtilityFunctions::randf() < CLAMP(0.175f * strength, 0.005f, 10.f) &&
-							data->is_in_slope(t.origin + global_local_offset - height_offset, slope_range, invert)) {
+							data->is_in_slope(t.origin + global_local_offset - height_offset, slope_range, invert) > 0.9999f) {
 						_backup_region(region);
 						continue;
 					} else {


### PR DESCRIPTION
Closes #725

example with the color map, painting red with a high slope limit, gives soft edges outside the range when painting.

<img width="1298" height="796" alt="image" src="https://github.com/user-attachments/assets/64c83500-0e24-4fcc-beda-4d8716c128c1" />

any time the original was "true" will still be 1.0 here, only the false conditions get faded out here.