### PR TITLE
Fix get_intersection w/ orthographic editor camera

### DIFF
--- a/src/shaders/gpu_depth.glsl
+++ b/src/shaders/gpu_depth.glsl
@@ -19,7 +19,7 @@ void fragment() {
 	view.xyz /= view.w;
 	float depth_linear = -view.z;
 
-	// Normalize depth to the range 0 - 1
+	// Normalize depth to the range 0 - 1. Divided by camera.get_far()
 	highp float scaledDepth = clamp(depth_linear / 100000.0, 0.0, 1.0);
 
 	// Encode using 127 steps, which map to the 128 - 255 range.


### PR DESCRIPTION
Recent changes from #830 #840 broke the editor ortho camera because of src_pos like (-772.4, 500115.5, -1651.1), and dir: (0.0, -1.0, 0.0).

After this change it should behave as follows:
* Straight down in a region, use get_height

Raymarch mode:
* Below terrain in a region - no hit
* Steps to intersection point, or no hit

GPU mode
* Use mouse_cam
* Special cases:
  * No visible polys: below terrain, sky, culled backfaces - no hit
  * looking straight down outside of a region y<99.5k - hits
  * looking straight down outside of a region y=99.5k-500k - no hit
  * looking straight down outside of a region w/ editor ortho camera (y>=500k) - return (src.x, 0.0, src.z) same as before

Docs will be updated in another PR.

Also see #851.