### PR TITLE
Remove Physics Interpolation for Godot 4.5+

### DIFF
--- a/src/terrain_3d_mesher.cpp
+++ b/src/terrain_3d_mesher.cpp
@@ -390,7 +390,10 @@ void Terrain3DMesher::snap() {
 				t = t.scaled(lod_scale);
 				t.origin += pos;
 				RS->instance_set_transform(mesh_array[instance], t);
+// Deprecated Godot 4.5+
+#if GODOT_VERSION_MAJOR == 4 && GODOT_VERSION_MINOR == 4
 				RS->instance_reset_physics_interpolation(mesh_array[instance]);
+#endif
 			}
 		}
 	}


### PR DESCRIPTION
Physics Interpolation is apparently removed in 4.5.
https://github.com/godotengine/godot-docs/issues/11119#issuecomment-3102014671
https://github.com/godotengine/godot/pull/104269

This PR gates instance_reset_physics_interpolation limiting it to 4.4.

Tested this build on 4.5b3 w/ PI enabled in the project settings and ensured it doesn't break the terrain. 

Fixes #771 