### PR TITLE
Avoid double update of asset dock

### DIFF
--- a/project/addons/terrain_3d/src/asset_dock.gd
+++ b/project/addons/terrain_3d/src/asset_dock.gd
@@ -18,6 +18,7 @@ const ES_DOCK_TAB: String = "terrain3d/dock/tab"
 var texture_list: ListContainer
 var mesh_list: ListContainer
 var _current_list: ListContainer
+var _updating_list: bool
 var _last_thumb_update_time: int = 0
 const MAX_UPDATE_TIME: int = 1000
 
@@ -266,6 +267,9 @@ func _on_slider_changed(value: float) -> void:
 
 
 func _on_textures_pressed() -> void:
+	if _updating_list:
+		return
+	_updating_list = true
 	_current_list = texture_list
 	texture_list.update_asset_list()
 	texture_list.visible = true
@@ -276,9 +280,13 @@ func _on_textures_pressed() -> void:
 	if plugin.is_terrain_valid():
 		EditorInterface.edit_node(plugin.terrain)
 	save_editor_settings()
+	_updating_list = false
 
 
 func _on_meshes_pressed() -> void:
+	if _updating_list:
+		return
+	_updating_list = true
 	_current_list = mesh_list
 	mesh_list.update_asset_list()
 	mesh_list.visible = true
@@ -290,6 +298,7 @@ func _on_meshes_pressed() -> void:
 		EditorInterface.edit_node(plugin.terrain)
 	update_thumbnails()
 	save_editor_settings()
+	_updating_list = false
 
 
 func _on_tool_changed(p_tool: Terrain3DEditor.Tool, p_operation: Terrain3DEditor.Operation) -> void:

--- a/project/addons/terrain_3d/src/asset_dock.gd
+++ b/project/addons/terrain_3d/src/asset_dock.gd
@@ -461,6 +461,7 @@ class ListContainer extends Container:
 	var height: float = 0
 	var width: float = 83
 	var focus_style: StyleBox
+	var _clearing_resource: bool = false
 
 	
 	func _ready() -> void:
@@ -573,7 +574,10 @@ class ListContainer extends Container:
 	
 	
 	func _on_resource_changed(p_resource: Resource, p_id: int) -> void:
+		if not p_resource and _clearing_resource:
+			return
 		if not p_resource:
+			_clearing_resource = true
 			var asset_dock: Control = get_parent().get_parent().get_parent()
 			if type == Terrain3DAssets.TYPE_TEXTURE:
 				asset_dock.confirm_dialog.dialog_text = "Are you sure you want to clear this texture?"
@@ -583,6 +587,7 @@ class ListContainer extends Container:
 			await asset_dock.confirmation_closed
 			if not asset_dock._confirmed:
 				update_asset_list()
+				_clearing_resource = false
 				return
 			
 		if not plugin.is_terrain_valid():
@@ -607,6 +612,7 @@ class ListContainer extends Container:
 			if p_id == entries.size()-2:
 				last_offset = 3
 			set_selected_id(clamp(selected_id, 0, entries.size() - last_offset))
+		_clearing_resource = false
 
 
 	func get_selected_id() -> int:

--- a/src/terrain_3d_mesh_asset.cpp
+++ b/src/terrain_3d_mesh_asset.cpp
@@ -250,7 +250,6 @@ void Terrain3DMeshAsset::set_scene_file(const Ref<PackedScene> &p_scene_file) {
 	_clear_lod_ranges();
 	notify_property_list_changed(); // Call _validate_property to update inspector
 	LOG(DEBUG, "Emitting file_changed");
-	emit_signal("file_changed");
 	emit_signal("instancer_setting_changed");
 }
 
@@ -277,7 +276,6 @@ void Terrain3DMeshAsset::set_generated_type(const GenType p_type) {
 	}
 	notify_property_list_changed(); // Call _validate_property to update inspector
 	LOG(DEBUG, "Emitting file_changed");
-	emit_signal("file_changed");
 	emit_signal("instancer_setting_changed");
 }
 
@@ -334,7 +332,6 @@ void Terrain3DMeshAsset::set_material_override(const Ref<Material> &p_material) 
 	LOG(INFO, _name, ": Setting material override: ", p_material);
 	_material_override = p_material;
 	LOG(DEBUG, "Emitting setting_changed");
-	emit_signal("setting_changed");
 	emit_signal("instancer_setting_changed");
 }
 
@@ -342,7 +339,6 @@ void Terrain3DMeshAsset::set_material_overlay(const Ref<Material> &p_material) {
 	LOG(INFO, _name, ": Setting material overlay: ", p_material);
 	_material_overlay = p_material;
 	LOG(DEBUG, "Emitting setting_changed");
-	emit_signal("setting_changed");
 	emit_signal("instancer_setting_changed");
 }
 
@@ -380,7 +376,6 @@ void Terrain3DMeshAsset::set_generated_faces(const int p_count) {
 				_material_override = _get_material();
 			}
 			LOG(DEBUG, "Emitting setting_changed");
-			emit_signal("setting_changed");
 			emit_signal("instancer_setting_changed");
 		}
 	}
@@ -396,7 +391,6 @@ void Terrain3DMeshAsset::set_generated_size(const Vector2 &p_size) {
 				_material_override = _get_material();
 			}
 			LOG(DEBUG, "Emitting setting_changed");
-			emit_signal("setting_changed");
 			emit_signal("instancer_setting_changed");
 		}
 	}


### PR DESCRIPTION
1. As documented in https://github.com/godotengine/godot/issues/109496, Godot prints an error when calling `EditorInterface.edit_node(plugin.terrain)` twice in one frame. This is triggered because we update the asset dock list twice when clicking the buttons - once from the button, and second from the tool change. This PR prevents the list from updating when it's already updating, due to multiple signals or quick double clicking, thus avoiding the error.

```
ERROR: Parameter "p_node" is null.
   at: is_ancestor_of (scene/main/node.cpp:2037)
ERROR: Must be an ancestor of the control.
   at: (scene/gui/scroll_container.cpp:293)
ERROR: Error calling deferred method: 'ScrollContainer::ScrollContainer::ensure_control_visible': Cannot convert argument 1 from Object to Object.
   at: _call_function (core/object/message_queue.cpp:222)
```

2. Prevent asset dock clear asset from asking twice.
3. Removes redundant signals