### PR TITLE
Scale normal depth by distance

### DIFF
--- a/doc/api/class_terrain3d.rst
+++ b/doc/api/class_terrain3d.rst
@@ -80,6 +80,8 @@ Properties
    +-------------------------------------------------------------+------------------------------------------------------------------------------------------------+-----------------+
    | ``int``                                                     | :ref:`label_size<class_Terrain3D_property_label_size>`                                         | ``48``          |
    +-------------------------------------------------------------+------------------------------------------------------------------------------------------------+-----------------+
+   | ``Node3D``                                                  | :ref:`light_target<class_Terrain3D_property_light_target>`                                     |                 |
+   +-------------------------------------------------------------+------------------------------------------------------------------------------------------------+-----------------+
    | :ref:`Terrain3DMaterial<class_Terrain3DMaterial>`           | :ref:`material<class_Terrain3D_property_material>`                                             |                 |
    +-------------------------------------------------------------+------------------------------------------------------------------------------------------------+-----------------+
    | ``int``                                                     | :ref:`mesh_lods<class_Terrain3D_property_mesh_lods>`                                           | ``7``           |
@@ -95,8 +97,6 @@ Properties
    | ``bool``                                                    | :ref:`ocean_enabled<class_Terrain3D_property_ocean_enabled>`                                   | ``false``       |
    +-------------------------------------------------------------+------------------------------------------------------------------------------------------------+-----------------+
    | GeometryInstance3D.GIMode                                   | :ref:`ocean_gi_mode<class_Terrain3D_property_ocean_gi_mode>`                                   | ``0``           |
-   +-------------------------------------------------------------+------------------------------------------------------------------------------------------------+-----------------+
-   | ``Node3D``                                                  | :ref:`ocean_light_target<class_Terrain3D_property_ocean_light_target>`                         |                 |
    +-------------------------------------------------------------+------------------------------------------------------------------------------------------------+-----------------+
    | ``Material``                                                | :ref:`ocean_material<class_Terrain3D_property_ocean_material>`                                 |                 |
    +-------------------------------------------------------------+------------------------------------------------------------------------------------------------+-----------------+
@@ -777,7 +777,7 @@ Alias for :ref:`Terrain3DInstancer.mode<class_Terrain3DInstancer_property_mode>`
 - |void| **set_label_distance**\ (\ value\: ``float``\ )
 - ``float`` **get_label_distance**\ (\ )
 
-If label_distance is non-zero (try 1024-4096) it will generate and display region coordinates in the viewport so you can identify the exact region files you are editing. This setting is the visible distance of the labels.
+If label_distance is non-zero (try 1024-4096) it will generate and display region coordinates in the viewport so you can identify the exact region files you are editing. This setting is the visible distance of the labels. With the mouse in the viewport you can press the hotkey to toggle visibility (default `2`).
 
 .. rst-class:: classref-item-separator
 
@@ -795,6 +795,23 @@ If label_distance is non-zero (try 1024-4096) it will generate and display regio
 - ``int`` **get_label_size**\ (\ )
 
 Sets the font size for region labels. See :ref:`label_distance<class_Terrain3D_property_label_distance>`.
+
+.. rst-class:: classref-item-separator
+
+----
+
+.. _class_Terrain3D_property_light_target:
+
+.. rst-class:: classref-property
+
+``Node3D`` **light_target** :ref:`🔗<class_Terrain3D_property_light_target>`
+
+.. rst-class:: classref-property-setget
+
+- |void| **set_light_target**\ (\ value\: ``Node3D``\ )
+- ``Node3D`` **get_light_target**\ (\ )
+
+This sets the _light_direction and _light_color uniforms in the terrain and ocean shaders, if they are present. You can use them for light scattering, detecting if the light is above the horizon or the terrain faces the sun, etc.
 
 .. rst-class:: classref-item-separator
 
@@ -937,23 +954,6 @@ GeometryInstance3D.GIMode **ocean_gi_mode** = ``0`` :ref:`🔗<class_Terrain3D_p
 - GeometryInstance3D.GIMode **get_ocean_gi_mode**\ (\ )
 
 Tells the renderer which global illumination mode to use for the ocean mesh. This sets ``GeometryInstance3D.gi_mode`` in the engine.
-
-.. rst-class:: classref-item-separator
-
-----
-
-.. _class_Terrain3D_property_ocean_light_target:
-
-.. rst-class:: classref-property
-
-``Node3D`` **ocean_light_target** :ref:`🔗<class_Terrain3D_property_ocean_light_target>`
-
-.. rst-class:: classref-property-setget
-
-- |void| **set_ocean_light_target**\ (\ value\: ``Node3D``\ )
-- ``Node3D`` **get_ocean_light_target**\ (\ )
-
-This sets the _light_direction and _light_color uniforms in the ocean shader, if they are present. You can use this for light scattering, detecting if the light is above the horizon, albedo coloring, etc.
 
 .. rst-class:: classref-item-separator
 
@@ -1205,7 +1205,7 @@ Alias for :ref:`Terrain3DMaterial.show_colormap<class_Terrain3DMaterial_property
 - |void| **set_show_contours**\ (\ value\: ``bool``\ )
 - ``bool`` **get_show_contours**\ (\ )
 
-Overlays contour lines on the terrain. Customize the options in the material when enabled. Press `4` with the mouse in the viewport to toggle.
+Overlays contour lines on the terrain. Customize the options in the material when enabled. With the mouse in the viewport you can press the hotkey to toggle visibility (default `3`).
 
 Alias for :ref:`Terrain3DMaterial.show_contours<class_Terrain3DMaterial_property_show_contours>`.
 
@@ -1336,7 +1336,7 @@ Alias for :ref:`Terrain3DMaterial.show_grey<class_Terrain3DMaterial_property_sho
 - |void| **set_show_region_grid**\ (\ value\: ``bool``\ )
 - ``bool`` **get_show_region_grid**\ (\ )
 
-Alias for :ref:`Terrain3DMaterial.show_region_grid<class_Terrain3DMaterial_property_show_region_grid>`. Press `1` with the mouse in the viewport to toggle.
+Alias for :ref:`Terrain3DMaterial.show_region_grid<class_Terrain3DMaterial_property_show_region_grid>`. With the mouse in the viewport you can press the hotkey to toggle visibility (default `1`).
 
 .. rst-class:: classref-item-separator
 
@@ -1372,7 +1372,7 @@ Alias for :ref:`Terrain3DMaterial.show_heightmap<class_Terrain3DMaterial_propert
 - |void| **set_show_instancer_grid**\ (\ value\: ``bool``\ )
 - ``bool`` **get_show_instancer_grid**\ (\ )
 
-Overlays the 32x32m instancer grid on the terrain, which shows how the instancer data is partitioned. Press `2` with the mouse in the viewport to toggle.
+Overlays the 32x32m instancer grid on the terrain, which shows how the instancer data is partitioned. With the mouse in the viewport you can press the hotkey to toggle visibility (default `4`).
 
 Alias for :ref:`Terrain3DMaterial.show_instancer_grid<class_Terrain3DMaterial_property_show_instancer_grid>`.
 
@@ -1429,7 +1429,7 @@ Alias for :ref:`Terrain3DMaterial.show_navigation<class_Terrain3DMaterial_proper
 - |void| **set_show_region_grid**\ (\ value\: ``bool``\ )
 - ``bool`` **get_show_region_grid**\ (\ )
 
-Overlays the region grid on the terrain. This is more accurate than the region grid gizmo for determining where the region border is when editing. Press `1` with the mouse in the viewport to toggle.
+Overlays the region grid on the terrain. This is more accurate than the region grid gizmo for determining where the region border is when editing. With the mouse in the viewport you can press the hotkey to toggle visibility (default `1`).
 
 Alias for :ref:`Terrain3DMaterial.show_region_grid<class_Terrain3DMaterial_property_show_region_grid>`.
 
@@ -1562,7 +1562,7 @@ Alias for :ref:`Terrain3DMaterial.show_texture_rough<class_Terrain3DMaterial_pro
 - |void| **set_show_vertex_grid**\ (\ value\: ``bool``\ )
 - ``bool`` **get_show_vertex_grid**\ (\ )
 
-Overlays the vertex grid on the terrain, showing where each vertex is. Press `3` with the mouse in the viewport to toggle.
+Overlays the vertex grid on the terrain, showing where each vertex is. With the mouse in the viewport you can press the hotkey to toggle visibility (default `5`).
 
 Alias for :ref:`Terrain3DMaterial.show_vertex_grid<class_Terrain3DMaterial_property_show_vertex_grid>`.
 

--- a/doc/doc_classes/Terrain3D.xml
+++ b/doc/doc_classes/Terrain3D.xml
@@ -217,10 +217,13 @@
 			Alias for [member Terrain3DInstancer.mode].
 		</member>
 		<member name="label_distance" type="float" setter="set_label_distance" getter="get_label_distance" default="0.0">
-			If label_distance is non-zero (try 1024-4096) it will generate and display region coordinates in the viewport so you can identify the exact region files you are editing. This setting is the visible distance of the labels.
+			If label_distance is non-zero (try 1024-4096) it will generate and display region coordinates in the viewport so you can identify the exact region files you are editing. This setting is the visible distance of the labels. With the mouse in the viewport you can press the hotkey to toggle visibility (default `2`).
 		</member>
 		<member name="label_size" type="int" setter="set_label_size" getter="get_label_size" default="48">
 			Sets the font size for region labels. See [member label_distance].
+		</member>
+		<member name="light_target" type="Node3D" setter="set_light_target" getter="get_light_target">
+			This sets the _light_direction and _light_color uniforms in the terrain and ocean shaders, if they are present. You can use them for light scattering, detecting if the light is above the horizon or the terrain faces the sun, etc.
 		</member>
 		<member name="material" type="Terrain3DMaterial" setter="set_material" getter="get_material">
 			A custom material for Terrain3D. You can optionally save this as an external [code skip-lint].tres[/code] text file if you wish to share it with instances of Terrain3D in other scenes. See [Terrain3DMaterial].
@@ -248,9 +251,6 @@
 		</member>
 		<member name="ocean_gi_mode" type="int" setter="set_ocean_gi_mode" getter="get_ocean_gi_mode" enum="GeometryInstance3D.GIMode" default="0">
 			Tells the renderer which global illumination mode to use for the ocean mesh. This sets [code skip-lint]GeometryInstance3D.gi_mode[/code] in the engine.
-		</member>
-		<member name="ocean_light_target" type="Node3D" setter="set_ocean_light_target" getter="get_ocean_light_target">
-			This sets the _light_direction and _light_color uniforms in the ocean shader, if they are present. You can use this for light scattering, detecting if the light is above the horizon, albedo coloring, etc.
 		</member>
 		<member name="ocean_material" type="Material" setter="set_ocean_material" getter="get_ocean_material">
 			You can assign a [code skip-lint]StandardMaterial[/code] here for testing, but you really need a [code skip-lint]ShaderMaterial[/code]. Start with the example in [code skip-lint]addons/terrain_3d/extras/shaders/M_ocean.tres[/code], which you can build on. Or use any of the ocean shaders available around the internet, provided you set `skip_vertex_transform` and copy the geomorphing code from our `vertex()` shader, which will properly handle the LOD transitions on the clipmap.
@@ -299,7 +299,7 @@
 			Alias for [member Terrain3DMaterial.show_colormap].
 		</member>
 		<member name="show_contours" type="bool" setter="set_show_contours" getter="get_show_contours" default="false">
-			Overlays contour lines on the terrain. Customize the options in the material when enabled. Press `4` with the mouse in the viewport to toggle.
+			Overlays contour lines on the terrain. Customize the options in the material when enabled. With the mouse in the viewport you can press the hotkey to toggle visibility (default `3`).
 			Alias for [member Terrain3DMaterial.show_contours].
 		</member>
 		<member name="show_control_angle" type="bool" setter="set_show_control_angle" getter="get_show_control_angle" default="false">
@@ -326,14 +326,14 @@
 			Alias for [member Terrain3DMaterial.show_grey].
 		</member>
 		<member name="show_grid" type="bool" setter="set_show_region_grid" getter="get_show_region_grid" default="false">
-			Alias for [member Terrain3DMaterial.show_region_grid]. Press `1` with the mouse in the viewport to toggle.
+			Alias for [member Terrain3DMaterial.show_region_grid]. With the mouse in the viewport you can press the hotkey to toggle visibility (default `1`).
 		</member>
 		<member name="show_heightmap" type="bool" setter="set_show_heightmap" getter="get_show_heightmap" default="false">
 			Albedo is a white to black gradient depending on height. The gradient is scaled to a height of 300, so above that or far below 0 will be all white or black.
 			Alias for [member Terrain3DMaterial.show_heightmap].
 		</member>
 		<member name="show_instancer_grid" type="bool" setter="set_show_instancer_grid" getter="get_show_instancer_grid" default="false">
-			Overlays the 32x32m instancer grid on the terrain, which shows how the instancer data is partitioned. Press `2` with the mouse in the viewport to toggle.
+			Overlays the 32x32m instancer grid on the terrain, which shows how the instancer data is partitioned. With the mouse in the viewport you can press the hotkey to toggle visibility (default `4`).
 			Alias for [member Terrain3DMaterial.show_instancer_grid].
 		</member>
 		<member name="show_jaggedness" type="bool" setter="set_show_jaggedness" getter="get_show_jaggedness" default="false">
@@ -345,7 +345,7 @@
 			Alias for [member Terrain3DMaterial.show_navigation].
 		</member>
 		<member name="show_region_grid" type="bool" setter="set_show_region_grid" getter="get_show_region_grid" default="false">
-			Overlays the region grid on the terrain. This is more accurate than the region grid gizmo for determining where the region border is when editing. Press `1` with the mouse in the viewport to toggle.
+			Overlays the region grid on the terrain. This is more accurate than the region grid gizmo for determining where the region border is when editing. With the mouse in the viewport you can press the hotkey to toggle visibility (default `1`).
 			Alias for [member Terrain3DMaterial.show_region_grid].
 		</member>
 		<member name="show_roughmap" type="bool" setter="set_show_roughmap" getter="get_show_roughmap" default="false">
@@ -373,7 +373,7 @@
 			Alias for [member Terrain3DMaterial.show_texture_rough].
 		</member>
 		<member name="show_vertex_grid" type="bool" setter="set_show_vertex_grid" getter="get_show_vertex_grid" default="false">
-			Overlays the vertex grid on the terrain, showing where each vertex is. Press `3` with the mouse in the viewport to toggle.
+			Overlays the vertex grid on the terrain, showing where each vertex is. With the mouse in the viewport you can press the hotkey to toggle visibility (default `5`).
 			Alias for [member Terrain3DMaterial.show_vertex_grid].
 		</member>
 		<member name="tessellation_level" type="int" setter="set_tessellation_level" getter="get_tessellation_level" default="0">

--- a/project/addons/terrain_3d/csharp/Terrain3D.cs
+++ b/project/addons/terrain_3d/csharp/Terrain3D.cs
@@ -173,6 +173,10 @@ public partial class Terrain3D : Node3D
 		/// </summary>
 		public new static readonly StringName Instancer = "instancer";
 		/// <summary>
+		/// Cached name for the 'light_target' member.
+		/// </summary>
+		public new static readonly StringName LightTarget = "light_target";
+		/// <summary>
 		/// Cached name for the 'region_size' member.
 		/// </summary>
 		public new static readonly StringName RegionSize = "region_size";
@@ -317,10 +321,6 @@ public partial class Terrain3D : Node3D
 		/// </summary>
 		public new static readonly StringName OceanMaterial = "ocean_material";
 		/// <summary>
-		/// Cached name for the 'ocean_light_target' member.
-		/// </summary>
-		public new static readonly StringName OceanLightTarget = "ocean_light_target";
-		/// <summary>
 		/// Cached name for the 'mouse_layer' member.
 		/// </summary>
 		public new static readonly StringName MouseLayer = "mouse_layer";
@@ -464,6 +464,12 @@ public partial class Terrain3D : Node3D
 	public new Terrain3DInstancer Instancer
 	{
 		get => Terrain3DInstancer.Bind(Get(GDExtensionPropertyName.Instancer).As<GodotObject>());
+	}
+
+	public new Node3D LightTarget
+	{
+		get => Get(GDExtensionPropertyName.LightTarget).As<Node3D>();
+		set => Set(GDExtensionPropertyName.LightTarget, value);
 	}
 
 	public new Terrain3D.RegionSizeEnum RegionSize
@@ -680,12 +686,6 @@ public partial class Terrain3D : Node3D
 	{
 		get => Get(GDExtensionPropertyName.OceanMaterial).As<Material>();
 		set => Set(GDExtensionPropertyName.OceanMaterial, value);
-	}
-
-	public new Node3D OceanLightTarget
-	{
-		get => Get(GDExtensionPropertyName.OceanLightTarget).As<Node3D>();
-		set => Set(GDExtensionPropertyName.OceanLightTarget, value);
 	}
 
 	public new long MouseLayer

--- a/project/addons/terrain_3d/csharp/Terrain3DMaterial.cs
+++ b/project/addons/terrain_3d/csharp/Terrain3DMaterial.cs
@@ -123,6 +123,10 @@ public partial class Terrain3DMaterial : Resource
 		/// </summary>
 		public new static readonly StringName OutputRoughness = "output_roughness";
 		/// <summary>
+		/// Cached name for the 'output_specular' member.
+		/// </summary>
+		public new static readonly StringName OutputSpecular = "output_specular";
+		/// <summary>
 		/// Cached name for the 'output_normal_map' member.
 		/// </summary>
 		public new static readonly StringName OutputNormalMap = "output_normal_map";
@@ -290,6 +294,12 @@ public partial class Terrain3DMaterial : Resource
 	{
 		get => Get(GDExtensionPropertyName.OutputRoughness).As<bool>();
 		set => Set(GDExtensionPropertyName.OutputRoughness, value);
+	}
+
+	public new bool OutputSpecular
+	{
+		get => Get(GDExtensionPropertyName.OutputSpecular).As<bool>();
+		set => Set(GDExtensionPropertyName.OutputSpecular, value);
 	}
 
 	public new bool OutputNormalMap

--- a/project/addons/terrain_3d/extras/shaders/lightweight.gdshader
+++ b/project/addons/terrain_3d/extras/shaders/lightweight.gdshader
@@ -438,7 +438,7 @@ void fragment() {
 	// Apply PBR
 	ALBEDO = albedo_height.rgb * color_map.rgb * macrov;
 	ROUGHNESS = roughness;
-	SPECULAR = 1. - normal_rough.a;
+	SPECULAR = 1. - roughness;
 	// Repack final normal map value.
 	NORMAL_MAP = fma(normalize(normal_rough.xzy), vec3(0.5), vec3(0.5));
 	NORMAL_MAP_DEPTH = normal_map_depth;

--- a/project/addons/terrain_3d/extras/shaders/ocean_shader.gdshader
+++ b/project/addons/terrain_3d/extras/shaders/ocean_shader.gdshader
@@ -63,8 +63,8 @@ uniform float _subdiv = 1.;
 uniform float _vertex_spacing = 1.;
 uniform float _vertex_density = 1.;
 uniform vec3 _target_pos = vec3(0.,0.,0.);
-uniform vec3 _light_direction = vec3(-0.196, 0.980, 0);
-uniform vec3 _light_color : source_color = vec3(1.0, 1.0, .735);
+uniform vec3 _light_direction = vec3(0.0, 0.0, 0.0);
+uniform vec3 _light_color : source_color = vec3(1.0, 1.0, 1.0);
 group_uniforms;
 
 uniform sampler2D depth_texture : hint_depth_texture, repeat_disable, filter_nearest;

--- a/project/demo/Demo.tscn
+++ b/project/demo/Demo.tscn
@@ -25,10 +25,11 @@ transform = Transform3D(0.176947, 0, -0.98422, 0, 1, 0, 0.98422, 0, 0.176947, 22
 [node name="Terrain3DParticles" parent="." node_paths=PackedStringArray("terrain") instance=ExtResource("8_fwrtk")]
 terrain = NodePath("../Terrain3D")
 
-[node name="Terrain3D" type="Terrain3D" parent="." node_paths=PackedStringArray("collision_target", "clipmap_target", "ocean_light_target")]
+[node name="Terrain3D" type="Terrain3D" parent="." node_paths=PackedStringArray("light_target", "collision_target", "clipmap_target")]
 data_directory = "res://demo/data"
 material = ExtResource("5_fwrtk")
 assets = ExtResource("8_g2of2")
+light_target = NodePath("../Environment/DirectionalLight3D")
 collision_target = NodePath("../Player")
 collision_mask = 3
 clipmap_target = NodePath("../Player")
@@ -37,7 +38,6 @@ mesh_size = 96
 cull_margin = 450.0
 ocean_enabled = true
 ocean_material = ExtResource("7_fwrtk")
-ocean_light_target = NodePath("../Environment/DirectionalLight3D")
 top_level = true
 metadata/_edit_lock_ = true
 

--- a/project/demo/data/M_terrain.tres
+++ b/project/demo/data/M_terrain.tres
@@ -31,6 +31,7 @@ _shader_parameters = {
 "bias_distance": 512.0,
 "blend_sharpness": 0.5,
 "depth_blur": 0.0,
+&"distant_normal_scale": 2.0,
 "dual_scale_far": 170.0,
 "dual_scale_near": 100.0,
 "dual_scale_reduction": 0.3,

--- a/src/shaders/main.glsl
+++ b/src/shaders/main.glsl
@@ -72,14 +72,16 @@ uniform highp sampler2DArray _control_maps : repeat_disable;
 uniform highp sampler2DArray _color_maps : source_color, FILTER_METHOD, repeat_disable;
 uniform highp sampler2DArray _texture_array_albedo : source_color, FILTER_METHOD, repeat_enable;
 uniform highp sampler2DArray _texture_array_normal : hint_normal, FILTER_METHOD, repeat_enable;
+uniform vec3 _light_direction = vec3(0., 0., 0);
+uniform vec3 _light_color : source_color = vec3(1.0, 1.0, .735);
 group_uniforms;
 
 // Public uniforms
 group_uniforms shader_uniforms.general;
 //INSERT: FLAT_UNIFORMS
 uniform bool flat_terrain_normals = false;
+uniform float distant_normal_scale : hint_range(1.0, 10.0, 0.1) = 2.0;
 uniform float blend_sharpness : hint_range(0, 1) = 0.5;
-//INSERT: PROJECTION_UNIFORMS
 group_uniforms;
 
 //INSERT: AUTO_SHADER_UNIFORMS
@@ -90,7 +92,6 @@ group_uniforms;
 group_uniforms shader_uniforms.mipmaps;
 uniform float bias_distance : hint_range(0.0, 16384.0, 0.1) = 512.0;
 uniform float mipmap_bias : hint_range(0.5, 1.5, 0.01) = 1.0;
-uniform float distant_normal_scale : hint_range(1.0, 10.0, 0.1) = 2.0;
 uniform float depth_blur : hint_range(0.0, 35.0, 0.1) = 0.0;
 group_uniforms;
 
@@ -580,18 +581,28 @@ void fragment() {
 	mat.ao *= weight_inv;
 	mat.ao_affect *= weight_inv;
 
-	//INSERT: MACRO_VARIATION
-	
-	// Wetness/roughness modifier, converting 0 - 1 range to -1 to 1 range, clamped to Godot roughness values 
-	float roughness = clamp(fma(color_map.a - 0.5, 2.0, mat.normal_rough.a), 0., 1.);
-
+	vec3 normal_map = fma(normalize(mat.normal_rough.xzy), vec3(0.5), vec3(0.5));
 	float distant_normal_amplifier = clamp(max(length(base_ddx.xz), length(base_ddy.xz)), 1., distant_normal_scale);
+	mat.normal_map_depth *= distant_normal_amplifier;
+
+	//INSERT: MACRO_VARIATION
+
+	// Wetness/roughness modifier, converting 0 - 1 range to -1 to 1 range, clamped to Godot roughness values 
+	float wetness = fma(color_map.a, -2., 1.);
+	float roughness = clamp(mat.normal_rough.a - wetness, 0., 1.);
 	
+	// Specular w/ non-light-facing suppression. Apply wetness after so it reflects the sky after sunset
+	float terrain_facing_light = clamp(dot(w_normal, normalize(_light_direction)), 0.0, 1.0);
+	float specular = 1. - mat.normal_rough.a;
+	specular *= mix(0.0, 1.0, terrain_facing_light);
+	specular = clamp(specular + wetness, 0., 1.);
+
 	// Apply PBR
 //INSERT: OUTPUT_ALBEDO
 //INSERT: OUTPUT_ALBEDO_GREY
 //INSERT: OUTPUT_ROUGHNESS
 //INSERT: OUTPUT_SPECULAR
+//INSERT: OUTPUT_SPECULAR_NONE
 //INSERT: OUTPUT_NORMAL_MAP
 //INSERT: OUTPUT_AMBIENT_OCCLUSION
 

--- a/src/shaders/main.glsl
+++ b/src/shaders/main.glsl
@@ -90,6 +90,7 @@ group_uniforms;
 group_uniforms shader_uniforms.mipmaps;
 uniform float bias_distance : hint_range(0.0, 16384.0, 0.1) = 512.0;
 uniform float mipmap_bias : hint_range(0.5, 1.5, 0.01) = 1.0;
+uniform float distant_normal_scale : hint_range(1.0, 10.0, 0.1) = 2.0;
 uniform float depth_blur : hint_range(0.0, 35.0, 0.1) = 0.0;
 group_uniforms;
 
@@ -583,6 +584,8 @@ void fragment() {
 	
 	// Wetness/roughness modifier, converting 0 - 1 range to -1 to 1 range, clamped to Godot roughness values 
 	float roughness = clamp(fma(color_map.a - 0.5, 2.0, mat.normal_rough.a), 0., 1.);
+
+	float distant_normal_amplifier = clamp(max(length(base_ddx.xz), length(base_ddy.xz)), 1., distant_normal_scale);
 	
 	// Apply PBR
 //INSERT: OUTPUT_ALBEDO

--- a/src/shaders/pbr_views.glsl
+++ b/src/shaders/pbr_views.glsl
@@ -61,13 +61,13 @@ R"(
 //INSERT: OUTPUT_ROUGHNESS
 	ROUGHNESS = roughness;
 //INSERT: OUTPUT_SPECULAR
-	SPECULAR = 1. - roughness;
+	SPECULAR = specular;
 //INSERT: OUTPUT_SPECULAR_NONE
 	SPECULAR = 0.;
 //INSERT: OUTPUT_NORMAL_MAP
-	// Repack final normal map value.
-	NORMAL_MAP = fma(normalize(mat.normal_rough.xzy), vec3(0.5), vec3(0.5));
-	NORMAL_MAP_DEPTH = mat.normal_map_depth * distant_normal_amplifier;
+	// Repack final normal map value
+	NORMAL_MAP = normal_map;
+	NORMAL_MAP_DEPTH = mat.normal_map_depth;
 //INSERT: OUTPUT_AMBIENT_OCCLUSION
 	AO = clamp(mat.ao, 0., 1.);
 	AO_LIGHT_AFFECT = mat.ao_affect;

--- a/src/shaders/pbr_views.glsl
+++ b/src/shaders/pbr_views.glsl
@@ -67,7 +67,7 @@ R"(
 //INSERT: OUTPUT_NORMAL_MAP
 	// Repack final normal map value.
 	NORMAL_MAP = fma(normalize(mat.normal_rough.xzy), vec3(0.5), vec3(0.5));
-	NORMAL_MAP_DEPTH = mat.normal_map_depth;
+	NORMAL_MAP_DEPTH = mat.normal_map_depth * distant_normal_amplifier;
 //INSERT: OUTPUT_AMBIENT_OCCLUSION
 	AO = clamp(mat.ao, 0., 1.);
 	AO_LIGHT_AFFECT = mat.ao_affect;

--- a/src/terrain_3d.cpp
+++ b/src/terrain_3d.cpp
@@ -124,15 +124,22 @@ void Terrain3D::__physics_process(const double p_delta) {
 	}
 	if (_ocean_enabled && _ocean_mesher) {
 		_ocean_mesher->snap();
-		if (_ocean_material.is_valid() && _ocean_light_target.is_valid()) {
-			DirectionalLight3D *light = cast_to<DirectionalLight3D>(_ocean_light_target.ptr());
-			ShaderMaterial *ocean_shader_mat = Object::cast_to<ShaderMaterial>(_ocean_material.ptr());
-			if (light && ocean_shader_mat) {
-				Color color = COLOR_WHITE;
-				color = light->get_color() * light->get_param(DirectionalLight3D::PARAM_ENERGY);
-				ocean_shader_mat->set_shader_parameter("_light_color", color);
-				Vector3 direction = light->get_global_basis().get_column(2);
-				ocean_shader_mat->set_shader_parameter("_light_direction", direction);
+	}
+	if (_light_target.is_valid()) {
+		DirectionalLight3D *light = cast_to<DirectionalLight3D>(_light_target.ptr());
+		if (light) {
+			Color color = light->get_color() * light->get_param(DirectionalLight3D::PARAM_ENERGY);
+			Vector3 direction = light->get_global_basis().get_column(2);
+			if (_material.is_valid()) {
+				_material->set_shader_param("_light_color", color);
+				_material->set_shader_param("_light_direction", direction);
+			}
+			if (_ocean_material.is_valid()) {
+				ShaderMaterial *ocean_shader_mat = Object::cast_to<ShaderMaterial>(_ocean_material.ptr());
+				if (ocean_shader_mat) {
+					ocean_shader_mat->set_shader_parameter("_light_color", color);
+					ocean_shader_mat->set_shader_parameter("_light_direction", direction);
+				}
 			}
 		}
 	}
@@ -692,11 +699,11 @@ Vector3 Terrain3D::get_collision_target_position() const {
 	return V3_ZERO;
 }
 
-void Terrain3D::set_ocean_light_target(Node3D *p_node) {
-	if (_ocean_light_target.ptr() != p_node) {
+void Terrain3D::set_light_target(Node3D *p_node) {
+	if (_light_target.ptr() != p_node) {
 		LOG(INFO, "Setting directional light target: ", p_node);
-		_ocean_light_target.set_target(p_node);
-		if (_ocean_light_target.is_valid()) {
+		_light_target.set_target(p_node);
+		if (_light_target.is_valid()) {
 			set_physics_process(true);
 		}
 	}
@@ -1372,8 +1379,8 @@ void Terrain3D::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("set_collision_target", "node"), &Terrain3D::set_collision_target);
 	ClassDB::bind_method(D_METHOD("get_collision_target"), &Terrain3D::get_collision_target);
 	ClassDB::bind_method(D_METHOD("get_collision_target_position"), &Terrain3D::get_collision_target_position);
-	ClassDB::bind_method(D_METHOD("set_ocean_light_target", "node"), &Terrain3D::set_ocean_light_target);
-	ClassDB::bind_method(D_METHOD("get_ocean_light_target"), &Terrain3D::get_ocean_light_target);
+	ClassDB::bind_method(D_METHOD("set_light_target", "node"), &Terrain3D::set_light_target);
+	ClassDB::bind_method(D_METHOD("get_light_target"), &Terrain3D::get_light_target);
 	ClassDB::bind_method(D_METHOD("snap"), &Terrain3D::snap);
 
 	// Collision
@@ -1517,6 +1524,7 @@ void Terrain3D::_bind_methods() {
 	ADD_PROPERTY(PropertyInfo(Variant::OBJECT, "data", PROPERTY_HINT_NONE, "", PROPERTY_USAGE_NONE, "Terrain3DData"), "", "get_data");
 	ADD_PROPERTY(PropertyInfo(Variant::OBJECT, "collision", PROPERTY_HINT_NONE, "", PROPERTY_USAGE_NONE, "Terrain3DCollision"), "", "get_collision");
 	ADD_PROPERTY(PropertyInfo(Variant::OBJECT, "instancer", PROPERTY_HINT_NONE, "", PROPERTY_USAGE_NONE, "Terrain3DInstancer"), "", "get_instancer");
+	ADD_PROPERTY(PropertyInfo(Variant::OBJECT, "light_target", PROPERTY_HINT_NODE_TYPE, "DirectionalLight3D", PROPERTY_USAGE_DEFAULT, "Node3D"), "set_light_target", "get_light_target");
 
 	ADD_GROUP("Regions", "");
 	ADD_PROPERTY(PropertyInfo(Variant::INT, "region_size", PROPERTY_HINT_ENUM, "64:64,128:128,256:256,512:512,1024:1024,2048:2048", PROPERTY_USAGE_EDITOR), "change_region_size", "get_region_size");
@@ -1563,7 +1571,6 @@ void Terrain3D::_bind_methods() {
 	ADD_PROPERTY(PropertyInfo(Variant::INT, "ocean_gi_mode", PROPERTY_HINT_ENUM, "Disabled,Static,Dynamic"), "set_ocean_gi_mode", "get_ocean_gi_mode");
 	ADD_PROPERTY(PropertyInfo(Variant::INT, "ocean_render_layers", PROPERTY_HINT_LAYERS_3D_RENDER), "set_ocean_render_layers", "get_ocean_render_layers");
 	ADD_PROPERTY(PropertyInfo(Variant::OBJECT, "ocean_material", PROPERTY_HINT_RESOURCE_TYPE, "ShaderMaterial,BaseMaterial3D"), "set_ocean_material", "get_ocean_material");
-	ADD_PROPERTY(PropertyInfo(Variant::OBJECT, "ocean_light_target", PROPERTY_HINT_NODE_TYPE, "DirectionalLight3D", PROPERTY_USAGE_DEFAULT, "Node3D"), "set_ocean_light_target", "get_ocean_light_target");
 
 	ADD_GROUP("Rendering", "");
 	ADD_PROPERTY(PropertyInfo(Variant::INT, "mouse_layer", PROPERTY_HINT_RANGE, "21, 32"), "set_mouse_layer", "get_mouse_layer");

--- a/src/terrain_3d.h
+++ b/src/terrain_3d.h
@@ -69,7 +69,7 @@ private:
 	// Tracked Targets
 	TargetNode3D _clipmap_target;
 	TargetNode3D _collision_target;
-	TargetNode3D _ocean_light_target;
+	TargetNode3D _light_target;
 	TargetNode3D _camera; // Fallback target for clipmap and collision
 
 	// Terrain Mesh
@@ -188,8 +188,8 @@ public:
 	void set_collision_target(Node3D *p_node);
 	Node3D *get_collision_target() const { return _collision_target.ptr(); }
 	Vector3 get_collision_target_position() const;
-	void set_ocean_light_target(Node3D *p_node);
-	Node3D *get_ocean_light_target() const { return _ocean_light_target.ptr(); }
+	void set_light_target(Node3D *p_node);
+	Node3D *get_light_target() const { return _light_target.ptr(); }
 	void snap();
 
 	// Collision Aliases

--- a/src/terrain_3d_material.cpp
+++ b/src/terrain_3d_material.cpp
@@ -887,13 +887,21 @@ void Terrain3DMaterial::set_buffer_shader_override(const Ref<Shader> &p_shader) 
 
 void Terrain3DMaterial::set_shader_param(const StringName &p_name, const Variant &p_value) {
 	LOG(INFO, "Setting shader parameter: ", p_name);
-	_set(p_name, p_value);
+	if (p_name.begins_with("_") && _material.is_valid()) {
+		RS->material_set_param(_material, p_name, p_value);
+	} else {
+		_set(p_name, p_value);
+	}
 }
 
 Variant Terrain3DMaterial::get_shader_param(const StringName &p_name) const {
 	LOG(INFO, "Getting shader parameter: ", p_name);
 	Variant value;
-	_get(p_name, value);
+	if (p_name.begins_with("_") && _material.is_valid()) {
+		value = RS->material_get_param(_material, p_name);
+	} else {
+		_get(p_name, value);
+	}
 	return value;
 }
 

--- a/src/terrain_3d_material.h
+++ b/src/terrain_3d_material.h
@@ -44,7 +44,7 @@ private:
 	Dictionary _shader_code; // All loaded shader and INSERT code
 	bool _shader_override_enabled = false;
 	Ref<Shader> _shader_override; // User's shader we copy code from
-	mutable TypedArray<StringName> _active_params; // All shader params in the current shader
+	mutable TypedArray<StringName> _active_params; // All public shader params in the current shader
 	mutable Dictionary _shader_params; // Public shader params saved to disk
 
 	RID _buffer_material;


### PR DESCRIPTION
Admin edit

This PR adds:
* Normal scaling, default on set to 2
* Light direction/color to the terrain shader (using the same light target as the ocean shader)
* [Specular suppression](https://github.com/TokisanGames/Terrain3D/pull/870#issuecomment-4968418686) for terrain faces that aren't facing the sun light

Normal scaling:

Before
<img width="526" height="307" alt="{6FDAB0DF-CB85-430C-88AB-9869AA07D58C}" src="https://github.com/user-attachments/assets/4572d248-1cdc-45a8-91c2-a26cfa3b40ac" />

After set to 10 (2-4 is best)
<img width="592" height="342" alt="{EBB6C664-3C96-4CF8-91AB-FE6BB5147179}" src="https://github.com/user-attachments/assets/e3fd68aa-2bd6-4132-9b5e-e2faced04fe3" />



-------

Fixes #857 

You can close this pull request if you like, as I understand I am not assigned to the issue, but I implemented a lightweight method using Xstarsia's plan to use dFdx/dFdy space for scaling the AO and normals intensity depending on their distance to the camera.

I allow for the effect's intensity to be adjusted by a shader parameter, and clamp it to 1.0 at minimum so that it doesn't go below the normal depth / ao original values. It adds a subtle but noticeable difference that improves the visuals, as seen here:

<img width="1149" height="647" alt="Screenshot 2025-11-19 230509" src="https://github.com/user-attachments/assets/3e66c52e-5ea1-4895-8a8e-ea9f14f55e9c" />
<img width="1148" height="645" alt="Screenshot 2025-11-19 230729" src="https://github.com/user-attachments/assets/fa1039b0-275b-4e94-9fe2-ed3f5b3404b8" />

