### PR TITLE
Fix differs(), inlines shares_ptr()

### DIFF
--- a/Terrain3D.vcxproj
+++ b/Terrain3D.vcxproj
@@ -158,6 +158,7 @@
     <ClInclude Include="src\terrain_3d_util.h" />
     <ClInclude Include="src\terrain_3d_material.h" />
     <ClInclude Include="src\terrain_3d_assets.h" />
+    <ClInclude Include="src\unit_testing.h" />
   </ItemGroup>
   <ItemGroup>
     <ClCompile Include="src\generated_texture.cpp" />
@@ -174,6 +175,7 @@
     <ClCompile Include="src\terrain_3d_texture_asset.cpp" />
     <ClCompile Include="src\terrain_3d_assets.cpp" />
     <ClCompile Include="src\terrain_3d_util.cpp" />
+    <ClCompile Include="src\unit_testing.cpp" />
   </ItemGroup>
   <ItemGroup>
     <None Include=".github\actions\base-deps\action.yml" />

--- a/Terrain3D.vcxproj.filters
+++ b/Terrain3D.vcxproj.filters
@@ -78,6 +78,9 @@
     <ClInclude Include="src\target_node_3d.h">
       <Filter>5. Headers</Filter>
     </ClInclude>
+    <ClInclude Include="src\unit_testing.h">
+      <Filter>5. Headers</Filter>
+    </ClInclude>
   </ItemGroup>
   <ItemGroup>
     <ClCompile Include="src\terrain_3d_mesher.cpp">
@@ -120,6 +123,9 @@
       <Filter>6. C++</Filter>
     </ClCompile>
     <ClCompile Include="src\terrain_3d_collision.cpp">
+      <Filter>6. C++</Filter>
+    </ClCompile>
+    <ClCompile Include="src\unit_testing.cpp">
       <Filter>6. C++</Filter>
     </ClCompile>
   </ItemGroup>

--- a/project/demo/data/assets.tres
+++ b/project/demo/data/assets.tres
@@ -1,6 +1,6 @@
 [gd_resource type="Terrain3DAssets" load_steps=11 format=3 uid="uid://dal3jhw6241qg"]
 
-[ext_resource type="PackedScene" uid="uid://bn5nf4esciwex" path="res://demo/assets/models/LODExample.tscn" id="1_4jrdu"]
+[ext_resource type="PackedScene" uid="uid://bn5nf4esciwex" path="res://demo/assets/models/LOD4Example.tscn" id="1_4jrdu"]
 [ext_resource type="Texture2D" uid="uid://c88j3oj0lf6om" path="res://demo/assets/textures/rock023_alb_ht.png" id="2_pog6b"]
 [ext_resource type="Texture2D" uid="uid://ddprscrpsofah" path="res://demo/assets/textures/ground037_alb_ht.png" id="3_g8f2m"]
 [ext_resource type="Texture2D" uid="uid://c307hdmos4gtm" path="res://demo/assets/textures/rock023_nrm_rgh.png" id="3_wncaf"]

--- a/src/terrain_3d.cpp
+++ b/src/terrain_3d.cpp
@@ -915,6 +915,7 @@ void Terrain3D::_notification(const int p_what) {
 			set_notify_transform(true);
 			set_meta("_edit_lock_", true);
 			_setup_mouse_picking();
+			// Reload editor textures - Also see READY
 			if (_free_editor_textures && !IS_EDITOR && _assets.is_valid() && !_assets->get_path().contains("Terrain3DAssets")) {
 				LOG(INFO, "free_editor_textures enabled, reloading Assets path: ", _assets->get_path());
 				_assets = ResourceLoader::get_singleton()->load(_assets->get_path(), "", ResourceLoader::CACHE_MODE_IGNORE);
@@ -927,6 +928,11 @@ void Terrain3D::_notification(const int p_what) {
 		case NOTIFICATION_READY: {
 			// Node is ready
 			LOG(INFO, "NOTIFICATION_READY");
+			// Optional: Run the testing suite
+			//#include "unit_testing.h"
+			//test_differs();
+
+			// Clear editor textures - also see ENTER_TREE
 			if (_free_editor_textures && !IS_EDITOR && _assets.is_valid()) {
 				if (_assets->get_path().contains("Terrain3DAssets")) {
 					LOG(WARN, "free_editor_textures requires `Assets` be saved to a file. Do so, or disable the former to turn off this warning");

--- a/src/terrain_3d_region.cpp
+++ b/src/terrain_3d_region.cpp
@@ -255,7 +255,7 @@ void Terrain3DRegion::calc_height_range() {
 }
 
 void Terrain3DRegion::set_instances(const Dictionary &p_instances) {
-	if (!_instances.is_empty() && !shares_ptr(_instances, p_instances)) {
+	if (!_instances.is_empty() && differs(_instances, p_instances)) {
 		_modified = true;
 	}
 	SET_IF_DIFF(_instances, p_instances);

--- a/src/unit_testing.cpp
+++ b/src/unit_testing.cpp
@@ -1,0 +1,167 @@
+// Copyright © 2025 Cory Petkovsek, Roope Palmroos, and Contributors.
+
+#include "unit_testing.h"
+#include "terrain_3d_util.h"
+
+void test_differs() {
+	UtilityFunctions::print("=== Testing differs function ===");
+
+	// Helper to log differs result with expected and PASS/FAIL
+	auto log_differs = [](const auto &a, const auto &b, const String &desc, bool expected) {
+		bool d = differs(a, b);
+		String result = (d == expected) ? "PASSED" : "FAILED";
+		UtilityFunctions::print(desc, ": differs(", a, ", ", b, ") = ", d, " - ", result);
+	};
+
+	// 1. Scalars: int, float (should use ==, differs if values differ)
+	{
+		int i1 = 42;
+		int i2 = 42; // Same
+		int i3 = 43; // Diff
+		log_differs(i1, i2, "int same", false);
+		log_differs(i1, i3, "int diff", true);
+
+		double f1 = 3.14;
+		double f2 = 3.14; // Same
+		double f3 = 3.14159; // Diff
+		log_differs(f1, f2, "float same", false);
+		log_differs(f1, f3, "float diff", true);
+	}
+
+	// 2. Vectors: Vector2, Vector2i, Vector3, Vector3i (should use ==)
+	{
+		Vector2 v2_1(1.0, 2.0);
+		Vector2 v2_2(1.0, 2.0); // Same
+		Vector2 v2_3(1.0, 3.0); // Diff
+		log_differs(v2_1, v2_2, "Vector2 same", false);
+		log_differs(v2_1, v2_3, "Vector2 diff", true);
+
+		Vector2i v2i_1(1, 2);
+		Vector2i v2i_2(1, 2); // Same
+		Vector2i v2i_3(1, 3); // Diff
+		log_differs(v2i_1, v2i_2, "Vector2i same", false);
+		log_differs(v2i_1, v2i_3, "Vector2i diff", true);
+
+		Vector3 v3_1(1.0, 2.0, 3.0);
+		Vector3 v3_2(1.0, 2.0, 3.0); // Same
+		Vector3 v3_3(1.0, 2.0, 4.0); // Diff
+		log_differs(v3_1, v3_2, "Vector3 same", false);
+		log_differs(v3_1, v3_3, "Vector3 diff", true);
+
+		Vector3i v3i_1(1, 2, 3);
+		Vector3i v3i_2(1, 2, 3); // Same
+		Vector3i v3i_3(1, 2, 4); // Diff
+		log_differs(v3i_1, v3i_2, "Vector3i same", false);
+		log_differs(v3i_1, v3i_3, "Vector3i diff", true);
+	}
+
+	// 3. String: Share (COW), same value diff ptr, diff value
+	{
+		String s1 = "test";
+		String s2 = s1; // Shared (COW)
+		String s3("test"); // Separate alloc, same value
+		String s4 = "diff";
+		log_differs(s1, s2, "String shared", false); // Same ptr
+		log_differs(s1, s3, "String same value diff ptr", false); // Length match + == true
+		log_differs(s1, s4, "String diff value", true); // Length may match, but == false
+	}
+
+	// 4. StringName: Similar to String (uses ==, but test sharing if applicable)
+	{
+		StringName sn1 = "test";
+		StringName sn2 = sn1; // Shared
+		StringName sn3("test"); // Separate, same value
+		StringName sn4 = "diff";
+		log_differs(sn1, sn2, "StringName shared", false);
+		log_differs(sn1, sn3, "StringName same value diff ptr", false); // == handles
+		log_differs(sn1, sn4, "StringName diff value", true);
+	}
+
+	// 5. Array: Share vs mutate
+	{
+		Array arr1;
+		arr1.push_back(42);
+		Array arr2 = arr1; // Shared
+		Array arr3; // Empty diff
+		arr3.push_back(42); // Same content, but separate (differs=true, conservative)
+		Array empty_arr; // Explicit empty for size diff
+		log_differs(arr1, arr2, "Array shared", false); // Same self ptr
+		log_differs(arr1, arr3, "Array same content diff ptr", true); // Diff self ptr (no fallback for Array)
+		log_differs(arr1, empty_arr, "Array size diff", true); // Size mismatch
+	}
+
+	// 6. TypedArray: e.g., TypedArray<int>
+	{
+		TypedArray<int> ta1;
+		ta1.push_back(42);
+		TypedArray<int> ta2 = ta1; // Shared
+		TypedArray<int> ta3; // Empty
+		ta3.push_back(42); // Separate
+		TypedArray<int> empty_ta; // Explicit empty
+		log_differs(ta1, ta2, "TypedArray shared", false); // Via Array base
+		log_differs(ta1, ta3, "TypedArray same content diff ptr", true); // Diff self
+		log_differs(ta1, empty_ta, "TypedArray size diff", true); // Size mismatch
+	}
+
+	// 7. Dictionary: Share vs mutate
+	{
+		Dictionary dict1;
+		dict1["key"] = 42;
+		Dictionary dict2 = dict1; // Shared
+		Dictionary dict3; // Empty
+		dict3["key"] = 42; // Separate
+		Dictionary empty_dict; // Explicit empty
+		log_differs(dict1, dict2, "Dictionary shared", false);
+		log_differs(dict1, dict3, "Dictionary same content diff ptr", true); // Diff self
+		log_differs(dict1, empty_dict, "Dictionary size diff", true); // Size mismatch
+	}
+
+	// 8. Variant types: Wrap above (falls to ==)
+	{
+		Variant v_int1 = 42;
+		Variant v_int2 = 42; // Same
+		Variant v_int3 = 43; // Diff
+		log_differs(v_int1, v_int2, "Variant int same", false);
+		log_differs(v_int1, v_int3, "Variant int diff", true);
+
+		Variant v_float1 = 3.14;
+		Variant v_float2 = 3.14;
+		Variant v_float3 = 3.14159;
+		log_differs(v_float1, v_float2, "Variant float same", false);
+		log_differs(v_float1, v_float3, "Variant float diff", true);
+
+		Variant v_str1 = String("test");
+		Variant v_str2 = String("test");
+		Variant v_str3 = String("diff");
+		log_differs(v_str1, v_str2, "Variant String same", false);
+		log_differs(v_str1, v_str3, "Variant String diff", true);
+
+		// Variant Object (use RefCounted for ref support)
+		Ref<RefCounted> rc1 = memnew(RefCounted);
+		Ref<RefCounted> rc2 = rc1; // Same ref
+		Ref<RefCounted> rc3 = memnew(RefCounted); // Diff
+		Variant v_rc1 = rc1;
+		Variant v_rc2 = rc2;
+		Variant v_rc3 = rc3;
+		log_differs(v_rc1, v_rc2, "Variant RefCounted same ref", false); // Ref == true
+		log_differs(v_rc1, v_rc3, "Variant RefCounted diff ref", true);
+
+		// Variant Array
+		Array arr_var1;
+		arr_var1.push_back(42);
+		Variant v_arr1 = arr_var1;
+		Array arr_var2 = arr_var1;
+		Variant v_arr2 = arr_var2;
+		log_differs(v_arr1, v_arr2, "Variant Array shared", false); // Variant == checks inner
+
+		// Variant Dictionary
+		Dictionary dict_var1;
+		dict_var1["key"] = 42;
+		Variant v_dict1 = dict_var1;
+		Dictionary dict_var2 = dict_var1;
+		Variant v_dict2 = dict_var2;
+		log_differs(v_dict1, v_dict2, "Variant Dictionary shared", false);
+	}
+
+	UtilityFunctions::print("=== End differs tests ===");
+}

--- a/src/unit_testing.h
+++ b/src/unit_testing.h
@@ -1,0 +1,26 @@
+// Copyright © 2025 Cory Petkovsek, Roope Palmroos, and Contributors.
+
+#ifndef UNIT_TESTING_H
+#define UNIT_TESTING_H
+
+#define EXPECT_FALSE(cond)                              \
+	do {                                                \
+		if (cond) {                                     \
+			UtilityFunctions::print("FAILED: ", #cond); \
+		} else {                                        \
+			UtilityFunctions::print("PASSED: ", #cond); \
+		}                                               \
+	} while (0)
+
+#define EXPECT_TRUE(cond)                               \
+	do {                                                \
+		if (cond) {                                     \
+			UtilityFunctions::print("PASSED: ", #cond); \
+		} else {                                        \
+			UtilityFunctions::print("FAILED: ", #cond); \
+		}                                               \
+	} while (0)
+
+void test_differs();
+
+#endif // UNIT_TESTING_H


### PR DESCRIPTION
Fixes #864 
Regression from https://github.com/TokisanGames/Terrain3D/commit/8cade44ba9985f52fd40c8bfb3a17d2b9c5a0459

Addresses a subtle issue with indexing into a pointer directly. The problem was the offset here `(pa + 8)` was wrong for Arrays/Dictionaries. It shouldn't have had the offset and was reading off the end of the array. The size of the array/object was different when building with dev_mode=yes or not.

The new code removes the +8 for Arrays/Dicts and keeps it for String, and rewrites the section a bit.

I also included a testing function that confirms with or without dev_mode arrays and other types compare properly.

@aidandavey 