### PR TITLE
 Fix regression on update_mmis()

### DIFF
--- a/project/addons/terrain_3d/src/asset_dock.gd
+++ b/project/addons/terrain_3d/src/asset_dock.gd
@@ -613,6 +613,7 @@ class ListContainer extends Container:
 
 	
 	func set_selected_after_swap(p_type: Terrain3DAssets.AssetType, p_old_id: int, p_new_id: int) -> void:
+		EditorInterface.mark_scene_as_unsaved()
 		set_selected_id(clamp(p_new_id, 0, entries.size() - 2))
 
 
@@ -1026,8 +1027,9 @@ class ListEntry extends MarginContainer:
 		resource = p_res
 		if resource:
 			resource.setting_changed.connect(_on_resource_changed)
-			resource.file_changed.connect(_on_resource_changed)
-			if resource is Terrain3DMeshAsset:
+			if resource is Terrain3DTextureAsset:
+				resource.file_changed.connect(_on_resource_changed)
+			elif resource is Terrain3DMeshAsset:
 				resource.instancer_setting_changed.connect(_on_resource_changed)
 		
 		if button_clear:

--- a/project/demo/assets/models/LODExample10.tscn
+++ b/project/demo/assets/models/LODExample10.tscn
@@ -26,7 +26,7 @@ albedo_color = Color(0.48, 1, 0.497333, 1)
 
 [sub_resource type="PrismMesh" id="PrismMesh_xnm4h"]
 material = SubResource("StandardMaterial3D_p0ha4")
-size = Vector3(1, 1, 0.855)
+size = Vector3(0.89, 0.82, 0.835)
 
 [sub_resource type="StandardMaterial3D" id="StandardMaterial3D_jv6fb"]
 albedo_color = Color(0.3384, 0.538933, 0.94, 1)
@@ -35,7 +35,7 @@ albedo_color = Color(0.3384, 0.538933, 0.94, 1)
 material = SubResource("StandardMaterial3D_jv6fb")
 top_radius = 0.0
 bottom_radius = 0.59
-height = 1.08
+height = 1.015
 radial_segments = 4
 
 [sub_resource type="StandardMaterial3D" id="StandardMaterial3D_0qk4s"]
@@ -43,18 +43,18 @@ albedo_color = Color(0.62325, 0.495, 0.9, 1)
 
 [sub_resource type="CylinderMesh" id="CylinderMesh_bvmel"]
 material = SubResource("StandardMaterial3D_0qk4s")
-top_radius = 0.765
-bottom_radius = 0.34
-height = 1.54
+top_radius = 0.58
+bottom_radius = 0.25
+height = 0.895
 
 [sub_resource type="StandardMaterial3D" id="StandardMaterial3D_438mn"]
 albedo_color = Color(0.933333, 0.2, 1, 1)
 
 [sub_resource type="CylinderMesh" id="CylinderMesh_x8oip"]
 material = SubResource("StandardMaterial3D_438mn")
-top_radius = 0.33
-bottom_radius = 0.34
-height = 1.0
+top_radius = 0.4
+bottom_radius = 0.4
+height = 0.96
 radial_segments = 7
 
 [sub_resource type="StandardMaterial3D" id="StandardMaterial3D_hqr78"]
@@ -74,7 +74,7 @@ albedo_color = Color(0.1512, 0.36, 0.17208, 1)
 material = SubResource("StandardMaterial3D_aba40")
 top_radius = 0.45
 bottom_radius = 0.495
-height = 1.54
+height = 0.89
 radial_segments = 4
 
 [sub_resource type="StandardMaterial3D" id="StandardMaterial3D_tl8dq"]
@@ -83,8 +83,8 @@ albedo_color = Color(0.2279, 0.36888, 0.53, 1)
 [sub_resource type="CylinderMesh" id="CylinderMesh_w2aj8"]
 material = SubResource("StandardMaterial3D_tl8dq")
 top_radius = 0.0
-bottom_radius = 0.77
-height = 1.54
+bottom_radius = 0.575
+height = 1.185
 radial_segments = 4
 
 [node name="TestMultimesh" type="Node3D"]
@@ -114,12 +114,10 @@ mesh = SubResource("CylinderMesh_i1yhp")
 skeleton = NodePath("../..")
 
 [node name="MeshInstance3D5" type="MeshInstance3D" parent="Node3D"]
-transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 0, 0.246009, 0)
 mesh = SubResource("CylinderMesh_bvmel")
 skeleton = NodePath("../..")
 
 [node name="MeshInstance3D6" type="MeshInstance3D" parent="Node3D"]
-transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 0, 0.246009, 0)
 mesh = SubResource("CylinderMesh_x8oip")
 skeleton = NodePath("../..")
 
@@ -129,11 +127,10 @@ mesh = SubResource("CylinderMesh_dp7xj")
 skeleton = NodePath("../..")
 
 [node name="MeshInstance3D8" type="MeshInstance3D" parent="Node3D"]
-transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 0, 0.246009, 0)
 mesh = SubResource("CylinderMesh_8ctts")
 skeleton = NodePath("../..")
 
 [node name="MeshInstance3D9" type="MeshInstance3D" parent="Node3D"]
-transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 0, 0.246009, 0)
+transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 0, 0.126, 0)
 mesh = SubResource("CylinderMesh_w2aj8")
 skeleton = NodePath("../..")

--- a/src/terrain_3d.cpp
+++ b/src/terrain_3d.cpp
@@ -85,12 +85,6 @@ void Terrain3D::_initialize() {
 		LOG(DEBUG, "Connecting _assets.textures_changed to _material->_update_texture_arrays()");
 		_assets->connect("textures_changed", callable_mp(_material.ptr(), &Terrain3DMaterial::_update_texture_arrays));
 	}
-	// MeshAssets changed, update instancer
-	if (!_assets->is_connected("meshes_changed", callable_mp(_instancer, &Terrain3DInstancer::update_mmis).bind(-1, V2I_MAX, false))) {
-		LOG(DEBUG, "Connecting _assets.meshes_changed to _instancer->update_mmis()");
-		_assets->connect("meshes_changed", callable_mp(_instancer, &Terrain3DInstancer::update_mmis).bind(-1, V2I_MAX, false));
-	}
-
 	// Initialize the system
 	if (!_initialized && _is_inside_world && is_inside_tree()) {
 		LOG(INFO, "Initializing main subsystems");

--- a/src/terrain_3d_assets.h
+++ b/src/terrain_3d_assets.h
@@ -59,6 +59,7 @@ private:
 
 	void _update_texture_files();
 	void _update_texture_settings();
+	void _update_mesh(const int p_id);
 	void _setup_thumbnail_creation();
 	void _update_thumbnail(const Ref<Terrain3DMeshAsset> &p_mesh_asset);
 

--- a/src/terrain_3d_instancer.h
+++ b/src/terrain_3d_instancer.h
@@ -53,10 +53,11 @@ private:
 	uint32_t _get_density_count(const real_t p_density);
 	void _process_updates();
 	void _update_mmi_by_region(const Terrain3DRegion *p_region, const int p_mesh_id);
-	void _setup_mmi_lod_ranges(MultiMeshInstance3D *p_mmi, const Ref<Terrain3DMeshAsset> &p_ma, const int p_lod);
+	void _set_mmi_lod_ranges(MultiMeshInstance3D *p_mmi, const Ref<Terrain3DMeshAsset> &p_ma, const int p_lod);
 	void _update_vertex_spacing(const real_t p_vertex_spacing);
-	void _destroy_mmi_by_cell(const Vector2i &p_region_loc, const int p_mesh_id, const Vector2i p_cell);
+	void _destroy_mmi_by_mesh(const int p_mesh_id);
 	void _destroy_mmi_by_location(const Vector2i &p_region_loc, const int p_mesh_id);
+	void _destroy_mmi_by_cell(const Vector2i &p_region_loc, const int p_mesh_id, const Vector2i p_cell, const int p_lod = INT32_MAX);
 	void _backup_region(const Ref<Terrain3DRegion> &p_region);
 	Ref<MultiMesh> _create_multimesh(const int p_mesh_id, const int p_lod, const TypedArray<Transform3D> &p_xforms = TypedArray<Transform3D>(), const PackedColorArray &p_colors = PackedColorArray()) const;
 	Vector2i _get_cell(const Vector3 &p_global_position, const int p_region_size) const;

--- a/src/terrain_3d_mesh_asset.h
+++ b/src/terrain_3d_mesh_asset.h
@@ -38,7 +38,7 @@ private:
 	// Saved data
 	bool _enabled = true;
 	Ref<PackedScene> _packed_scene;
-	GenType _generated_type = TYPE_NONE;
+	GenType _generated_type = TYPE_TEXTURE_CARD;
 
 	real_t _height_offset = 0.f;
 	real_t _density = 10.f;
@@ -81,7 +81,7 @@ public:
 	void set_enabled(const bool p_enabled);
 	bool is_enabled() const { return _enabled; }
 
-	void update_instance_count(const uint32_t p_amount);
+	void update_instance_count(const int p_amount);
 	void set_instance_count(const uint32_t p_amount);
 	uint32_t get_instance_count() const { return _instance_count; }
 
@@ -145,6 +145,8 @@ public:
 
 protected:
 	void _validate_property(PropertyInfo &p_property) const;
+	bool _property_can_revert(const StringName &p_name) const;
+	bool _property_get_revert(const StringName &p_name, Variant &r_property) const;
 	static void _bind_methods();
 };
 

--- a/src/terrain_3d_texture_asset.cpp
+++ b/src/terrain_3d_texture_asset.cpp
@@ -60,7 +60,7 @@ void Terrain3DTextureAsset::set_name(const String &p_name) {
 
 void Terrain3DTextureAsset::set_id(const int p_new_id) {
 	int old_id = _id;
-	_id = CLAMP(p_new_id, 0, Terrain3DAssets::MAX_TEXTURES);
+	_id = CLAMP(p_new_id, 0, Terrain3DAssets::MAX_TEXTURES - 1);
 	LOG(INFO, "Setting texture id: ", _id);
 	LOG(DEBUG, "Emitting id_changed, TYPE_TEXTURE, ", old_id, ", ", _id);
 	emit_signal("id_changed", Terrain3DAssets::TYPE_TEXTURE, old_id, _id);


### PR DESCRIPTION
* Fixes regression https://github.com/TokisanGames/Terrain3D/pull/788 where shadow impostor mmi wasn't being calculated correctly.
* Removes multiple signal calls to update_mmis
* Fixes generated mesh settings not updating the display
* Fix Clamps and off by one bugs
* Fixes #818 
