### PR TITLE
Limit godot namespace to GDExtension

### DIFF
--- a/Terrain3D.vcxproj
+++ b/Terrain3D.vcxproj
@@ -78,6 +78,7 @@
     <AdditionalOptions>/std:c++17</AdditionalOptions>
     <OutDir>.vs</OutDir>
     <IntDir>.vs</IntDir>
+    <NMakePreprocessorDefinitions>GDEXTENSION</NMakePreprocessorDefinitions>
   </PropertyGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
     <ClCompile>

--- a/src/constants.h
+++ b/src/constants.h
@@ -3,7 +3,10 @@
 #ifndef CONSTANTS_CLASS_H
 #define CONSTANTS_CLASS_H
 
+// GDExtension uses the godot namespace, custom modules do not.
+#if defined(GDEXTENSION) && !defined(GODOT_MODULE)
 using namespace godot;
+#endif
 
 // Engine Shortcuts
 #define RS RenderingServer::get_singleton()

--- a/src/generated_texture.h
+++ b/src/generated_texture.h
@@ -7,8 +7,6 @@
 
 #include "constants.h"
 
-using namespace godot;
-
 class GeneratedTexture {
 	CLASS_NAME_STATIC("Terrain3DGenTex");
 

--- a/src/logger.h
+++ b/src/logger.h
@@ -5,9 +5,8 @@
 
 #include <godot_cpp/variant/utility_functions.hpp>
 
+#include "constants.h"
 #include "terrain_3d.h"
-
-using namespace godot;
 
 /**
  * Prints warnings, errors, and messages to the console.

--- a/src/register_types.cpp
+++ b/src/register_types.cpp
@@ -1,13 +1,14 @@
 // Copyright © 2025 Cory Petkovsek, Roope Palmroos, and Contributors.
 
+#ifdef GDEXTENSION
 #include <gdextension_interface.h>
+#endif
+
 #include <godot_cpp/core/class_db.hpp>
 
 #include "register_types.h"
 #include "terrain_3d.h"
 #include "terrain_3d_editor.h"
-
-using namespace godot;
 
 void initialize_terrain_3d(ModuleInitializationLevel p_level) {
 	if (p_level != MODULE_INITIALIZATION_LEVEL_SCENE) {

--- a/src/register_types.h
+++ b/src/register_types.h
@@ -3,9 +3,12 @@
 #ifndef TERRAIN3D_REGISTER_TYPES_H
 #define TERRAIN3D_REGISTER_TYPES_H
 
+#ifdef GDEXTENSION
 #include <godot_cpp/godot.hpp>
-
 using namespace godot;
+#else
+#include "modules/register_module_types.h"
+#endif
 
 void initialize_terrain_3d(ModuleInitializationLevel p_level);
 void uninitialize_terrain_3d(ModuleInitializationLevel p_level);

--- a/src/target_node_3d.h
+++ b/src/target_node_3d.h
@@ -5,7 +5,7 @@
 
 #include <godot_cpp/classes/node3d.hpp>
 
-using namespace godot;
+#include "constants.h"
 
 class TargetNode3D {
 	CLASS_NAME_STATIC("Terrain3DTargetNode3D");

--- a/src/terrain_3d.h
+++ b/src/terrain_3d.h
@@ -22,8 +22,6 @@
 #include "terrain_3d_material.h"
 #include "terrain_3d_mesher.h"
 
-using namespace godot;
-
 class Terrain3D : public Node3D {
 	GDCLASS(Terrain3D, Node3D);
 	CLASS_NAME();

--- a/src/terrain_3d_asset_resource.h
+++ b/src/terrain_3d_asset_resource.h
@@ -7,7 +7,6 @@
 
 #include "constants.h"
 
-using namespace godot;
 class Terrain3DAssets;
 
 // Parent class of Terrain3DMeshAsset and Terrain3DTextureAsset

--- a/src/terrain_3d_assets.h
+++ b/src/terrain_3d_assets.h
@@ -9,7 +9,6 @@
 #include "terrain_3d_mesh_asset.h"
 #include "terrain_3d_texture_asset.h"
 
-using namespace godot;
 class Terrain3D;
 class Terrain3DInstancer;
 

--- a/src/terrain_3d_collision.h
+++ b/src/terrain_3d_collision.h
@@ -11,8 +11,6 @@
 #include "constants.h"
 #include "terrain_3d_util.h"
 
-using namespace godot;
-
 class Terrain3D;
 
 class Terrain3DCollision : public Object {

--- a/src/terrain_3d_data.h
+++ b/src/terrain_3d_data.h
@@ -10,8 +10,6 @@
 
 class Terrain3D;
 
-using namespace godot;
-
 class Terrain3DData : public Object {
 	GDCLASS(Terrain3DData, Object);
 	CLASS_NAME();

--- a/src/terrain_3d_editor.h
+++ b/src/terrain_3d_editor.h
@@ -9,8 +9,6 @@
 #include "terrain_3d.h"
 #include "terrain_3d_region.h"
 
-using namespace godot;
-
 class Terrain3DEditor : public Object {
 	GDCLASS(Terrain3DEditor, Object);
 	CLASS_NAME();

--- a/src/terrain_3d_instancer.h
+++ b/src/terrain_3d_instancer.h
@@ -11,8 +11,6 @@
 #include "constants.h"
 #include "terrain_3d_region.h"
 
-using namespace godot;
-
 class Terrain3D;
 class Terrain3DAssets;
 

--- a/src/terrain_3d_material.h
+++ b/src/terrain_3d_material.h
@@ -10,8 +10,6 @@
 
 class Terrain3D;
 
-using namespace godot;
-
 class Terrain3DMaterial : public Resource {
 	GDCLASS(Terrain3DMaterial, Resource);
 	CLASS_NAME();

--- a/src/terrain_3d_mesh_asset.h
+++ b/src/terrain_3d_mesh_asset.h
@@ -13,7 +13,6 @@
 #include "constants.h"
 #include "terrain_3d_asset_resource.h"
 
-using namespace godot;
 using ShadowCasting = GeometryInstance3D::ShadowCastingSetting;
 constexpr ShadowCasting SHADOWS_ON = GeometryInstance3D::SHADOW_CASTING_SETTING_ON;
 constexpr ShadowCasting SHADOWS_OFF = GeometryInstance3D::SHADOW_CASTING_SETTING_OFF;

--- a/src/terrain_3d_mesher.h
+++ b/src/terrain_3d_mesher.h
@@ -5,8 +5,6 @@
 
 #include "constants.h"
 
-using namespace godot;
-
 class Terrain3D;
 
 class Terrain3DMesher {

--- a/src/terrain_3d_region.h
+++ b/src/terrain_3d_region.h
@@ -6,8 +6,6 @@
 #include "constants.h"
 #include "terrain_3d_util.h"
 
-using namespace godot;
-
 class Terrain3DRegion : public Resource {
 	GDCLASS(Terrain3DRegion, Resource);
 	CLASS_NAME();

--- a/src/terrain_3d_texture_asset.h
+++ b/src/terrain_3d_texture_asset.h
@@ -8,8 +8,6 @@
 #include "constants.h"
 #include "terrain_3d_asset_resource.h"
 
-using namespace godot;
-
 class Terrain3DTextureAsset : public Terrain3DAssetResource {
 	GDCLASS(Terrain3DTextureAsset, Terrain3DAssetResource);
 	CLASS_NAME();

--- a/src/terrain_3d_util.h
+++ b/src/terrain_3d_util.h
@@ -11,8 +11,6 @@
 #include "generated_texture.h"
 #include "terrain_3d.h"
 
-using namespace godot;
-
 // This file holds stateless utility functions for both C++ and GDScript
 // The class exposes static member and inline functions to GDscript
 // The inline functions below are not part of the class but are in the namespace, eg bilerp


### PR DESCRIPTION
This is first part of a series of commits to make GDNative build easier (but not fully supported).

GDExtension has everything under `godot` namespace. In engine, no such namespace exists. Since it is an error in C++ to use namespace which is not defined preprocessing is used to detect should godot namespace be used.

To avoid having to write this check to every header "using.inc" is added. This way using.inc only needs to be added every header without worrying about details. (I felt that .inc was better extension but I don't particularly care either way)

register_types is specially handled as gdextension_interface.h gives information in the GDExtension which is given modules/register_module_types.h in engine.