### PR TITLE
Improve Create thumbnails, update_mmis()

### DIFF
--- a/project/addons/terrain_3d/src/asset_dock.gd
+++ b/project/addons/terrain_3d/src/asset_dock.gd
@@ -688,10 +688,10 @@ class ListContainer extends Container:
 				plugin.terrain.get_assets().set_texture(p_id, p_resource)
 			else:
 				plugin.terrain.get_assets().set_mesh_asset(p_id, p_resource)
-				await get_tree().create_timer(.01).timeout
-				plugin.terrain.assets.create_mesh_thumbnails(p_id)
-				if selected_id < entries.size():
-					entries[selected_id].queue_redraw()
+				#await get_tree().create_timer(.01).timeout
+				#plugin.terrain.assets.create_mesh_thumbnails(p_id)
+				#if selected_id < entries.size():
+					#entries[selected_id].queue_redraw()
 
 			# If removing an entry, clear inspector
 			if not p_resource:
@@ -1026,8 +1026,9 @@ class ListEntry extends MarginContainer:
 		resource = p_res
 		if resource:
 			resource.setting_changed.connect(_on_resource_changed)
-			resource.file_changed.connect(_on_resource_changed)
-			if resource is Terrain3DMeshAsset:
+			if resource is Terrain3DTextureAsset:
+				resource.file_changed.connect(_on_resource_changed)
+			elif resource is Terrain3DMeshAsset:
 				resource.instancer_setting_changed.connect(_on_resource_changed)
 		
 		if button_clear:
@@ -1047,7 +1048,13 @@ class ListEntry extends MarginContainer:
 		is_selected = value
 		if is_selected:
 			# Handle scrolling to show the selected item
-			await get_tree().process_frame
+			#await get_tree().process_frame
+			await RenderingServer.frame_pre_draw
+			#if is_inside_tree():
+			#print("is in tree? ", is_inside_tree())
+			#print("Parent: ", get_parent())
+			#print("Grand Parent: ", get_parent().get_parent())
+			#print_tree()
 			get_parent().get_parent().get_v_scroll_bar().ratio = position.y / get_parent().size.y
 		queue_redraw()
 

--- a/src/terrain_3d.cpp
+++ b/src/terrain_3d.cpp
@@ -85,11 +85,11 @@ void Terrain3D::_initialize() {
 		LOG(DEBUG, "Connecting _assets.textures_changed to _material->_update_texture_arrays()");
 		_assets->connect("textures_changed", callable_mp(_material.ptr(), &Terrain3DMaterial::_update_texture_arrays));
 	}
-	// MeshAssets changed, update instancer
-	if (!_assets->is_connected("meshes_changed", callable_mp(_instancer, &Terrain3DInstancer::update_mmis).bind(-1, V2I_MAX, false))) {
-		LOG(DEBUG, "Connecting _assets.meshes_changed to _instancer->update_mmis()");
-		_assets->connect("meshes_changed", callable_mp(_instancer, &Terrain3DInstancer::update_mmis).bind(-1, V2I_MAX, false));
-	}
+	//// MeshAssets changed, update instancer
+	//if (!_assets->is_connected("meshes_changed", callable_mp(_instancer, &Terrain3DInstancer::update_mmis).bind(-1, V2I_MAX, false))) {
+	//	LOG(DEBUG, "Connecting _assets.meshes_changed to _instancer->update_mmis()");
+	//	_assets->connect("meshes_changed", callable_mp(_instancer, &Terrain3DInstancer::update_mmis).bind(-1, V2I_MAX, false));
+	//}
 
 	// Initialize the system
 	if (!_initialized && _is_inside_world && is_inside_tree()) {

--- a/src/terrain_3d_assets.cpp
+++ b/src/terrain_3d_assets.cpp
@@ -128,6 +128,7 @@ void Terrain3DAssets::_set_asset_list(const AssetType p_type, const TypedArray<T
 }
 
 void Terrain3DAssets::_set_asset(const AssetType p_type, const int p_id, const Ref<Terrain3DAssetResource> &p_asset) {
+	LOG(INFO, "Setting asset type: ", p_type, ", ID: ", p_id, ", asset: ", p_asset);
 	Array list;
 	int max_size;
 	switch (p_type) {
@@ -372,6 +373,14 @@ void Terrain3DAssets::_update_texture_settings() {
 	emit_signal("textures_changed");
 }
 
+//void Terrain3DAssets::_update_mesh(const int p_id) {
+//	IS_INSTANCER_INIT(VOID);
+//	Terrain3DInstancer *instancer = _terrain->get_instancer();
+//	//instancer->_destroy_mmi_by_mesh(p_id);
+//	create_mesh_thumbnails(p_id, V2I(128));
+//	instancer->update_mmis(p_id, V2I_MAX, false);
+//}
+
 void Terrain3DAssets::_setup_thumbnail_creation() {
 	IS_INIT(VOID);
 	if (_scenario.is_valid()) {
@@ -405,12 +414,6 @@ void Terrain3DAssets::_setup_thumbnail_creation() {
 
 	_mesh_instance = RS->instance_create();
 	RS->instance_set_scenario(_mesh_instance, _scenario);
-}
-
-void Terrain3DAssets::_update_thumbnail(const Ref<Terrain3DMeshAsset> &p_mesh_asset) {
-	if (p_mesh_asset.is_valid()) {
-		create_mesh_thumbnails(p_mesh_asset->get_id());
-	}
 }
 
 ///////////////////////////
@@ -512,8 +515,6 @@ void Terrain3DAssets::update_texture_list() {
 			texture_set->connect("setting_changed", callable_mp(this, &Terrain3DAssets::_update_texture_settings));
 		}
 	}
-	_generated_albedo_textures.clear();
-	_generated_normal_textures.clear();
 	_update_texture_files();
 	_update_texture_settings();
 }
@@ -544,9 +545,12 @@ void Terrain3DAssets::set_mesh_list(const TypedArray<Terrain3DMeshAsset> &p_mesh
 // p_id = -1 for all meshes
 // Adapted from godot\editor\plugins\editor_preview_plugins.cpp:EditorMeshPreviewPlugin
 void Terrain3DAssets::create_mesh_thumbnails(const int p_id, const Vector2i &p_size) {
-	LOG(INFO, "Creating mesh thumbnails");
-	int start, end;
+	LOG(MESG, "Creating mesh thumbnails for ID: ", p_id, ", size: ", p_size);
 	int max = get_mesh_count();
+	if (p_id < -1 || p_id >= max) {
+		return;
+	}
+	int start, end;
 	if (p_id < 0) {
 		start = 0;
 		end = max;
@@ -554,9 +558,9 @@ void Terrain3DAssets::create_mesh_thumbnails(const int p_id, const Vector2i &p_s
 		start = CLAMP(p_id, 0, max - 1);
 		end = CLAMP(p_id + 1, 0, max);
 	}
-	Vector2i size = CLAMP(p_size, V2I(1), V2I(4096));
+	Vector2i size = CLAMP(p_size, V2I(2), V2I(4096));
 
-	LOG(INFO, "Creating thumbnails for ids: ", start, " through ", end - 1);
+	LOG(MESG, "Creating thumbnails for ids: ", start, " through ", end - 1);
 	for (int i = start; i < end; i++) {
 		Ref<Terrain3DMeshAsset> ma = get_mesh_asset(i);
 		if (ma.is_null()) {
@@ -564,9 +568,9 @@ void Terrain3DAssets::create_mesh_thumbnails(const int p_id, const Vector2i &p_s
 			continue;
 		}
 		// Setup mesh
-		LOG(DEBUG, i, ": Getting Terrain3DMeshAsset: ", String::num_uint64(ma->get_instance_id()));
+		LOG(MESG, i, ": Getting Terrain3DMeshAsset: ", String::num_uint64(ma->get_instance_id()));
 		Ref<Mesh> mesh = ma->get_mesh(0);
-		LOG(DEBUG, i, ": Getting Mesh 0: ", mesh);
+		LOG(MESG, i, ": Getting Mesh 0: ", mesh);
 		if (mesh.is_null()) {
 			LOG(WARN, i, ": Mesh is null");
 			continue;
@@ -607,9 +611,9 @@ void Terrain3DAssets::create_mesh_thumbnails(const int p_id, const Vector2i &p_s
 		RS->instance_set_base(_mesh_instance, RID());
 
 		if (img.is_valid()) {
-			LOG(DEBUG, i, ": Retrieving image: ", img, " size: ", img->get_size(), " format: ", img->get_format());
+			LOG(MESG, i, ": Retrieving image: ", img, " size: ", img->get_size(), " format: ", img->get_format());
 		} else {
-			LOG(WARN, "_viewport_texture is null");
+			LOG(MESG, "_viewport_texture is null");
 			continue;
 		}
 
@@ -621,14 +625,14 @@ void Terrain3DAssets::create_mesh_thumbnails(const int p_id, const Vector2i &p_s
 void Terrain3DAssets::update_mesh_list() {
 	IS_INSTANCER_INIT(VOID);
 	LOG(INFO, "Updating mesh list");
-	if (_mesh_list.size() == 0) {
-		LOG(DEBUG, "Mesh list empty, clearing instancer and adding a default mesh");
-		_terrain->get_instancer()->destroy();
-		Ref<Terrain3DMeshAsset> new_mesh;
-		new_mesh.instantiate();
-		new_mesh->set_generated_type(Terrain3DMeshAsset::TYPE_TEXTURE_CARD);
-		set_mesh_asset(0, new_mesh);
-	}
+	//if (_mesh_list.size() == 0) {
+	//	LOG(DEBUG, "Mesh list empty, clearing instancer and adding a default mesh");
+	//	_terrain->get_instancer()->destroy();
+	//	Ref<Terrain3DMeshAsset> new_mesh;
+	//	new_mesh.instantiate();
+	//	new_mesh->set_generated_type(Terrain3DMeshAsset::TYPE_TEXTURE_CARD);
+	//	set_mesh_asset(0, new_mesh);
+	//}
 	LOG(DEBUG, "Reconnecting mesh instance signals");
 	for (int i = 0; i < _mesh_list.size(); i++) {
 		Ref<Terrain3DMeshAsset> mesh_asset = _mesh_list[i];
@@ -637,24 +641,16 @@ void Terrain3DAssets::update_mesh_list() {
 			continue;
 		}
 		if (mesh_asset->get_mesh().is_null()) {
-			LOG(DEBUG, "Terrain3DMeshAsset has no mesh, adding a default");
+			LOG(DEBUG, "Terrain3DMeshAsset has no mesh, adding a default mesh");
 			mesh_asset->set_generated_type(Terrain3DMeshAsset::TYPE_TEXTURE_CARD);
 		}
-		if (!mesh_asset->is_connected("file_changed", callable_mp(this, &Terrain3DAssets::update_mesh_list))) {
-			LOG(DEBUG, "Connecting file_changed signal to self");
-			mesh_asset->connect("file_changed", callable_mp(this, &Terrain3DAssets::update_mesh_list));
-		}
-		if (!mesh_asset->is_connected("setting_changed", callable_mp(this, &Terrain3DAssets::update_mesh_list))) {
-			LOG(DEBUG, "Connecting setting_changed signal to self");
-			mesh_asset->connect("setting_changed", callable_mp(this, &Terrain3DAssets::update_mesh_list));
-		}
-		if (!mesh_asset->is_connected("file_changed", callable_mp(this, &Terrain3DAssets::_update_thumbnail).bind(mesh_asset))) {
-			LOG(DEBUG, "Connecting file_changed signal to _update_thumbnail");
-			mesh_asset->connect("file_changed", callable_mp(this, &Terrain3DAssets::_update_thumbnail).bind(mesh_asset));
-		}
-		if (!mesh_asset->is_connected("setting_changed", callable_mp(this, &Terrain3DAssets::_update_thumbnail).bind(mesh_asset))) {
-			LOG(DEBUG, "Connecting setting_changed signal to _update_thumbnail");
-			mesh_asset->connect("setting_changed", callable_mp(this, &Terrain3DAssets::_update_thumbnail).bind(mesh_asset));
+		//if (!mesh_asset->is_connected("instancer_setting_changed", callable_mp(this, &Terrain3DAssets::_update_mesh))) {
+		//	LOG(DEBUG, "Connecting instancer_setting_changed signal to _update_mesh");
+		//	mesh_asset->connect("instancer_setting_changed", callable_mp(this, &Terrain3DAssets::_update_mesh));
+		//}
+		if (!mesh_asset->is_connected("instancer_setting_changed", callable_mp(this, &Terrain3DAssets::create_mesh_thumbnails).bind(V2I(128)))) {
+			LOG(DEBUG, "Connecting instancer_setting_changed signal to create_mesh_thumbnails");
+			mesh_asset->connect("instancer_setting_changed", callable_mp(this, &Terrain3DAssets::create_mesh_thumbnails).bind(V2I(128)));
 		}
 		if (!mesh_asset->is_connected("instancer_setting_changed", callable_mp(_terrain->get_instancer(), &Terrain3DInstancer::update_mmis).bind(V2I_MAX, false))) {
 			LOG(DEBUG, "Connecting instancer_setting_changed signal to update_mmis");

--- a/src/terrain_3d_assets.h
+++ b/src/terrain_3d_assets.h
@@ -59,8 +59,8 @@ private:
 
 	void _update_texture_files();
 	void _update_texture_settings();
+	//void _update_mesh(const int p_id);
 	void _setup_thumbnail_creation();
-	void _update_thumbnail(const Ref<Terrain3DMeshAsset> &p_mesh_asset);
 
 public:
 	Terrain3DAssets() {}

--- a/src/terrain_3d_instancer.cpp
+++ b/src/terrain_3d_instancer.cpp
@@ -104,7 +104,7 @@ void Terrain3DInstancer::_update_mmi_by_region(const Terrain3DRegion *p_region, 
 		LOG(ERROR, "p_region is null");
 		return;
 	}
-	if (p_mesh_id < 0 || p_mesh_id > Terrain3DAssets::MAX_MESHES) {
+	if (p_mesh_id < 0 || p_mesh_id >= Terrain3DAssets::MAX_MESHES) {
 		LOG(ERROR, "p_mesh_id is out of bounds");
 		return;
 	}
@@ -226,7 +226,7 @@ void Terrain3DInstancer::_update_mmi_by_region(const Terrain3DRegion *p_region, 
 			mmi->set_global_transform(t);
 
 			// Only recreate MultiMesh if modified or no existing
-			if (modified || !mmi->get_multimesh().is_valid()) {
+			if (modified || mmi->get_multimesh().is_null()) {
 				// Subtract previous instance count for this cell
 				if (mmi->get_multimesh().is_valid() && lod == ma->get_last_lod()) {
 					ma->update_instance_count(-mmi->get_multimesh()->get_instance_count());
@@ -254,6 +254,9 @@ void Terrain3DInstancer::_update_mmi_by_region(const Terrain3DRegion *p_region, 
 					ma->update_instance_count(mm->get_instance_count());
 				}
 				triple[2] = false; // Modified cleared after successful rebuild
+			} else {
+				LOG(MESG, "Skipping because not modified or MM is null");
+				mmi->get_multimesh()->set_mesh(ma->get_mesh(lod));
 			}
 		} // End for LOD loop
 
@@ -353,6 +356,39 @@ void Terrain3DInstancer::_update_vertex_spacing(const real_t p_vertex_spacing) {
 	update_mmis(-1, V2I_MAX, true);
 }
 
+void Terrain3DInstancer::_destroy_mmi_by_mesh(const int p_mesh_id) {
+	LOG(DEBUG, "Deleting all MMIs in all regions with mesh_id: ", p_mesh_id);
+	TypedArray<Vector2i> region_locations = _terrain->get_data()->get_region_locations();
+	for (int i = 0; i < region_locations.size(); i++) {
+		_destroy_mmi_by_location(region_locations[i], p_mesh_id);
+	}
+}
+
+void Terrain3DInstancer::_destroy_mmi_by_location(const Vector2i &p_region_loc, const int p_mesh_id) {
+	LOG(DEBUG, "Deleting all MMIs in region: ", p_region_loc, " for mesh_id: ", p_mesh_id);
+	if (_mmi_nodes.count(p_region_loc) == 0) {
+		return;
+	}
+	MeshMMIDict &mesh_mmi_dict = _mmi_nodes[p_region_loc];
+
+	for (int lod = Terrain3DMeshAsset::SHADOW_LOD_ID; lod < Terrain3DMeshAsset::MAX_LOD_COUNT; lod++) {
+		Vector2i mesh_key(p_mesh_id, lod);
+		CellMMIDict &cell_mmi_dict = mesh_mmi_dict[mesh_key];
+
+		// Iterate over keys as functions will invalidate standard iterator
+		std::vector<Vector2i> keys;
+		keys.reserve(cell_mmi_dict.size());
+		int i = 0;
+		for (auto &it : cell_mmi_dict) {
+			keys.push_back(it.first);
+			i++;
+		}
+		for (auto &cell : keys) {
+			_destroy_mmi_by_cell(p_region_loc, p_mesh_id, cell);
+		}
+	}
+}
+
 void Terrain3DInstancer::_destroy_mmi_by_cell(const Vector2i &p_region_loc, const int p_mesh_id, const Vector2i p_cell) {
 	if (_mmi_nodes.count(p_region_loc) == 0) {
 		return;
@@ -402,31 +438,6 @@ void Terrain3DInstancer::_destroy_mmi_by_cell(const Vector2i &p_region_loc, cons
 		}
 		_mmi_nodes.erase(p_region_loc); // invalidates mesh_mmi_dict
 		return;
-	}
-}
-
-void Terrain3DInstancer::_destroy_mmi_by_location(const Vector2i &p_region_loc, const int p_mesh_id) {
-	LOG(DEBUG, "Deleting all MMIs in region: ", p_region_loc, " for mesh_id: ", p_mesh_id);
-	if (_mmi_nodes.count(p_region_loc) == 0) {
-		return;
-	}
-	MeshMMIDict &mesh_mmi_dict = _mmi_nodes[p_region_loc];
-
-	for (int lod = Terrain3DMeshAsset::SHADOW_LOD_ID; lod < Terrain3DMeshAsset::MAX_LOD_COUNT; lod++) {
-		Vector2i mesh_key(p_mesh_id, lod);
-		CellMMIDict &cell_mmi_dict = mesh_mmi_dict[mesh_key];
-
-		// Iterate over keys as functions will invalidate standard iterator
-		std::vector<Vector2i> keys;
-		keys.reserve(cell_mmi_dict.size());
-		int i = 0;
-		for (auto &it : cell_mmi_dict) {
-			keys.push_back(it.first);
-			i++;
-		}
-		for (auto &cell : keys) {
-			_destroy_mmi_by_cell(p_region_loc, p_mesh_id, cell);
-		}
 	}
 }
 
@@ -1289,7 +1300,7 @@ void Terrain3DInstancer::update_mmis(const int p_mesh_id, const Vector2i &p_regi
 		return;
 	}
 	// If all regions for mesh_id are queued, quit
-	int mesh_id = CLAMP(p_mesh_id, -1, Terrain3DAssets::MAX_MESHES);
+	int mesh_id = CLAMP(p_mesh_id, -1, Terrain3DAssets::MAX_MESHES - 1);
 	if (_queued_updates.find({ V2I_MAX, mesh_id }) != _queued_updates.end()) {
 		return;
 	}

--- a/src/terrain_3d_instancer.h
+++ b/src/terrain_3d_instancer.h
@@ -55,8 +55,9 @@ private:
 	void _update_mmi_by_region(const Terrain3DRegion *p_region, const int p_mesh_id);
 	void _setup_mmi_lod_ranges(MultiMeshInstance3D *p_mmi, const Ref<Terrain3DMeshAsset> &p_ma, const int p_lod);
 	void _update_vertex_spacing(const real_t p_vertex_spacing);
-	void _destroy_mmi_by_cell(const Vector2i &p_region_loc, const int p_mesh_id, const Vector2i p_cell);
+	void _destroy_mmi_by_mesh(const int p_mesh_id);
 	void _destroy_mmi_by_location(const Vector2i &p_region_loc, const int p_mesh_id);
+	void _destroy_mmi_by_cell(const Vector2i &p_region_loc, const int p_mesh_id, const Vector2i p_cell);
 	void _backup_region(const Ref<Terrain3DRegion> &p_region);
 	Ref<MultiMesh> _create_multimesh(const int p_mesh_id, const int p_lod, const TypedArray<Transform3D> &p_xforms = TypedArray<Transform3D>(), const PackedColorArray &p_colors = PackedColorArray()) const;
 	Vector2i _get_cell(const Vector3 &p_global_position, const int p_region_size) const;

--- a/src/terrain_3d_mesh_asset.cpp
+++ b/src/terrain_3d_mesh_asset.cpp
@@ -126,7 +126,6 @@ void Terrain3DMeshAsset::clear() {
 	_highlight_mat = Ref<Material>();
 	_enabled = true;
 	_packed_scene.unref();
-	_generated_type = TYPE_NONE;
 	_meshes.clear();
 	_thumbnail.unref();
 	_height_offset = 0.f;
@@ -139,8 +138,9 @@ void Terrain3DMeshAsset::clear() {
 	_last_lod = MAX_LOD_COUNT - 1;
 	_last_shadow_lod = MAX_LOD_COUNT - 1;
 	_shadow_impostor = 0;
-	_clear_lod_ranges();
 	_fade_margin = 0.f;
+	_clear_lod_ranges();
+	_generated_type = TYPE_NONE;
 }
 
 void Terrain3DMeshAsset::set_name(const String &p_name) {
@@ -149,13 +149,13 @@ void Terrain3DMeshAsset::set_name(const String &p_name) {
 	}
 	LOG(INFO, "Setting name: ", p_name.left(96));
 	_name = p_name.left(96);
-	LOG(DEBUG, "Emitting setting_changed");
-	emit_signal("setting_changed");
+	LOG(DEBUG, "Emitting setting_changed, ID: ", _id);
+	emit_signal("setting_changed, ", _id);
 }
 
 void Terrain3DMeshAsset::set_id(const int p_new_id) {
 	int old_id = _id;
-	_id = CLAMP(p_new_id, 0, Terrain3DAssets::MAX_MESHES);
+	_id = CLAMP(p_new_id, 0, Terrain3DAssets::MAX_MESHES - 1);
 	LOG(INFO, "Setting mesh ID: ", _id);
 	LOG(DEBUG, "Emitting id_changed, TYPE_MESH, ", old_id, ", ", p_new_id);
 	emit_signal("id_changed", Terrain3DAssets::TYPE_MESH, old_id, p_new_id);
@@ -325,13 +325,15 @@ Ref<Mesh> Terrain3DMeshAsset::get_mesh(const int p_lod) const {
 void Terrain3DMeshAsset::set_height_offset(const real_t p_offset) {
 	_height_offset = CLAMP(p_offset, -50.f, 50.f);
 	LOG(INFO, "Setting height offset: ", _height_offset);
-	LOG(DEBUG, "Emitting setting_changed");
-	emit_signal("setting_changed");
+	LOG(DEBUG, "Emitting setting_changed, ID: ", _id);
+	emit_signal("setting_changed", _id);
 }
 
 void Terrain3DMeshAsset::set_density(const real_t p_density) {
 	LOG(INFO, "Setting mesh density: ", p_density);
 	_density = CLAMP(p_density, 0.01f, 10.f);
+	LOG(DEBUG, "Emitting setting_changed, ID: ", _id);
+	emit_signal("setting_changed", _id);
 }
 
 void Terrain3DMeshAsset::set_cast_shadows(const ShadowCasting p_cast_shadows) {
@@ -510,7 +512,6 @@ void Terrain3DMeshAsset::_bind_methods() {
 	BIND_ENUM_CONSTANT(TYPE_MAX);
 
 	ADD_SIGNAL(MethodInfo("id_changed"));
-	ADD_SIGNAL(MethodInfo("file_changed"));
 	ADD_SIGNAL(MethodInfo("setting_changed"));
 	ADD_SIGNAL(MethodInfo("instancer_setting_changed"));
 	ADD_SIGNAL(MethodInfo("instance_count_changed"));

--- a/src/terrain_3d_texture_asset.cpp
+++ b/src/terrain_3d_texture_asset.cpp
@@ -60,7 +60,7 @@ void Terrain3DTextureAsset::set_name(const String &p_name) {
 
 void Terrain3DTextureAsset::set_id(const int p_new_id) {
 	int old_id = _id;
-	_id = CLAMP(p_new_id, 0, Terrain3DAssets::MAX_TEXTURES);
+	_id = CLAMP(p_new_id, 0, Terrain3DAssets::MAX_TEXTURES - 1);
 	LOG(INFO, "Setting texture id: ", _id);
 	LOG(DEBUG, "Emitting id_changed, TYPE_TEXTURE, ", old_id, ", ", _id);
 	emit_signal("id_changed", Terrain3DAssets::TYPE_TEXTURE, old_id, _id);


### PR DESCRIPTION
* Generate thumbnails when settings changed
  * Still can't do it on material settings changed, since materials don't emit Resource::changed.
* Fixes generated mesh settings not updating the display
* Removes multiple signal calls to update_mmis
* Moves scroll asset dock to frame_pre_draw instead of physics frame, which fixes not being in the tree (test OOTA)
* Fixes edge case bugs: 
  * min thumbnail size 1x1 - min viewport is 2x2. 
  * Clamps must be MAX_TEXTURE/MESH_SIZE -1. 