### PR TITLE
Fix #830 - get_intersection() implementation does not align with the docs

### DIFF
--- a/src/constants.h
+++ b/src/constants.h
@@ -49,7 +49,7 @@ static const Vector3 V3_ZERO{ 0.f, 0.f, 0.f };
 static const Vector3 V3_MAX{ FLT_MAX, FLT_MAX, FLT_MAX };
 static const Vector3 V3_NAN{ NAN, NAN, NAN };
 static const Vector3 V3_UP{ 0.f, 1.f, 0.f };
-static const Vector3 V3_DOWN{ 0.f, -1.f, 0.f };
+//static const Vector3 V3_DOWN{ 0.f, -1.f, 0.f };
 
 struct Vector2iHash {
 	std::size_t operator()(const Vector2i &v) const {


### PR DESCRIPTION
(cherry picked from commit 8d17f6085df1db13a585eace85a3e99da6b5e93b)

Fixes #830 

If the direction is down or up in GPU mode, do not use look_at() just set the rotation on mouse_cam directly.

In non-GPU mode, determine whether we are below and looking up or above and looking down, then return get_height() or NAN accordingly. 

Grouped GPU and non-GPU logic

Handle impossible direction vectors