### PR TITLE
Remove dependency on Godot "Editor..." classes.

### DIFF
--- a/project/addons/terrain_3d/src/editor_plugin.gd
+++ b/project/addons/terrain_3d/src/editor_plugin.gd
@@ -477,3 +477,26 @@ func has_setting(p_str: String) -> bool:
 
 func erase_setting(p_str: String) -> void:
 	editor_settings.erase(p_str)
+
+
+## Undo / Redo Functions
+
+
+func create_undo_action(p_action_name: String) -> void:
+	get_undo_redo().create_action(p_action_name, UndoRedo.MERGE_DISABLE, terrain)
+
+
+func add_undo_method(p_method: Callable) -> void:
+	var args := [ p_method.get_object(), p_method.get_method() ]
+	args.append_array(p_method.get_bound_arguments())
+	get_undo_redo().add_undo_method.callv(args)
+
+
+func add_do_method(p_method: Callable) -> void:
+	var args := [ p_method.get_object(), p_method.get_method() ]
+	args.append_array(p_method.get_bound_arguments())
+	get_undo_redo().add_do_method.callv(args)
+
+
+func commit_action(p_execute: bool) -> void:
+	get_undo_redo().commit_action(p_execute)

--- a/src/terrain_3d.cpp
+++ b/src/terrain_3d.cpp
@@ -452,20 +452,20 @@ void Terrain3D::set_editor(Terrain3DEditor *p_editor) {
 		LOG(ERROR, "Attempted to set a node queued for deletion");
 		return;
 	}
-	LOG(INFO, "Set Terrain3DEditor: ", p_editor);
+	LOG(INFO, "Setting Terrain3DEditor: ", p_editor);
 	_editor = p_editor;
 	if (_material.is_valid()) {
 		_material->update();
 	}
 }
 
-void Terrain3D::set_plugin(EditorPlugin *p_plugin) {
+void Terrain3D::set_plugin(Object *p_plugin) {
 	if (p_plugin && p_plugin->is_queued_for_deletion()) {
 		LOG(ERROR, "Attempted to set a node queued for deletion");
 		return;
 	}
-	LOG(INFO, "Set EditorPlugin: ", p_plugin);
-	_plugin = p_plugin;
+	LOG(INFO, "Setting Editor Plugin: ", p_plugin);
+	_editor_plugin = p_plugin;
 }
 
 void Terrain3D::set_camera(Camera3D *p_camera) {
@@ -633,8 +633,8 @@ void Terrain3D::set_vertex_spacing(const real_t p_spacing) {
 			_collision->build();
 		}
 	}
-	if (IS_EDITOR && _plugin) {
-		_plugin->call("update_region_grid");
+	if (IS_EDITOR && _editor_plugin) {
+		_editor_plugin->call("update_region_grid");
 	}
 }
 

--- a/src/terrain_3d.h
+++ b/src/terrain_3d.h
@@ -4,10 +4,10 @@
 #define TERRAIN3D_CLASS_H
 
 #include <godot_cpp/classes/camera3d.hpp>
-#include <godot_cpp/classes/editor_plugin.hpp>
 #include <godot_cpp/classes/geometry_instance3d.hpp>
 #include <godot_cpp/classes/mesh.hpp>
 #include <godot_cpp/classes/mesh_instance3d.hpp>
+#include <godot_cpp/classes/object.hpp>
 #include <godot_cpp/classes/rendering_server.hpp>
 #include <godot_cpp/classes/static_body3d.hpp>
 #include <godot_cpp/classes/sub_viewport.hpp>
@@ -62,7 +62,7 @@ private:
 	Terrain3DCollision *_collision = nullptr;
 	Terrain3DMesher *_mesher = nullptr;
 	Terrain3DEditor *_editor = nullptr;
-	EditorPlugin *_plugin = nullptr;
+	Object *_editor_plugin = nullptr;
 
 	// Tracked Targets
 	TargetNode3D _clipmap_target;
@@ -143,8 +143,8 @@ public:
 	Node *get_mmi_parent() const { return _mmi_parent; }
 	void set_editor(Terrain3DEditor *p_editor);
 	Terrain3DEditor *get_editor() const { return _editor; }
-	void set_plugin(EditorPlugin *p_plugin);
-	EditorPlugin *get_plugin() const { return _plugin; }
+	void set_plugin(Object *p_plugin);
+	Object *get_plugin() const { return _editor_plugin; }
 
 	// Target Tracking
 	void set_camera(Camera3D *p_camera);

--- a/src/terrain_3d_material.cpp
+++ b/src/terrain_3d_material.cpp
@@ -275,7 +275,7 @@ String Terrain3DMaterial::_inject_editor_code(const String &p_shader) const {
 		LOG(DEBUG, "No void vertex(); cannot inject editor code");
 		return shader;
 	}
-	if (IS_EDITOR && _terrain && _terrain->get_editor()) {
+	if (_terrain && _terrain->get_editor()) {
 		insert_names.push_back("EDITOR_DECAL_SETUP");
 	}
 	if (_debug_view_heightmap) {
@@ -374,10 +374,10 @@ String Terrain3DMaterial::_inject_editor_code(const String &p_shader) const {
 		insert_names.push_back("OVERLAY_VERTEX_GRID");
 	}
 	// Editor Functions
-	if (_show_navigation || (IS_EDITOR && _terrain && _terrain->get_editor() && _terrain->get_editor()->get_tool() == Terrain3DEditor::NAVIGATION)) {
+	if (_show_navigation || (_terrain && _terrain->get_editor() && _terrain->get_editor()->get_tool() == Terrain3DEditor::NAVIGATION)) {
 		insert_names.push_back("EDITOR_NAVIGATION");
 	}
-	if (IS_EDITOR && _terrain && _terrain->get_editor()) {
+	if (_terrain && _terrain->get_editor()) {
 		insert_names.push_back("EDITOR_DECAL_RENDER");
 	}
 	// Apply pending inserts


### PR DESCRIPTION
 * Abstract the UndoRedo functionality out to methods on the plugin class.
 * Change the plugin interface to expect an Object rather than an EditorPlugin derived class to allow alternative implementations outside of the Godot editor.