### PR TITLE
Adjust blend mode

### DIFF
--- a/project/addons/terrain_3d/src/tool_settings.gd
+++ b/project/addons/terrain_3d/src/tool_settings.gd
@@ -155,11 +155,9 @@ func _ready() -> void:
 								"list":color_list, "default":0, "unit":"°", "range":Vector3(0, 360, 1) })
 	add_setting({ "name":"random_darken", "type":SettingType.SLIDER, "list":color_list, "default":50, 
 								"unit":"%", "range":Vector3(0, 100, 1) })
-	#add_setting({ "name":"blend_mode", "type":SettingType.OPTION, "list":color_list, "default":0, 
-								#"range":Vector3(0, 3, 1) })
 
 	add_setting({ "name":"on_collision", "label":"On Collision", "type":SettingType.CHECKBOX, "list":main_list,
-								"default":true, "flags":ADD_SPACER  })
+								"default":true, "flags":ADD_SPACER })
 
 	if DisplayServer.is_touchscreen_available():
 		add_setting({ "name":"invert", "label":"Invert", "type":SettingType.CHECKBOX, "list":main_list, "default":false, "flags":ADD_SEPARATOR })

--- a/src/terrain_3d_editor.cpp
+++ b/src/terrain_3d_editor.cpp
@@ -380,27 +380,35 @@ void Terrain3DEditor::_operate_map(const Vector3 &p_global_position, const real_
 								if (enable_texture && brush_alpha * strength * 11.f > 0.1f) {
 									// Pick lowest weighted id, and lower to zero before setting new asset id.
 									if (asset_id != base_id && asset_id != overlay_id) {
-										if (blend >= 0.5f) {
-											blend = CLAMP(blend + brush_value, 0.f, 1.f);
+										if (modifier_alt) {
+											if (blend < 0.5f) {
+												overlay_id = asset_id;
+											} else {
+												base_id = asset_id;
+											}
 										} else {
-											blend = CLAMP(blend - brush_value, 0.f, 1.f);
-										}
-										if (blend <= 1.0f / 254.f) {
-											overlay_id = asset_id;
-										} else if (blend >= (1.f - 1.0f / 254.f)) {
-											base_id = asset_id;
+											if (blend >= 0.5f) {
+												blend = CLAMP(blend + brush_value, 0.f, 1.f);
+											} else {
+												blend = CLAMP(blend - brush_value, 0.f, 1.f);
+											}
+											if (blend <= 1.0f / 254.f) {
+												overlay_id = asset_id;
+											} else if (blend >= (1.f - 1.0f / 254.f)) {
+												base_id = asset_id;
+											}
 										}
 									}
 
 									if (base_id == asset_id) {
 										blend = CLAMP(blend - brush_value, 0.f, 1.f);
-										if (blend < 0.5f) {
+										if (brush_alpha > 0.5f && blend < 0.5f) {
 											autoshader = false;
 										}
 									}
 									if (overlay_id == asset_id) {
 										blend = CLAMP(blend + brush_value, 0.f, 1.f);
-										if (blend >= 0.5f) {
+										if (brush_alpha > 0.5f && blend >= 0.5f) {
 											autoshader = false;
 										}
 									}


### PR DESCRIPTION
Adjusts Spray blending

* Add toggleable alternate blend mode to Spray that instantly changes overlay texture instead of after a threshold. Difference is visible with debug_views_control_texture. (Experimental, may be temporary)
* Fixes Spray disabling autoshader in whole circle, while Paint only does brush_alpha > .5
