### PR TITLE
Installing hook did not set execution bit on Linux.

### DIFF
--- a/tools/install-hooks.py
+++ b/tools/install-hooks.py
@@ -1,4 +1,5 @@
 import os
+import stat
 import sys
 import shutil
 
@@ -11,5 +12,11 @@ if not os.path.exists(dist_dir):
 
 for file in os.listdir(src_dir):
     shutil.copy(os.path.join(src_dir, file), dist_dir)
+
+# Unix user needs the execute bit set.
+if os.name == "posix":
+    mode = stat.S_IRWXU | stat.S_IRGRP | stat.S_IROTH;
+    os.chmod(os.path.join(dist_dir, "pre-commit"), mode);
+    os.chmod(os.path.join(dist_dir, "pre-commit-clang-format"), mode);
 
 print("Copied tools/hooks/* to .git/hooks")


### PR DESCRIPTION
The precommit install script does not set execution bit. Linux user has to manually flip that. Commit adds this part to the install script.

Files ".git/hooks/pre-commit" and ".git/hooks/pre-commit-clang-format" are set to "-rwxr--r--" a.k.a owning user has read write execute rights; group with owning user and others have only read rights.

I put platform check because I'm not sure is this good in Apple products.