### PR TITLE
Fix decal under editor ortho camera

### DIFF
--- a/src/shaders/editor_functions.glsl
+++ b/src/shaders/editor_functions.glsl
@@ -21,7 +21,7 @@ uniform bool _editor_decal_visible[3]; // show decal: brush, slope point1, point
 uniform bool _editor_decal_part[2]; // show decal[0] component: texture, reticle
 
 float get_reticle(vec2 uv, int index) {
-	float cam_dist = length(_camera_pos - v_vertex);
+	float cam_dist = clamp(length(_camera_pos - v_vertex), 0., 4000.);
 	float sq_cam_dist = sqrt(cam_dist);
 	float view_scale = 16.0 / sq_cam_dist;
 	vec2 cross_uv = (uv * _vertex_spacing - _editor_decal_position[index]) * view_scale;

--- a/src/terrain_3d.cpp
+++ b/src/terrain_3d.cpp
@@ -776,8 +776,8 @@ Vector3 Terrain3D::get_intersection(const Vector3 &p_src_pos, const Vector3 &p_d
 
 		// Near-plane noise filter, or no hit (sky, underside, far clip)
 		if (decoded_depth < 0.00001f || decoded_depth > 1.f) {
-			// Catch editor ortho camera with src_pos.y at 500115.5
-			if (direction.y < -.99999f && p_src_pos.y >= 500000.f) {
+			// Catch editor ortho camera with src_pos.y at some random value around 500k
+			if (direction.y < -.99999f && p_src_pos.y >= 100000.f) {
 				return Vector3(p_src_pos.x, 0.f, p_src_pos.z);
 			}
 			return V3_MAX;


### PR DESCRIPTION
Under the editor ortho camera, which is positioned some random value around 500k, the editor decal was scaled too large. Now it's clamped to a max distance of 4000 which works fine on far perspective and ortho modes.

Also the get_intersection() catch for the editor ortho camera has dropped from y>= 500k to 100k. Most times the camera is above 500k, but I had one around 499k. 🤷‍♂️ 

Regression #848 