### PR TITLE
Changing init functions to be custom module friendly

### DIFF
--- a/src/register_types.cpp
+++ b/src/register_types.cpp
@@ -10,7 +10,7 @@
 #include "terrain_3d.h"
 #include "terrain_3d_editor.h"
 
-void initialize_terrain_3d(ModuleInitializationLevel p_level) {
+void initialize_terrain_3d_module(ModuleInitializationLevel p_level) {
 	if (p_level != MODULE_INITIALIZATION_LEVEL_SCENE) {
 		return;
 	}
@@ -27,11 +27,13 @@ void initialize_terrain_3d(ModuleInitializationLevel p_level) {
 	ClassDB::register_class<Terrain3DUtil>();
 }
 
-void uninitialize_terrain_3d(ModuleInitializationLevel p_level) {
+void uninitialize_terrain_3d_module(ModuleInitializationLevel p_level) {
 	if (p_level != MODULE_INITIALIZATION_LEVEL_SCENE) {
 		return;
 	}
 }
+
+#ifdef GDEXTENSION
 
 extern "C" {
 // Initialization.
@@ -41,10 +43,12 @@ GDExtensionBool GDE_EXPORT terrain_3d_init(
 		GDExtensionInitialization *r_initialization) {
 	GDExtensionBinding::InitObject init_obj(p_get_proc_address, p_library, r_initialization);
 
-	init_obj.register_initializer(initialize_terrain_3d);
-	init_obj.register_terminator(uninitialize_terrain_3d);
+	init_obj.register_initializer(initialize_terrain_3d_module);
+	init_obj.register_terminator(uninitialize_terrain_3d_module);
 	init_obj.set_minimum_library_initialization_level(MODULE_INITIALIZATION_LEVEL_SERVERS);
 
 	return init_obj.init();
 }
 }
+
+#endif /* GDEXTENSION */

--- a/src/register_types.h
+++ b/src/register_types.h
@@ -10,7 +10,8 @@ using namespace godot;
 #include "modules/register_module_types.h"
 #endif
 
-void initialize_terrain_3d(ModuleInitializationLevel p_level);
-void uninitialize_terrain_3d(ModuleInitializationLevel p_level);
+// NOTE: These have module ending for custom module build compatibility.
+void initialize_terrain_3d_module(ModuleInitializationLevel p_level);
+void uninitialize_terrain_3d_module(ModuleInitializationLevel p_level);
 
 #endif // TERRAIN3D_REGISTER_TYPES_H


### PR DESCRIPTION
Custom module build expects that init functions end with module.

Also wrapping the GDExtension starter function to preprocessing to:
* avoid errors
* been unnessary for custom module build.