### PR TITLE
fix - "Channel Packer" menu is hard to see in light UI theme

### DIFF
--- a/project/addons/terrain_3d/menu/channel_packer.gd
+++ b/project/addons/terrain_3d/menu/channel_packer.gd
@@ -115,6 +115,9 @@ func pack_textures_popup() -> void:
 
 	(window.find_child("PackButton") as Button).pressed.connect(_on_pack_button_pressed)
 
+	# This method will also be called if the `window` is inited and the editor's theme had changed.
+	prepare_theme()
+
 
 func _on_close_requested() -> void:
 	last_file_selected_fn = no_op
@@ -463,3 +466,26 @@ func _pack_textures(p_rgb_image: Image, p_a_image: Image, p_dst_path: String, p_
 	else:
 		_show_message(ERROR, "Failed to load one or more textures")
 		return FAILED
+
+
+func prepare_theme() -> void:
+	# If the `window` is not inited, do not prepare theme.
+	if window == null:
+		return
+
+	var editor_theme := EditorInterface.get_editor_theme()
+
+	var main_panel_stylebox: StyleBoxFlat = window.find_child("PanelContainer").get_theme_stylebox("panel")
+	main_panel_stylebox.bg_color = editor_theme.get_color("background", "Editor")
+
+	var alb_nrm_stylebox: StyleBoxFlat = window.find_child("AlbedoHeightPanel").get_theme_stylebox("panel")
+	alb_nrm_stylebox.bg_color = editor_theme.get_color("base_color", "Editor")
+	alb_nrm_stylebox.border_color = editor_theme.get_color("contrast_color_1", "Editor")
+
+	window.print_tree_pretty()
+	var img_drop_box_stylebox: StyleBoxFlat = window.get_node(
+		"PanelContainer/MarginContainer/VBoxContainer/AlbedoHeightPanel/MarginContainer/HBoxContainer/AlbedoVBox/MarginContainer/Panel"
+	).get_theme_stylebox("panel")
+	# The following line seems not setting the colour.
+	img_drop_box_stylebox.bg_color = editor_theme.get_color("dark_color_1", "Editor")
+	img_drop_box_stylebox.border_color = editor_theme.get_color("contrast_color_2", "Editor")

--- a/project/addons/terrain_3d/menu/channel_packer.tscn
+++ b/project/addons/terrain_3d/menu/channel_packer.tscn
@@ -1,28 +1,28 @@
 [gd_scene load_steps=7 format=3 uid="uid://nud6dwjcnj5v"]
 
 [sub_resource type="StyleBoxFlat" id="StyleBoxFlat_ysabf"]
-bg_color = Color(0.211765, 0.239216, 0.290196, 1)
+bg_color = Color(0.115499996, 0.132, 0.15949999, 1)
 
 [sub_resource type="StyleBoxFlat" id="StyleBoxFlat_lcvna"]
-bg_color = Color(0.168627, 0.211765, 0.266667, 1)
+bg_color = Color(0.21, 0.24, 0.29, 1)
 border_width_left = 3
 border_width_top = 3
 border_width_right = 3
 border_width_bottom = 3
-border_color = Color(0.270588, 0.435294, 0.580392, 1)
+border_color = Color(0.44700003, 0.468, 0.503, 1)
 corner_radius_top_left = 5
 corner_radius_top_right = 5
 corner_radius_bottom_right = 5
 corner_radius_bottom_left = 5
 
 [sub_resource type="StyleBoxFlat" id="StyleBoxFlat_cb0xf"]
-bg_color = Color(0.137255, 0.137255, 0.137255, 1)
+bg_color = Color(0.14699998, 0.16799998, 0.203, 1)
 draw_center = false
 border_width_left = 3
 border_width_top = 3
 border_width_right = 3
 border_width_bottom = 3
-border_color = Color(0.784314, 0.784314, 0.784314, 1)
+border_color = Color(0.5655, 0.582, 0.60950005, 1)
 corner_radius_top_left = 5
 corner_radius_top_right = 5
 corner_radius_bottom_right = 5

--- a/project/addons/terrain_3d/menu/terrain_menu.gd
+++ b/project/addons/terrain_3d/menu/terrain_menu.gd
@@ -48,6 +48,12 @@ func _enter_tree() -> void:
 	add_child(menu_button)
 
 
+func _notification(what: int) -> void:
+	match what:
+		Control.NOTIFICATION_THEME_CHANGED:
+			packer.prepare_theme()
+
+
 func _on_menu_pressed(p_id: int) -> void:
 	match p_id:
 		MENU_DIRECTORY_SETUP:


### PR DESCRIPTION
Changed fixed background colour to current editor theme colour, controlled by script.

The `tscn` file is changed because Godot reassign the value if there is a script setting that. Currently, the value is assigned in dark mode to keep consistency.

Fixes #777.

Effect now:

<img width="608" height="810" alt="image" src="https://github.com/user-attachments/assets/94ab8fdb-c7a8-4af9-83f2-9e5af0655514" />

<img width="608" height="810" alt="image" src="https://github.com/user-attachments/assets/07c52466-a011-4c54-a7c4-4fae6d70f3ca" />
