### PR TITLE
Fix instancer on_collision slope

### DIFF
--- a/doc/api/class_terrain3ddata.rst
+++ b/doc/api/class_terrain3ddata.rst
@@ -128,7 +128,7 @@ Methods
    +----------------------------------------------------------------------------+----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
    | |void|                                                                     | :ref:`import_images<class_Terrain3DData_method_import_images>`\ (\ images\: :ref:`Array<class_Array>`\[``Image``\], global_position\: ``Vector3`` = Vector3(0, 0, 0), offset\: ``float`` = 0.0, scale\: ``float`` = 1.0\ ) |
    +----------------------------------------------------------------------------+----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
-   | ``bool``                                                                   | :ref:`is_in_slope<class_Terrain3DData_method_is_in_slope>`\ (\ global_position\: ``Vector3``, slope_range\: ``Vector2``, invert\: ``bool`` = false\ ) |const|                                                              |
+   | ``bool``                                                                   | :ref:`is_in_slope<class_Terrain3DData_method_is_in_slope>`\ (\ global_position\: ``Vector3``, slope_range\: ``Vector2``, normal\: ``Vector3`` = Vector3(0, 0, 0)\ ) |const|                                                |
    +----------------------------------------------------------------------------+----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
    | ``bool``                                                                   | :ref:`is_region_deleted<class_Terrain3DData_method_is_region_deleted>`\ (\ region_location\: ``Vector2i``\ ) |const|                                                                                                       |
    +----------------------------------------------------------------------------+----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
@@ -973,9 +973,9 @@ Imports an Image set (Height, Control, Color) into this resource. It does NOT no
 
 .. rst-class:: classref-method
 
-``bool`` **is_in_slope**\ (\ global_position\: ``Vector3``, slope_range\: ``Vector2``, invert\: ``bool`` = false\ ) |const| :ref:`🔗<class_Terrain3DData_method_is_in_slope>`
+``bool`` **is_in_slope**\ (\ global_position\: ``Vector3``, slope_range\: ``Vector2``, normal\: ``Vector3`` = Vector3(0, 0, 0)\ ) |const| :ref:`🔗<class_Terrain3DData_method_is_in_slope>`
 
-Returns true if the slope of the terrain at the given position is within the slope range. If invert is true, it returns true if the position is outside the given range.
+Returns true if the slope of the terrain at the given position is within the slope range. If normal is provided it will use that instead of querying the terrain.
 
 .. rst-class:: classref-item-separator
 

--- a/doc/api/class_terrain3dinstancer.rst
+++ b/doc/api/class_terrain3dinstancer.rst
@@ -35,7 +35,7 @@ Data is currently stored in :ref:`Terrain3DRegion.instances<class_Terrain3DRegio
 
 - :ref:`remove_instances()<class_Terrain3DInstancer_method_remove_instances>` - Like add_instances, this is can be used procedurally but is designed for hand editing.
 
-- :ref:`clear_by_mesh()<class_Terrain3DInstancer_method_clear_by_mesh>`, :ref:`clear_by_location()<class_Terrain3DInstancer_method_clear_by_location>` - To erase large sections of instances
+- :ref:`clear_by_mesh()<class_Terrain3DInstancer_method_clear_by_mesh>`, :ref:`clear_by_location()<class_Terrain3DInstancer_method_clear_by_location>` - To erase large sections of instances.
 
 - Editing :ref:`Terrain3DRegion.instances<class_Terrain3DRegion_property_instances>` directly.
 
@@ -100,7 +100,7 @@ Method Descriptions
 
 |void| **add_instances**\ (\ global_position\: ``Vector3``, params\: ``Dictionary``\ ) :ref:`🔗<class_Terrain3DInstancer_method_add_instances>`
 
-Used by Terrain3DEditor to place instances given many brush parameters. In addition to the brush position, it also uses the following parameters: asset_id, size, strength, fixed_scale, random_scale, fixed_spin, random_spin, fixed_tilt, random_tilt, align_to_normal, height_offset, random_height, vertex_color, random_hue, random_darken. All of these settings are set in the editor through tool_settings.gd.
+Used by Terrain3DEditor to place instances given many brush parameters. In addition to the brush position, it also uses the following parameters: asset_id:int, size:float, strength:float, fixed_scale:float, random_scale:float, fixed_spin:float, random_spin:float, fixed_tilt:float, random_tilt:float, align_to_normal:bool, height_offset:float, random_height:float, vertex_color:Color, random_hue:float, random_darken:float, slope:Vector2, on_collision:bool, raycast_height:float. All of these settings are set in the editor via tool_settings.gd.
 
 .. rst-class:: classref-item-separator
 
@@ -230,7 +230,7 @@ Dumps the MultiMeshInstance3Ds attached to the tree and information about the no
 
 |void| **remove_instances**\ (\ global_position\: ``Vector3``, params\: ``Dictionary``\ ) :ref:`🔗<class_Terrain3DInstancer_method_remove_instances>`
 
-Uses parameters asset_id, size, strength, fixed_scale, random_scale, slope (Vector2), to randomly remove instances within the indicated brush position and size.
+Uses parameters asset_id:int, size:float, strength:float, slope:Vector2, on_collision:bool, raycast_height:float to randomly remove instances within the indicated brush position and size.
 
 .. rst-class:: classref-item-separator
 

--- a/doc/doc_classes/Terrain3DData.xml
+++ b/doc/doc_classes/Terrain3DData.xml
@@ -345,9 +345,9 @@
 			<return type="bool" />
 			<param index="0" name="global_position" type="Vector3" />
 			<param index="1" name="slope_range" type="Vector2" />
-			<param index="2" name="invert" type="bool" default="false" />
+			<param index="2" name="normal" type="Vector3" default="Vector3(0, 0, 0)" />
 			<description>
-				Returns true if the slope of the terrain at the given position is within the slope range. If invert is true, it returns true if the position is outside the given range.
+				Returns true if the slope of the terrain at the given position is within the slope range. If normal is provided it will use that instead of querying the terrain.
 			</description>
 		</method>
 		<method name="is_region_deleted" qualifiers="const">

--- a/doc/doc_classes/Terrain3DInstancer.xml
+++ b/doc/doc_classes/Terrain3DInstancer.xml
@@ -12,7 +12,7 @@
 		- Creating your own instance data and inserting it directly into [member Terrain3DRegion.instances]. It's not difficult to do this in GDScript, but a thorough understanding of the C++ code in this class is recommended.
 		[b]The methods available for removing instances are:[/b]
 		- [method remove_instances] - Like add_instances, this is can be used procedurally but is designed for hand editing.
-		- [method clear_by_mesh], [method clear_by_location] - To erase large sections of instances
+		- [method clear_by_mesh], [method clear_by_location] - To erase large sections of instances.
 		- Editing [member Terrain3DRegion.instances] directly.
 		After modifying region data, run [method update_mmis] to rebuild the MultiMeshInstance3Ds.
 		[b]Read More:[/b]
@@ -27,7 +27,7 @@
 			<param index="0" name="global_position" type="Vector3" />
 			<param index="1" name="params" type="Dictionary" />
 			<description>
-				Used by Terrain3DEditor to place instances given many brush parameters. In addition to the brush position, it also uses the following parameters: asset_id, size, strength, fixed_scale, random_scale, fixed_spin, random_spin, fixed_tilt, random_tilt, align_to_normal, height_offset, random_height, vertex_color, random_hue, random_darken. All of these settings are set in the editor through tool_settings.gd.
+				Used by Terrain3DEditor to place instances given many brush parameters. In addition to the brush position, it also uses the following parameters: asset_id:int, size:float, strength:float, fixed_scale:float, random_scale:float, fixed_spin:float, random_spin:float, fixed_tilt:float, random_tilt:float, align_to_normal:bool, height_offset:float, random_height:float, vertex_color:Color, random_hue:float, random_darken:float, slope:Vector2, on_collision:bool, raycast_height:float. All of these settings are set in the editor via tool_settings.gd.
 			</description>
 		</method>
 		<method name="add_multimesh">
@@ -117,7 +117,7 @@
 			<param index="0" name="global_position" type="Vector3" />
 			<param index="1" name="params" type="Dictionary" />
 			<description>
-				Uses parameters asset_id, size, strength, fixed_scale, random_scale, slope (Vector2), to randomly remove instances within the indicated brush position and size.
+				Uses parameters asset_id:int, size:float, strength:float, slope:Vector2, on_collision:bool, raycast_height:float to randomly remove instances within the indicated brush position and size.
 			</description>
 		</method>
 		<method name="swap_ids">

--- a/project/addons/terrain_3d/src/editor_plugin.gd
+++ b/project/addons/terrain_3d/src/editor_plugin.gd
@@ -365,6 +365,8 @@ func consume_hotkey(keycode: int) -> bool:
 			ui.toolbar.get_button("SprayTexture").set_pressed(true)
 		KEY_A:
 			ui.toolbar.get_button("PaintAutoshader").set_pressed(true)
+		KEY_T:
+			ui.tool_settings.inverse_slope_range()
 		_:
 			return false
 	return true

--- a/project/addons/terrain_3d/src/tool_settings.gd
+++ b/project/addons/terrain_3d/src/tool_settings.gd
@@ -572,8 +572,7 @@ func get_setting(p_setting: String) -> Variant:
 	if object is Range:
 		value = object.get_value()
 		# Adjust widths of all sliders on update of values
-		var digits: float = count_digits(value)
-		var width: float = clamp( (1 + count_digits(value)) * 19., 50, 80) * clamp(EditorInterface.get_editor_scale(), .9, 2)
+		var width: float = clamp( (1 + _count_digits(value)) * 19., 50, 80) * clamp(EditorInterface.get_editor_scale(), .9, 2)
 		object.set_custom_minimum_size(Vector2(width, 0))
 	elif object is DoubleSlider:
 		value = object.get_value()
@@ -676,7 +675,7 @@ func _get_brush_preview_material() -> ShaderMaterial:
 
 
 # Counts digits of a number including negative sign, decimal points, and up to 3 decimals 
-func count_digits(p_value: float) -> int:
+func _count_digits(p_value: float) -> int:
 	var count: int = 1
 	for i in range(5, 0, -1):
 		if abs(p_value) >= pow(10, i):
@@ -694,4 +693,21 @@ func count_digits(p_value: float) -> int:
 	if p_value < 0:
 		count += 1
 	return count
-	
+
+
+func inverse_slope_range() -> void:
+	var slope_range: Vector2 = get_setting("slope")
+	if slope_range.y - slope_range.x > 89.99:
+		return
+	if slope_range.x == 0.0:
+		slope_range = Vector2(slope_range.y, 90.0)
+	elif slope_range.y == 90.0:
+		slope_range = Vector2(0.0, slope_range.x)
+	else:
+		# If midpoint <= 45, inverse to 90, else to 0
+		var midpoint: float = 0.5 * (slope_range.x + slope_range.y)
+		if midpoint <= 45.0:
+			slope_range = Vector2(slope_range.y, 90.0)
+		else:
+			slope_range = Vector2(0.0, slope_range.x)
+	set_setting("slope", slope_range)

--- a/src/constants.h
+++ b/src/constants.h
@@ -37,6 +37,7 @@ using namespace godot;
 #define V3_(x) Vector3(x, 0.f, x)
 #define V3_ZERO Vector3(0.f, 0.f, 0.f)
 #define V3_MAX Vector3(FLT_MAX, FLT_MAX, FLT_MAX)
+static const Vector3 V3_UP{ 0.f, 1.f, 0.f };
 
 // Terrain3D::_warnings is uint8_t
 #define WARN_MISMATCHED_SIZE 0x01

--- a/src/constants.h
+++ b/src/constants.h
@@ -29,14 +29,14 @@ using namespace godot;
 
 #define V2(x) Vector2(x, x)
 #define V2I(x) Vector2i(x, x)
-#define V2_ZERO Vector2(0.f, 0.f)
-#define V2I_ZERO Vector2i(0, 0)
-#define V2_MAX Vector2(FLT_MAX, FLT_MAX)
-#define V2I_MAX Vector2i(INT32_MAX, INT32_MAX)
 #define V3(x) Vector3(x, x, x)
-#define V3_(x) Vector3(x, 0.f, x)
-#define V3_ZERO Vector3(0.f, 0.f, 0.f)
-#define V3_MAX Vector3(FLT_MAX, FLT_MAX, FLT_MAX)
+static const Vector2 V2_ZERO{ 0.f, 0.f };
+static const Vector2 V2_MAX{ FLT_MAX, FLT_MAX };
+static const Vector2i V2I_ZERO{ 0, 0 };
+static const Vector2i V2I_MAX{ INT32_MAX, INT32_MAX };
+static const Vector3 V3_ZERO{ 0.f, 0.f, 0.f };
+static const Vector3 V3_MAX{ FLT_MAX, FLT_MAX, FLT_MAX };
+static const Vector3 V3_NAN{ NAN, NAN, NAN };
 static const Vector3 V3_UP{ 0.f, 1.f, 0.f };
 
 // Terrain3D::_warnings is uint8_t

--- a/src/terrain_3d.cpp
+++ b/src/terrain_3d.cpp
@@ -201,7 +201,7 @@ void Terrain3D::_setup_mouse_picking() {
 	_mouse_vp = memnew(SubViewport);
 	_mouse_vp->set_name("MouseViewport");
 	add_child(_mouse_vp, true);
-	_mouse_vp->set_size(Vector2i(2, 2));
+	_mouse_vp->set_size(V2I(2));
 	_mouse_vp->set_scaling_3d_mode(Viewport::SCALING_3D_MODE_BILINEAR);
 	_mouse_vp->set_update_mode(SubViewport::UPDATE_ONCE);
 	_mouse_vp->set_handle_input_locally(false);
@@ -233,7 +233,7 @@ void Terrain3D::_setup_mouse_picking() {
 	_mouse_cam->add_child(_mouse_quad, true);
 	Ref<QuadMesh> quad;
 	quad.instantiate();
-	quad->set_size(Vector2(0.1f, 0.1f));
+	quad->set_size(V2(0.1f));
 	_mouse_quad->set_mesh(quad);
 	String shader_code = String(
 #include "shaders/gpu_depth.glsl"
@@ -541,7 +541,7 @@ void Terrain3D::set_region_size(const RegionSize p_size) {
 	_region_size = p_size;
 	if (_data) {
 		_data->_region_size = _region_size;
-		_data->_region_sizev = Vector2i(_region_size, _region_size);
+		_data->_region_sizev = V2I(_region_size);
 	}
 	if (_material.is_valid()) {
 		_material->_update_maps();
@@ -706,7 +706,7 @@ void Terrain3D::set_cull_margin(const real_t p_margin) {
 Vector3 Terrain3D::get_intersection(const Vector3 &p_src_pos, const Vector3 &p_direction, const bool p_gpu_mode) {
 	if (!_mouse_cam) {
 		LOG(ERROR, "Invalid mouse camera");
-		return Vector3(NAN, NAN, NAN);
+		return V3_NAN;
 	}
 	Vector3 direction = p_direction.normalized();
 	Vector3 point;
@@ -738,7 +738,7 @@ Vector3 Terrain3D::get_intersection(const Vector3 &p_src_pos, const Vector3 &p_d
 	} else {
 		// Else use GPU mode, which requires multiple calls
 		// Get depth from perspective camera snapshot
-		_mouse_cam->look_at(_mouse_cam->get_global_position() + direction, Vector3(0.f, 1.f, 0.f));
+		_mouse_cam->look_at(_mouse_cam->get_global_position() + direction, V3_UP);
 		_mouse_vp->set_update_mode(SubViewport::UPDATE_ONCE);
 		Ref<ViewportTexture> vp_tex = _mouse_vp->get_texture();
 		Ref<Image> vp_img = vp_tex->get_image();

--- a/src/terrain_3d_assets.cpp
+++ b/src/terrain_3d_assets.cpp
@@ -269,8 +269,8 @@ void Terrain3DAssets::_update_texture_files() {
 		albedo_size = normal_size;
 	}
 	if (albedo_size == V2I_ZERO) {
-		albedo_size = Vector2i(1024, 1024);
-		normal_size = Vector2i(1024, 1024);
+		albedo_size = V2I(1024);
+		normal_size = albedo_size;
 	}
 
 	// Generate TextureArrays and replace nulls with a empty image
@@ -392,12 +392,12 @@ void Terrain3DAssets::_setup_thumbnail_creation() {
 
 	_key_light = RS->directional_light_create();
 	_key_light_instance = RS->instance_create2(_key_light, _scenario);
-	RS->instance_set_transform(_key_light_instance, Transform3D().looking_at(Vector3(-1, -1, -1), Vector3(0, 1, 0)));
+	RS->instance_set_transform(_key_light_instance, Transform3D().looking_at(V3(-1), V3_UP));
 
 	_fill_light = RS->directional_light_create();
 	RS->light_set_color(_fill_light, Color(0.3, 0.3, 0.3));
 	_fill_light_instance = RS->instance_create2(_fill_light, _scenario);
-	RS->instance_set_transform(_fill_light_instance, Transform3D().looking_at(Vector3(0, 1, 0), Vector3(0, 0, 1)));
+	RS->instance_set_transform(_fill_light_instance, Transform3D().looking_at(V3_UP, Vector3(0, 0, 1)));
 
 	_mesh_instance = RS->instance_create();
 	RS->instance_set_scenario(_mesh_instance, _scenario);
@@ -550,7 +550,7 @@ void Terrain3DAssets::create_mesh_thumbnails(const int p_id, const Vector2i &p_s
 		start = CLAMP(p_id, 0, max - 1);
 		end = CLAMP(p_id + 1, 0, max);
 	}
-	Vector2i size = CLAMP(p_size, Vector2i(1, 1), Vector2i(4096, 4096));
+	Vector2i size = CLAMP(p_size, V2I(1), V2I(4096));
 
 	LOG(INFO, "Creating thumbnails for ids: ", start, " through ", end - 1);
 	for (int i = start; i < end; i++) {
@@ -582,7 +582,7 @@ void Terrain3DAssets::create_mesh_thumbnails(const int p_id, const Vector2i &p_s
 		Vector3 ofs = aabb.get_center();
 		aabb.position -= ofs;
 		Transform3D xform;
-		xform.basis = Basis().rotated(Vector3(0.f, 1.f, 0.f), -Math_PI * 0.125f);
+		xform.basis = Basis().rotated(V3_UP, -Math_PI * 0.125f);
 		xform.basis = Basis().rotated(Vector3(1.f, 0.f, 0.f), Math_PI * 0.125f) * xform.basis;
 		AABB rot_aabb = xform.xform(aabb);
 		real_t m = MAX(rot_aabb.size.x, rot_aabb.size.y) * 0.5f;
@@ -590,7 +590,7 @@ void Terrain3DAssets::create_mesh_thumbnails(const int p_id, const Vector2i &p_s
 			m = 1.f;
 		}
 		m = .5f / m;
-		xform.basis.scale(Vector3(m, m, m));
+		xform.basis.scale(V3(m));
 		xform.origin = -xform.basis.xform(ofs);
 		xform.origin.z -= rot_aabb.size.z * 2.f;
 		RS->instance_set_transform(_mesh_instance, xform);
@@ -716,7 +716,7 @@ void Terrain3DAssets::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("set_mesh_list", "mesh_list"), &Terrain3DAssets::set_mesh_list);
 	ClassDB::bind_method(D_METHOD("get_mesh_list"), &Terrain3DAssets::get_mesh_list);
 	ClassDB::bind_method(D_METHOD("get_mesh_count"), &Terrain3DAssets::get_mesh_count);
-	ClassDB::bind_method(D_METHOD("create_mesh_thumbnails", "id", "size"), &Terrain3DAssets::create_mesh_thumbnails, DEFVAL(-1), DEFVAL(Vector2i(128, 128)));
+	ClassDB::bind_method(D_METHOD("create_mesh_thumbnails", "id", "size"), &Terrain3DAssets::create_mesh_thumbnails, DEFVAL(-1), DEFVAL(V2I(128)));
 	ClassDB::bind_method(D_METHOD("update_mesh_list"), &Terrain3DAssets::update_mesh_list);
 
 	ClassDB::bind_method(D_METHOD("save", "path"), &Terrain3DAssets::save, DEFVAL(""));

--- a/src/terrain_3d_assets.h
+++ b/src/terrain_3d_assets.h
@@ -92,7 +92,7 @@ public:
 	void set_mesh_list(const TypedArray<Terrain3DMeshAsset> &p_mesh_list);
 	TypedArray<Terrain3DMeshAsset> get_mesh_list() const { return _mesh_list; }
 	int get_mesh_count() const { return _mesh_list.size(); }
-	void create_mesh_thumbnails(const int p_id = -1, const Vector2i &p_size = Vector2i(128, 128));
+	void create_mesh_thumbnails(const int p_id = -1, const Vector2i &p_size = V2I(128));
 	void update_mesh_list();
 
 	Error save(const String &p_path = "");

--- a/src/terrain_3d_collision.cpp
+++ b/src/terrain_3d_collision.cpp
@@ -110,7 +110,7 @@ Dictionary Terrain3DCollision::_get_shape_data(const Vector2i &p_position, const
 	// Non rotated shape for normal array index above
 	//Transform3D xform = Transform3D(Basis(), global_pos);
 	// Rotated shape Y=90 for -90 rotated array index
-	Transform3D xform = Transform3D(Basis(Vector3(0, 1.0, 0), Math_PI * .5), v2iv3(p_position + V2I(p_size / 2)));
+	Transform3D xform = Transform3D(Basis(V3_UP, Math_PI * .5), v2iv3(p_position + V2I(p_size / 2)));
 	Dictionary shape_data;
 	shape_data["width"] = hshape_size;
 	shape_data["depth"] = hshape_size;

--- a/src/terrain_3d_data.h
+++ b/src/terrain_3d_data.h
@@ -168,7 +168,7 @@ public:
 	bool get_control_auto(const Vector3 &p_global_position) const;
 
 	Vector3 get_normal(const Vector3 &p_global_position) const;
-	bool is_in_slope(const Vector3 &p_global_position, const Vector2 &p_slope_range, const bool p_invert = false) const;
+	bool is_in_slope(const Vector3 &p_global_position, const Vector2 &p_slope_range, const Vector3 &p_normal = V3_ZERO) const;
 	Vector3 get_texture_id(const Vector3 &p_global_position) const;
 	Vector3 get_mesh_vertex(const int32_t p_lod, const HeightFilter p_filter, const Vector3 &p_global_position) const;
 

--- a/src/terrain_3d_data.h
+++ b/src/terrain_3d_data.h
@@ -20,7 +20,7 @@ class Terrain3DData : public Object {
 public: // Constants
 	static inline const real_t CURRENT_VERSION = 0.93f;
 	static inline const int REGION_MAP_SIZE = 32;
-	static inline const Vector2i REGION_MAP_VSIZE = Vector2i(REGION_MAP_SIZE, REGION_MAP_SIZE);
+	static inline const Vector2i REGION_MAP_VSIZE = V2I(REGION_MAP_SIZE);
 
 	enum HeightFilter {
 		HEIGHT_FILTER_NEAREST,
@@ -32,7 +32,7 @@ private:
 
 	// Data Settings & flags
 	int _region_size = 0; // Set by Terrain3D::set_region_size
-	Vector2i _region_sizev = Vector2i(_region_size, _region_size);
+	Vector2i _region_sizev = V2I(_region_size);
 	real_t _vertex_spacing = 1.f; // Set by Terrain3D::set_vertex_spacing
 
 	AABB _edited_area;

--- a/src/terrain_3d_editor.cpp
+++ b/src/terrain_3d_editor.cpp
@@ -95,7 +95,7 @@ void Terrain3DEditor::_operate_map(const Vector3 &p_global_position, const real_
 	}
 
 	int region_size = _terrain->get_region_size();
-	Vector2i region_vsize = Vector2i(region_size, region_size);
+	Vector2i region_vsize = V2I(region_size);
 
 	// If no region and can't add one, skip whole function. Checked again later
 	Terrain3DData *data = _terrain->get_data();
@@ -184,7 +184,7 @@ void Terrain3DEditor::_operate_map(const Vector3 &p_global_position, const real_
 
 	for (real_t x = 0.f; x < brush_size; x += vertex_spacing) {
 		for (real_t y = 0.f; y < brush_size; y += vertex_spacing) {
-			Vector2 brush_offset = Vector2(x, y) - (Vector2(brush_size, brush_size) / 2.f);
+			Vector2 brush_offset = Vector2(x, y) - (V2(brush_size) * .5f);
 			Vector3 brush_global_position =
 					Vector3(p_global_position.x + brush_offset.x + .5f, p_global_position.y,
 							p_global_position.z + brush_offset.y + .5f);
@@ -788,7 +788,7 @@ void Terrain3DEditor::start_operation(const Vector3 &p_global_position) {
 	_terrain->get_instancer()->reset_density_counter();
 	_terrain->get_data()->clear_edited_area();
 	_operation_position = p_global_position;
-	_operation_movement = Vector3();
+	_operation_movement = V3_ZERO;
 }
 
 // Called on mouse movement with left mouse button down

--- a/src/terrain_3d_editor.cpp
+++ b/src/terrain_3d_editor.cpp
@@ -338,7 +338,7 @@ void Terrain3DEditor::_operate_map(const Vector3 &p_global_position, const real_
 
 				switch (_tool) {
 					case TEXTURE: {
-						if (!data->is_in_slope(brush_global_position, slope_range, modifier_alt)) {
+						if (!data->is_in_slope(brush_global_position, slope_range)) {
 							continue;
 						}
 						switch (_operation) {
@@ -502,7 +502,7 @@ void Terrain3DEditor::_operate_map(const Vector3 &p_global_position, const real_
 						continue;
 					}
 				}
-				if (!data->is_in_slope(brush_global_position, slope_range, modifier_alt)) {
+				if (!data->is_in_slope(brush_global_position, slope_range)) {
 					continue;
 				}
 				switch (_tool) {

--- a/src/terrain_3d_editor.h
+++ b/src/terrain_3d_editor.h
@@ -73,8 +73,8 @@ private:
 	Tool _tool = REGION;
 	Operation _operation = ADD;
 	Dictionary _brush_data;
-	Vector3 _operation_position = Vector3();
-	Vector3 _operation_movement = Vector3();
+	Vector3 _operation_position = V3_ZERO;
+	Vector3 _operation_movement = V3_ZERO;
 	Array _operation_movement_history;
 	bool _is_operating = false;
 	uint64_t _last_region_bounds_error = 0;
@@ -85,7 +85,7 @@ private:
 	Dictionary _undo_data; // See _get_undo_data for definition
 	uint64_t _last_pen_tick = 0;
 
-	void _send_region_aabb(const Vector2i &p_region_loc, const Vector2 &p_height_range = Vector2());
+	void _send_region_aabb(const Vector2i &p_region_loc, const Vector2 &p_height_range = V2_ZERO);
 	Ref<Terrain3DRegion> _operate_region(const Vector2i &p_region_loc);
 	void _operate_map(const Vector3 &p_global_position, const real_t p_camera_direction);
 	MapType _get_map_type() const;
@@ -163,9 +163,9 @@ inline Vector2 Terrain3DEditor::_get_uv_position(const Vector3 &p_global_positio
 }
 
 inline Vector2 Terrain3DEditor::_get_rotated_uv(const Vector2 &p_uv, const real_t p_angle) const {
-	Vector2 rotation_offset = Vector2(0.5f, 0.5f);
+	Vector2 rotation_offset = V2(0.5f);
 	Vector2 uv = (p_uv - rotation_offset).rotated(p_angle) + rotation_offset;
-	return uv.clamp(V2_ZERO, Vector2(1.f, 1.f));
+	return uv.clamp(V2_ZERO, V2(1.f));
 }
 
 #endif // TERRAIN3D_EDITOR_CLASS_H

--- a/src/terrain_3d_instancer.cpp
+++ b/src/terrain_3d_instancer.cpp
@@ -403,7 +403,7 @@ Ref<MultiMesh> Terrain3DInstancer::_create_multimesh(const int p_mesh_id, const 
 }
 
 Vector2i Terrain3DInstancer::_get_cell(const Vector3 &p_global_position, const int p_region_size) {
-	IS_INIT(Vector2i());
+	IS_INIT(V2I_ZERO);
 	real_t vertex_spacing = _terrain->get_vertex_spacing();
 	Vector2i cell;
 	cell.x = UtilityFunctions::posmod(UtilityFunctions::floori(p_global_position.x / vertex_spacing), p_region_size) / CELL_SIZE;
@@ -915,7 +915,7 @@ void Terrain3DInstancer::update_transforms(const AABB &p_aabb) {
 	LOG(EXTREME, "Updating transforms within ", rect);
 	Vector2 global_position = rect.get_center();
 	Vector2 size = rect.get_size();
-	Vector2 half_size = size * 0.5f + Vector2(1.f, 1.f); // 1m margin
+	Vector2 half_size = size * 0.5f + V2(1.f); // 1m margin
 	if (size == V2_ZERO) {
 		return;
 	}

--- a/src/terrain_3d_instancer.cpp
+++ b/src/terrain_3d_instancer.cpp
@@ -535,7 +535,6 @@ void Terrain3DInstancer::add_instances(const Vector3 &p_global_position, const D
 	real_t density = CLAMP(.1f * brush_size * strength * mesh_asset->get_density() /
 					MAX(0.01f, fixed_scale + .5f * random_scale),
 			.001f, 1000.f);
-
 	// Density based on strength, mesh AABB and input scale determines how many to place, even fractional
 	uint32_t count = _get_density_count(density);
 	if (count <= 0) {
@@ -556,7 +555,9 @@ void Terrain3DInstancer::add_instances(const Vector3 &p_global_position, const D
 	real_t random_hue = CLAMP(real_t(p_params.get("random_hue", 0.f)) / 360.f, 0.f, 1.f); // degrees -> 0-1
 	real_t random_darken = CLAMP(real_t(p_params.get("random_darken", 0.f)) * .01f, 0.f, 1.f); // 0-100%
 
-	Vector2 slope_range = p_params["slope"]; // 0-90 degrees already clamped in Editor
+	Vector2 slope_range = p_params.get("slope", Vector2(0.f, 90.f)); // 0-90 degrees
+	slope_range.x = CLAMP(slope_range.x, 0.f, 90.f);
+	slope_range.y = CLAMP(slope_range.y, 0.f, 90.f);
 	bool on_collision = bool(p_params.get("on_collision", false));
 	real_t raycast_height = p_params.get("raycast_height", 10.f);
 	Terrain3DData *data = _terrain->get_data();
@@ -647,9 +648,9 @@ void Terrain3DInstancer::remove_instances(const Vector3 &p_global_position, cons
 	real_t half_brush_size = brush_size * 0.5f + 1.f; // 1m margin
 	real_t radius = brush_size * .5f;
 	real_t strength = CLAMP(real_t(p_params.get("strength", .1f)), .01f, 100.f); // (premul) 1-10k%
-	real_t fixed_scale = CLAMP(real_t(p_params.get("fixed_scale", 100.f)) * .01f, .01f, 100.f); // 1-10k%
-	real_t random_scale = CLAMP(real_t(p_params.get("random_scale", 0.f)) * .01f, 0.f, 10.f); // +/- 1000%
-	Vector2 slope_range = p_params["slope"]; // 0-90 degrees already clamped in Editor
+	Vector2 slope_range = p_params.get("slope", Vector2(0.f, 90.f)); // 0-90 degrees
+	slope_range.x = CLAMP(slope_range.x, 0.f, 90.f);
+	slope_range.y = CLAMP(slope_range.y, 0.f, 90.f);
 	bool on_collision = bool(p_params.get("on_collision", false));
 	real_t raycast_height = p_params.get("raycast_height", 10.f);
 

--- a/src/terrain_3d_instancer.h
+++ b/src/terrain_3d_instancer.h
@@ -50,7 +50,7 @@ private:
 	void _backup_region(const Ref<Terrain3DRegion> &p_region);
 	Ref<MultiMesh> _create_multimesh(const int p_mesh_id, const int p_lod, const TypedArray<Transform3D> &p_xforms = TypedArray<Transform3D>(), const PackedColorArray &p_colors = PackedColorArray()) const;
 	Vector2i _get_cell(const Vector3 &p_global_position, const int p_region_size);
-	Array _get_usable_height(const Vector3 &p_global_position, const Vector2 &p_slope_range, const bool p_invert, const bool p_on_collision, const real_t p_raycast_start) const;
+	Array _get_usable_height(const Vector3 &p_global_position, const Vector2 &p_slope_range, const bool p_on_collision, const real_t p_raycast_start) const;
 
 public:
 	Terrain3DInstancer() {}

--- a/src/terrain_3d_mesh_asset.cpp
+++ b/src/terrain_3d_mesh_asset.cpp
@@ -42,11 +42,10 @@ Ref<ArrayMesh> Terrain3DMeshAsset::_get_generated_mesh() const {
 
 	int i, j, prevrow, thisrow, point = 0;
 	float x, z;
-	Size2 start_pos = Vector2(_generated_size.x * -0.5, -0.5f);
-	Vector3 normal = Vector3(0.0, 0.0, 1.0);
+	Size2 start_pos = Vector2(_generated_size.x * -0.5f, -0.5f);
+	Vector3 normal = Vector3(0.f, 0.f, 1.f);
 	thisrow = point;
 	prevrow = 0;
-	Vector3 Up = Vector3(0.f, 1.f, 0.f);
 	for (int m = 1; m <= _generated_faces; m++) {
 		z = start_pos.y;
 		real_t angle = 0.f;
@@ -58,14 +57,13 @@ Ref<ArrayMesh> Terrain3DMeshAsset::_get_generated_mesh() const {
 			for (int i = 0; i <= 1; i++) {
 				float u = i;
 				float v = j;
-
-				vertices.push_back(Vector3(-x, z, 0.0).rotated(Up, angle));
+				vertices.push_back(Vector3(-x, z, 0.f).rotated(V3_UP, angle));
 				normals.push_back(normal);
-				tangents.push_back(1.0);
-				tangents.push_back(0.0);
-				tangents.push_back(0.0);
-				tangents.push_back(1.0);
-				uvs.push_back(Vector2(1.0 - u, 1.0 - v));
+				tangents.push_back(1.f);
+				tangents.push_back(0.f);
+				tangents.push_back(0.f);
+				tangents.push_back(1.f);
+				uvs.push_back(Vector2(1.f - u, 1.f - v));
 				point++;
 				if (i > 0 && j > 0) {
 					indices.push_back(prevrow + i - 1);
@@ -136,7 +134,7 @@ void Terrain3DMeshAsset::clear() {
 	_material_override.unref();
 	_material_overlay.unref();
 	_generated_faces = 2.f;
-	_generated_size = Vector2(1.f, 1.f);
+	_generated_size = V2(1.f);
 	_last_lod = MAX_LOD_COUNT - 1;
 	_last_shadow_lod = MAX_LOD_COUNT - 1;
 	_shadow_impostor = 0;

--- a/src/terrain_3d_mesh_asset.h
+++ b/src/terrain_3d_mesh_asset.h
@@ -46,7 +46,7 @@ private:
 	Ref<Material> _material_override;
 	Ref<Material> _material_overlay;
 	int _generated_faces = 2;
-	Vector2 _generated_size = Vector2(1.f, 1.f);
+	Vector2 _generated_size = V2(1.f);
 	int _last_lod = MAX_LOD_COUNT - 1;
 	int _last_shadow_lod = MAX_LOD_COUNT - 1;
 	int _shadow_impostor = 0;

--- a/src/terrain_3d_mesher.cpp
+++ b/src/terrain_3d_mesher.cpp
@@ -17,7 +17,7 @@ void Terrain3DMesher::_generate_mesh_types(const int p_size) {
 	LOG(INFO, "Generating all Mesh segments for clipmap of size ", p_size);
 	// Create initial set of Mesh blocks to build the clipmap
 	// # 0 TILE - mesh_size x mesh_size tiles
-	_mesh_rids.push_back(_generate_mesh(Vector2i(p_size, p_size)));
+	_mesh_rids.push_back(_generate_mesh(V2I(p_size)));
 	// # 1 EDGE_A - 2 by (mesh_size * 4 + 8) strips to bridge LOD transitions along +-Z axis
 	_mesh_rids.push_back(_generate_mesh(Vector2i(2, p_size * 4 + 8)));
 	// # 2 EDGE_B - (mesh_size * 4 + 4) by 2 strips to bridge LOD transitions along +-X axis
@@ -49,7 +49,7 @@ RID Terrain3DMesher::_generate_mesh(const Vector2i &p_size, const bool p_standar
 	for (int y = 0; y <= p_size.y; ++y) {
 		for (int x = 0; x <= p_size.x; ++x) {
 			// Match GDScript vertex definitions
-			vertices.push_back(Vector3(x, 0, y)); // bottom-left
+			vertices.push_back(Vector3(x, 0.f, y)); // bottom-left
 		}
 	}
 
@@ -92,7 +92,7 @@ RID Terrain3DMesher::_instantiate_mesh(const PackedVector3Array &p_vertices, con
 
 	PackedVector3Array normals;
 	normals.resize(p_vertices.size());
-	normals.fill(Vector3(0, 1, 0));
+	normals.fill(V3_UP);
 	arrays[RenderingServer::ARRAY_NORMAL] = normals;
 
 	PackedFloat32Array tangents;
@@ -208,7 +208,7 @@ void Terrain3DMesher::_generate_offset_data(const int p_size) {
 	_tile_pos_lod_0.push_back(Vector3(-p_size * 2, 0, p_size));
 	_tile_pos_lod_0.push_back(Vector3(-p_size, 0, p_size));
 	// Inner tiles
-	_tile_pos_lod_0.push_back(Vector3(0, 0, 0));
+	_tile_pos_lod_0.push_back(V3_ZERO);
 	_tile_pos_lod_0.push_back(Vector3(-p_size, 0, 0));
 	_tile_pos_lod_0.push_back(Vector3(0, 0, -p_size));
 	_tile_pos_lod_0.push_back(Vector3(-p_size, 0, -p_size));
@@ -327,7 +327,7 @@ void Terrain3DMesher::snap() {
 	Vector3 snapped_pos = (target_pos / vertex_spacing).floor() * vertex_spacing;
 	RS->material_set_param(_terrain->get_material()->get_material_rid(), "_camera_pos", snapped_pos);
 
-	Vector3 pos = Vector3(0.f, 0.f, 0.f);
+	Vector3 pos = V3_ZERO;
 	for (int lod = 0; lod < _clipmap_rids.size(); ++lod) {
 		real_t snap_step = pow(2.f, lod + 1.f) * vertex_spacing;
 		Vector3 lod_scale = Vector3(pow(2.f, lod) * vertex_spacing, 1.f, pow(2.f, lod) * vertex_spacing);

--- a/src/terrain_3d_region.cpp
+++ b/src/terrain_3d_region.cpp
@@ -197,7 +197,7 @@ Ref<Image> Terrain3DRegion::sanitize_map(const MapType p_map_type, const Ref<Ima
 	}
 	if (map.is_null()) {
 		LOG(DEBUG, "Making new image of type: ", type_str, " and generating mipmaps: ", p_map_type == TYPE_COLOR);
-		return Util::get_filled_image(Vector2i(_region_size, _region_size), color, p_map_type == TYPE_COLOR, format);
+		return Util::get_filled_image(V2I(_region_size), color, p_map_type == TYPE_COLOR, format);
 	} else {
 		if (p_map_type == TYPE_COLOR && !map->has_mipmaps()) {
 			LOG(DEBUG, "Color map does not have mipmaps. Generating");

--- a/src/terrain_3d_util.cpp
+++ b/src/terrain_3d_util.cpp
@@ -154,10 +154,10 @@ Ref<Image> Terrain3DUtil::black_to_alpha(const Ref<Image> &p_image) {
 Vector2 Terrain3DUtil::get_min_max(const Ref<Image> &p_image) {
 	if (p_image.is_null()) {
 		LOG(ERROR, "Provided image is not valid. Nothing to analyze");
-		return Vector2(INFINITY, INFINITY);
+		return V2(INFINITY);
 	} else if (p_image->is_empty()) {
 		LOG(ERROR, "Provided image is empty. Nothing to analyze");
-		return Vector2(INFINITY, INFINITY);
+		return V2(INFINITY);
 	}
 
 	Vector2 min_max = Vector2(FLT_MAX, FLT_MIN);
@@ -332,7 +332,7 @@ Ref<Image> Terrain3DUtil::load_image(const String &p_file_name, const int p_cach
 			file->seek_end();
 			int fsize = file->get_position();
 			int fwidth = sqrt(fsize / 2);
-			r16_size = Vector2i(fwidth, fwidth);
+			r16_size = V2I(fwidth);
 			LOG(DEBUG, "Total file size is: ", fsize, " calculated width: ", fwidth, " dimensions: ", r16_size);
 			file->seek(0);
 		}
@@ -535,9 +535,9 @@ void Terrain3DUtil::_bind_methods() {
 	// Image handling
 	ClassDB::bind_static_method("Terrain3DUtil", D_METHOD("black_to_alpha", "image"), &Terrain3DUtil::black_to_alpha);
 	ClassDB::bind_static_method("Terrain3DUtil", D_METHOD("get_min_max", "image"), &Terrain3DUtil::get_min_max);
-	ClassDB::bind_static_method("Terrain3DUtil", D_METHOD("get_thumbnail", "image", "size"), &Terrain3DUtil::get_thumbnail, DEFVAL(Vector2i(256, 256)));
+	ClassDB::bind_static_method("Terrain3DUtil", D_METHOD("get_thumbnail", "image", "size"), &Terrain3DUtil::get_thumbnail, DEFVAL(V2I(256)));
 	ClassDB::bind_static_method("Terrain3DUtil", D_METHOD("get_filled_image", "size", "color", "create_mipmaps", "format"), &Terrain3DUtil::get_filled_image);
-	ClassDB::bind_static_method("Terrain3DUtil", D_METHOD("load_image", "file_name", "cache_mode", "r16_height_range", "r16_size"), &Terrain3DUtil::load_image, DEFVAL(ResourceLoader::CACHE_MODE_IGNORE), DEFVAL(Vector2(0, 255)), DEFVAL(V2I_ZERO));
+	ClassDB::bind_static_method("Terrain3DUtil", D_METHOD("load_image", "file_name", "cache_mode", "r16_height_range", "r16_size"), &Terrain3DUtil::load_image, DEFVAL(ResourceLoader::CACHE_MODE_IGNORE), DEFVAL(Vector2(0.f, 255.f)), DEFVAL(V2I_ZERO));
 	ClassDB::bind_static_method("Terrain3DUtil", D_METHOD("pack_image", "src_rgb", "src_a", "invert_green", "invert_alpha", "normalize_alpha", "alpha_channel"), &Terrain3DUtil::pack_image, DEFVAL(false), DEFVAL(false), DEFVAL(false), DEFVAL(0));
 	ClassDB::bind_static_method("Terrain3DUtil", D_METHOD("luminance_to_height", "src_rgb"), &Terrain3DUtil::luminance_to_height);
 }

--- a/src/terrain_3d_util.h
+++ b/src/terrain_3d_util.h
@@ -39,7 +39,7 @@ public:
 	// Image operations
 	static Ref<Image> black_to_alpha(const Ref<Image> &p_image);
 	static Vector2 get_min_max(const Ref<Image> &p_image);
-	static Ref<Image> get_thumbnail(const Ref<Image> &p_image, const Vector2i &p_size = Vector2i(256, 256));
+	static Ref<Image> get_thumbnail(const Ref<Image> &p_image, const Vector2i &p_size = V2I(256));
 	static Ref<Image> get_filled_image(const Vector2i &p_size,
 			const Color &p_color = COLOR_BLACK,
 			const bool p_create_mipmaps = true,


### PR DESCRIPTION
* The slope filter wasn't being properly considered during adding or removing when instancing with on_collision. So you could add instances but not remove them with a narrow range. Now both functions evaluate slope of meshes.
* Fixes #789 so slope isn't required for add_instances
* Converts vector defines to static const