### PR TITLE
Ocean mesh

### DIFF
--- a/project/addons/terrain_3d/extras/shaders/ocean.gdshader
+++ b/project/addons/terrain_3d/extras/shaders/ocean.gdshader
@@ -1,0 +1,97 @@
+shader_type spatial;
+render_mode specular_toon;
+
+// Shader adapted from https://docs.godotengine.org/en/4.4/tutorials/shaders/your_first_shader/your_second_3d_shader.html
+// Also includes snippets from https://godotshaders.com/snippet/useful-code-snippets/ 
+
+group_uniforms ocean;
+uniform float sea_level : hint_range(-50.0, 50.0, 0.1) = 0.0;
+uniform float height_scale : hint_range(0.01, 10.0, 0.01) = 0.5;
+uniform float uv_scale : hint_range(1.0, 50.0, 1.0) = 1.0;
+group_uniforms;
+
+uniform sampler2D screen_tex : hint_screen_texture;
+
+uniform int _cell_amount = 10;
+uniform vec2 _period = vec2(5., 10.);
+
+vec2 modulo(vec2 divident, vec2 divisor){
+	vec2 positiveDivident = mod(divident, divisor) + divisor;
+	return mod(positiveDivident, divisor);
+}
+
+vec2 random(vec2 value){
+	value = vec2( dot(value, vec2(127.1,311.7) ),
+				  dot(value, vec2(269.5,183.3) ) );
+	return -1.0 + 2.0 * fract(sin(value) * 43758.5453123);
+}
+
+float seamless_noise(vec2 uv) {
+	uv = uv * float(_cell_amount);
+	vec2 cellsMinimum = floor(uv);
+	vec2 cellsMaximum = ceil(uv);
+	vec2 uv_fract = fract(uv);
+
+	cellsMinimum = modulo(cellsMinimum, _period);
+	cellsMaximum = modulo(cellsMaximum, _period);
+
+	vec2 blur = smoothstep(0.0, 1.0, uv_fract);
+
+	vec2 lowerLeftDirection = random(vec2(cellsMinimum.x, cellsMinimum.y));
+	vec2 lowerRightDirection = random(vec2(cellsMaximum.x, cellsMinimum.y));
+	vec2 upperLeftDirection = random(vec2(cellsMinimum.x, cellsMaximum.y));
+	vec2 upperRightDirection = random(vec2(cellsMaximum.x, cellsMaximum.y));
+
+	vec2 fraction = fract(uv);
+
+	return mix( mix( dot( lowerLeftDirection, fraction - vec2(0, 0) ),
+                     dot( lowerRightDirection, fraction - vec2(1, 0) ), blur.x),
+                mix( dot( upperLeftDirection, fraction - vec2(0, 1) ),
+                     dot( upperRightDirection, fraction - vec2(1, 1) ), blur.x), blur.y) * 0.8 + 0.5;
+}
+
+float fbm(vec2 uv) {
+    int octaves = 6;
+    float amplitude = 5.0;
+    float frequency = 2.0;
+	float value = 0.0;
+
+    for(int i = 0; i < octaves; i++) {
+        value += amplitude * seamless_noise(frequency * uv);
+        amplitude *= 0.5;
+        frequency *= 2.0;
+    }
+    return value;
+}
+
+float wave(vec2 position){
+  position += fbm(position * 0.01) * 2.0 - 1.0;
+  vec2 wv = 1.0 - abs(sin(position));
+  return pow(1.0 - pow(wv.x * wv.y, 0.65), 4.0);
+}
+
+float get_height(vec2 position, float time) {
+  float d = wave((position + time) * 0.4) * 0.3;
+  d += wave((position - time) * 0.3) * 0.3;
+  d += wave((position + time) * 0.5) * 0.2;
+  d += wave((position - time) * 0.6) * 0.2;
+  return d;
+}
+
+void vertex() {
+	// Get vertex of flat plane in world coordinates and set world UV
+	vec3 vertex = (MODEL_MATRIX * vec4(VERTEX, 1.0)).xyz;
+	vec2 uv = (vertex.xz / 2.0 + 0.5) / uv_scale;
+	float height = get_height(uv, TIME);
+	VERTEX.y = sea_level + (height  * height_scale);
+	NORMAL = normalize(vec3(height - get_height(uv + vec2(0.1, 0.0), TIME), 0.1, height - get_height(uv + vec2(0.0, 0.1), TIME)));
+}
+
+void fragment() {
+	float fresnel = sqrt(1.0 - dot(NORMAL, VIEW));
+	vec3 screen_clr = texture(screen_tex, SCREEN_UV).rgb;
+	RIM = 0.1;
+	ROUGHNESS = 0.01;
+	METALLIC = 0.0;
+	ALBEDO = screen_clr + (0.1 * fresnel);	
+}

--- a/project/addons/terrain_3d/extras/shaders/ocean.gdshader.uid
+++ b/project/addons/terrain_3d/extras/shaders/ocean.gdshader.uid
@@ -1,0 +1,1 @@
+uid://cn05moyauhmut

--- a/project/demo/assets/materials/M_ocean.tres
+++ b/project/demo/assets/materials/M_ocean.tres
@@ -1,0 +1,12 @@
+[gd_resource type="ShaderMaterial" load_steps=2 format=3 uid="uid://c4vrkvmhr2giw"]
+
+[ext_resource type="Shader" uid="uid://cn05moyauhmut" path="res://addons/terrain_3d/extras/shaders/ocean.gdshader" id="1_7od5o"]
+
+[resource]
+render_priority = 0
+shader = ExtResource("1_7od5o")
+shader_parameter/sea_level = 0.0
+shader_parameter/height_scale = 0.5
+shader_parameter/uv_scale = 1.0
+shader_parameter/_cell_amount = 10
+shader_parameter/_period = Vector2(5, 10)

--- a/src/terrain_3d.h
+++ b/src/terrain_3d.h
@@ -79,6 +79,14 @@ private:
 	int _tessellation_level = 0;
 	real_t _vertex_spacing = 1.0f;
 
+	// Ocean meshes
+	int _ocean_mesh_lods = 7;
+	int _ocean_mesh_size = 48;
+	int _ocean_tessellation_level = 0;
+
+	// Ocean material
+	Ref<Material> _ocean_material;
+
 	// Rendering
 	uint32_t _render_layers = 1u | (1u << 31u); // Bit 1 and 32 for the cursor
 	RenderingServer::ShadowCastingSetting _cast_shadows = RenderingServer::SHADOW_CASTING_SETTING_ON;
@@ -194,6 +202,19 @@ public:
 	bool is_buffer_shader_override_enabled() const { return _material.is_valid() ? _material->is_buffer_shader_override_enabled() : false; }
 	void set_buffer_shader_override(const Ref<Shader> &p_shader) { return _material.is_valid() ? _material->set_buffer_shader_override(p_shader) : void(); }
 	Ref<Shader> get_buffer_shader_override() const { return _material.is_valid() ? _material->get_buffer_shader_override() : Ref<Shader>(); }
+
+	// Ocean Mesh
+	void set_ocean_enabled(const bool p_enabled);
+	bool is_ocean_enabled() const { return _mesher ? _mesher->is_ocean_enabled() : false; }
+	void set_ocean_mesh_lods(const int p_count);
+	int get_ocean_mesh_lods() const { return _ocean_mesh_lods; }
+	void set_ocean_mesh_size(const int p_size);
+	int get_ocean_mesh_size() const { return _ocean_mesh_size; }
+	void set_ocean_tessellation_level(const int p_level);
+	int get_ocean_tessellation_level() const { return _ocean_tessellation_level; }
+	Ref<Material> get_ocean_material() const { return _ocean_material; }
+	void set_ocean_material(const Ref<Material> &p_material);
+	RID get_ocean_material_rid() const { return _ocean_material.is_valid() ? _ocean_material->get_rid() : RID(); }
 
 	// Rendering
 	void set_render_layers(const uint32_t p_layers);

--- a/src/terrain_3d_mesher.cpp
+++ b/src/terrain_3d_mesher.cpp
@@ -12,34 +12,33 @@
 // Private Functions
 ///////////////////////////
 
-void Terrain3DMesher::_generate_mesh_types(const int p_size) {
-	_clear_mesh_types();
+void Terrain3DMesher::_generate_mesh_types(Array &p_mesh_rids_array, const int p_size, const RID &p_mat) {
 	LOG(INFO, "Generating all Mesh segments for clipmap of size ", p_size);
 	// Create initial set of Mesh blocks to build the clipmap
 	// # 0 TILE - mesh_size x mesh_size tiles
-	_mesh_rids.push_back(_generate_mesh(V2I(p_size)));
+	p_mesh_rids_array.push_back(_generate_mesh(V2I(p_size), false, p_mat));
 	// # 1 EDGE_A - 2 by (mesh_size * 4 + 8) strips to bridge LOD transitions along +-Z axis
-	_mesh_rids.push_back(_generate_mesh(Vector2i(2, p_size * 4 + 8)));
+	p_mesh_rids_array.push_back(_generate_mesh(Vector2i(2, p_size * 4 + 8), false, p_mat));
 	// # 2 EDGE_B - (mesh_size * 4 + 4) by 2 strips to bridge LOD transitions along +-X axis
-	_mesh_rids.push_back(_generate_mesh(Vector2i(p_size * 4 + 4, 2)));
+	p_mesh_rids_array.push_back(_generate_mesh(Vector2i(p_size * 4 + 4, 2), false, p_mat));
 	// # 3 FILL_A - 4 by mesh_size
-	_mesh_rids.push_back(_generate_mesh(Vector2i(4, p_size)));
+	p_mesh_rids_array.push_back(_generate_mesh(Vector2i(4, p_size), false, p_mat));
 	// # 4 FILL_B - mesh_size by 4
-	_mesh_rids.push_back(_generate_mesh(Vector2i(p_size, 4)));
+	p_mesh_rids_array.push_back(_generate_mesh(Vector2i(p_size, 4), false, p_mat));
 	// # 5 STANDARD_TRIM_A - 2 by (mesh_size * 4 + 2) strips for LOD0 +-Z axis edge
-	_mesh_rids.push_back(_generate_mesh(Vector2i(2, p_size * 4 + 2), true));
+	p_mesh_rids_array.push_back(_generate_mesh(Vector2i(2, p_size * 4 + 2), true, p_mat));
 	// # 6 STANDARD_TRIM_B - (mesh_size * 4 + 2) by 2 strips for LOD0 +-X axis edge
-	_mesh_rids.push_back(_generate_mesh(Vector2i(p_size * 4 + 2, 2), true));
+	p_mesh_rids_array.push_back(_generate_mesh(Vector2i(p_size * 4 + 2, 2), true, p_mat));
 	// # 7 STANDARD_TILE - mesh_size x mesh_size tiles
-	_mesh_rids.push_back(_generate_mesh(Vector2i(p_size, p_size), true));
+	p_mesh_rids_array.push_back(_generate_mesh(Vector2i(p_size, p_size), true, p_mat));
 	// # 8 STANDARD_EDGE_A - 2 by (mesh_size * 4 + 8) strips to bridge LOD transitions along +-Z axis
-	_mesh_rids.push_back(_generate_mesh(Vector2i(2, p_size * 4 + 8), true));
+	p_mesh_rids_array.push_back(_generate_mesh(Vector2i(2, p_size * 4 + 8), true, p_mat));
 	// # 9 STANDARD_EDGE_B - (mesh_size * 4 + 4) by 2 strips to bridge LOD transitions along +-X axis
-	_mesh_rids.push_back(_generate_mesh(Vector2i(p_size * 4 + 4, 2), true));
+	p_mesh_rids_array.push_back(_generate_mesh(Vector2i(p_size * 4 + 4, 2), true, p_mat));
 	return;
 }
 
-RID Terrain3DMesher::_generate_mesh(const Vector2i &p_size, const bool p_standard_grid) {
+RID Terrain3DMesher::_generate_mesh(const Vector2i &p_size, const bool p_standard_grid, const RID &p_mat) {
 	PackedVector3Array vertices;
 	PackedInt32Array indices;
 	AABB aabb = AABB(V3_ZERO, Vector3(p_size.x, 0.1f, p_size.y));
@@ -80,11 +79,10 @@ RID Terrain3DMesher::_generate_mesh(const Vector2i &p_size, const bool p_standar
 			}
 		}
 	}
-
-	return _instantiate_mesh(vertices, indices, aabb);
+	return _instantiate_mesh(vertices, indices, aabb, p_mat);
 }
 
-RID Terrain3DMesher::_instantiate_mesh(const PackedVector3Array &p_vertices, const PackedInt32Array &p_indices, const AABB &p_aabb) {
+RID Terrain3DMesher::_instantiate_mesh(const PackedVector3Array &p_vertices, const PackedInt32Array &p_indices, const AABB &p_aabb, const RID &p_mat) {
 	Array arrays;
 	arrays.resize(RenderingServer::ARRAY_MAX);
 	arrays[RenderingServer::ARRAY_VERTEX] = p_vertices;
@@ -106,25 +104,31 @@ RID Terrain3DMesher::_instantiate_mesh(const PackedVector3Array &p_vertices, con
 
 	LOG(DEBUG, "Setting custom aabb: ", p_aabb.position, ", ", p_aabb.size);
 	RS->mesh_set_custom_aabb(mesh, p_aabb);
-	RS->mesh_surface_set_material(mesh, 0, _terrain->get_material()->get_material_rid());
+	RS->mesh_surface_set_material(mesh, 0, p_mat);
 
 	return mesh;
 }
 
-void Terrain3DMesher::_generate_clipmap(const int p_size, const int p_lods, const RID &p_scenario) {
-	_clear_clipmap();
-	_generate_mesh_types(p_size);
-	_generate_offset_data(p_size);
+void Terrain3DMesher::_generate_clipmap(Array &p_instance_rids, Array &p_mesh_rids, MeshOffsetData &p_offset_data, const int p_size, const int p_lods, const RID &p_scenario, const RID &p_mat) {
+	_clear_clipmap(p_instance_rids);
+	_clear_mesh_types(p_mesh_rids);
+	_clear_offset_data(p_offset_data);
+	_generate_mesh_types(p_mesh_rids, p_size, p_mat);
+	_generate_offset_data(p_offset_data, p_size);
 	LOG(DEBUG, "Creating instances for all mesh segments for clipmap of size ", p_size, " for ", p_lods, " LODs");
+	_generate_instances(p_instance_rids, p_mesh_rids, p_lods, p_scenario);
+}
 
+void Terrain3DMesher::_generate_instances(Array &p_instance_rids, Array &p_mesh_rids, const int p_lods, const RID &p_scenario) {
 	for (int level = 0; level < p_lods; level++) {
+		LOG(DEBUG, "Generating instances for lod", level);
 		Array lod;
 		// 12 Tiles LOD1+, 16 for LOD0
 		Array tile_rids;
-		int tile_ammount = (level == 0) ? 16 : 12;
+		int tile_amount = (level == 0) ? 16 : 12;
 
-		for (int i = 0; i < tile_ammount; i++) {
-			RID tile_rid = RS->instance_create2(_mesh_rids[level == 0 ? STANDARD_TILE : TILE], p_scenario);
+		for (int i = 0; i < tile_amount; i++) {
+			RID tile_rid = RS->instance_create2(p_mesh_rids[level == 0 ? STANDARD_TILE : TILE], p_scenario);
 			tile_rids.append(tile_rid);
 		}
 		lod.append(tile_rids); // index 0 TILE
@@ -132,14 +136,14 @@ void Terrain3DMesher::_generate_clipmap(const int p_size, const int p_lods, cons
 		// 4 Edges present on all LODs
 		Array edge_a_rids;
 		for (int i = 0; i < 2; i++) {
-			RID edge_a_rid = RS->instance_create2(_mesh_rids[level == 0 ? STANDARD_EDGE_A : EDGE_A], p_scenario);
+			RID edge_a_rid = RS->instance_create2(p_mesh_rids[level == 0 ? STANDARD_EDGE_A : EDGE_A], p_scenario);
 			edge_a_rids.append(edge_a_rid);
 		}
 		lod.append(edge_a_rids); // index 1 EDGE_A
 
 		Array edge_b_rids;
 		for (int i = 0; i < 2; i++) {
-			RID edge_b_rid = RS->instance_create2(_mesh_rids[level == 0 ? STANDARD_EDGE_B : EDGE_B], p_scenario);
+			RID edge_b_rid = RS->instance_create2(p_mesh_rids[level == 0 ? STANDARD_EDGE_B : EDGE_B], p_scenario);
 			edge_b_rids.append(edge_b_rid);
 		}
 		lod.append(edge_b_rids); // index 2 EDGE_B
@@ -148,14 +152,14 @@ void Terrain3DMesher::_generate_clipmap(const int p_size, const int p_lods, cons
 		if (level > 0) {
 			Array fill_a_rids;
 			for (int i = 0; i < 2; i++) {
-				RID fill_a_rid = RS->instance_create2(_mesh_rids[FILL_A], p_scenario);
+				RID fill_a_rid = RS->instance_create2(p_mesh_rids[FILL_A], p_scenario);
 				fill_a_rids.append(fill_a_rid);
 			}
 			lod.append(fill_a_rids); // index 4 FILL_A
 
 			Array fill_b_rids;
 			for (int i = 0; i < 2; i++) {
-				RID fill_b_rid = RS->instance_create2(_mesh_rids[FILL_B], p_scenario);
+				RID fill_b_rid = RS->instance_create2(p_mesh_rids[FILL_B], p_scenario);
 				fill_b_rids.append(fill_b_rid);
 			}
 			lod.append(fill_b_rids); // index 5 FILL_B
@@ -164,116 +168,197 @@ void Terrain3DMesher::_generate_clipmap(const int p_size, const int p_lods, cons
 		} else {
 			Array trim_a_rids;
 			for (int i = 0; i < 2; i++) {
-				RID trim_a_rid = RS->instance_create2(_mesh_rids[STANDARD_TRIM_A], p_scenario);
+				RID trim_a_rid = RS->instance_create2(p_mesh_rids[STANDARD_TRIM_A], p_scenario);
 				trim_a_rids.append(trim_a_rid);
 			}
 			lod.append(trim_a_rids); // index 4 TRIM_A
 
 			Array trim_b_rids;
 			for (int i = 0; i < 2; i++) {
-				RID trim_b_rid = RS->instance_create2(_mesh_rids[STANDARD_TRIM_B], p_scenario);
+				RID trim_b_rid = RS->instance_create2(p_mesh_rids[STANDARD_TRIM_B], p_scenario);
 				trim_b_rids.append(trim_b_rid);
 			}
 			lod.append(trim_b_rids); // index 5 TRIM_B
 		}
 
 		// Append LOD to _lod_rids array
-		_clipmap_rids.append(lod);
+		p_instance_rids.append(lod);
 	}
 }
 
 // Precomputes all instance offset data into lookup arrays that match created instances.
 // All meshes are created with 0,0 as their origin and grow along +xz. Offsets account for this.
-void Terrain3DMesher::_generate_offset_data(const int p_size) {
+void Terrain3DMesher::_generate_offset_data(MeshOffsetData &p_offset_data, const int p_size) {
 	LOG(INFO, "Computing all clipmap instance positioning offsets");
-	_tile_pos_lod_0.clear();
-	_trim_a_pos.clear();
-	_trim_b_pos.clear();
-	_edge_pos.clear();
-	_fill_a_pos.clear();
-	_fill_b_pos.clear();
-	_tile_pos.clear();
+	p_offset_data.tile_pos_lod_0.clear();
+	p_offset_data.trim_a_pos.clear();
+	p_offset_data.trim_b_pos.clear();
+	p_offset_data.edge_pos.clear();
+	p_offset_data.fill_a_pos.clear();
+	p_offset_data.fill_b_pos.clear();
+	p_offset_data.tile_pos.clear();
 
 	// LOD0 Tiles: Full 4x4 Grid of mesh size tiles
-	_tile_pos_lod_0.push_back(Vector3(0, 0, p_size));
-	_tile_pos_lod_0.push_back(Vector3(p_size, 0, p_size));
-	_tile_pos_lod_0.push_back(Vector3(p_size, 0, 0));
-	_tile_pos_lod_0.push_back(Vector3(p_size, 0, -p_size));
-	_tile_pos_lod_0.push_back(Vector3(p_size, 0, -p_size * 2));
-	_tile_pos_lod_0.push_back(Vector3(0, 0, -p_size * 2));
-	_tile_pos_lod_0.push_back(Vector3(-p_size, 0, -p_size * 2));
-	_tile_pos_lod_0.push_back(Vector3(-p_size * 2, 0, -p_size * 2));
-	_tile_pos_lod_0.push_back(Vector3(-p_size * 2, 0, -p_size));
-	_tile_pos_lod_0.push_back(Vector3(-p_size * 2, 0, 0));
-	_tile_pos_lod_0.push_back(Vector3(-p_size * 2, 0, p_size));
-	_tile_pos_lod_0.push_back(Vector3(-p_size, 0, p_size));
+	p_offset_data.tile_pos_lod_0.push_back(Vector3(0, 0, p_size));
+	p_offset_data.tile_pos_lod_0.push_back(Vector3(p_size, 0, p_size));
+	p_offset_data.tile_pos_lod_0.push_back(Vector3(p_size, 0, 0));
+	p_offset_data.tile_pos_lod_0.push_back(Vector3(p_size, 0, -p_size));
+	p_offset_data.tile_pos_lod_0.push_back(Vector3(p_size, 0, -p_size * 2));
+	p_offset_data.tile_pos_lod_0.push_back(Vector3(0, 0, -p_size * 2));
+	p_offset_data.tile_pos_lod_0.push_back(Vector3(-p_size, 0, -p_size * 2));
+	p_offset_data.tile_pos_lod_0.push_back(Vector3(-p_size * 2, 0, -p_size * 2));
+	p_offset_data.tile_pos_lod_0.push_back(Vector3(-p_size * 2, 0, -p_size));
+	p_offset_data.tile_pos_lod_0.push_back(Vector3(-p_size * 2, 0, 0));
+	p_offset_data.tile_pos_lod_0.push_back(Vector3(-p_size * 2, 0, p_size));
+	p_offset_data.tile_pos_lod_0.push_back(Vector3(-p_size, 0, p_size));
 	// Inner tiles
-	_tile_pos_lod_0.push_back(V3_ZERO);
-	_tile_pos_lod_0.push_back(Vector3(-p_size, 0, 0));
-	_tile_pos_lod_0.push_back(Vector3(0, 0, -p_size));
-	_tile_pos_lod_0.push_back(Vector3(-p_size, 0, -p_size));
+	p_offset_data.tile_pos_lod_0.push_back(V3_ZERO);
+	p_offset_data.tile_pos_lod_0.push_back(Vector3(-p_size, 0, 0));
+	p_offset_data.tile_pos_lod_0.push_back(Vector3(0, 0, -p_size));
+	p_offset_data.tile_pos_lod_0.push_back(Vector3(-p_size, 0, -p_size));
 
 	// LOD0 Trims: Fixed 2 unit wide ring around LOD0 tiles.
-	_trim_a_pos.push_back(Vector3(p_size * 2, 0, -p_size * 2));
-	_trim_a_pos.push_back(Vector3(-p_size * 2 - 2, 0, -p_size * 2 - 2));
-	_trim_b_pos.push_back(Vector3(-p_size * 2, 0, -p_size * 2 - 2));
-	_trim_b_pos.push_back(Vector3(-p_size * 2 - 2, 0, p_size * 2));
+	p_offset_data.trim_a_pos.push_back(Vector3(p_size * 2, 0, -p_size * 2));
+	p_offset_data.trim_a_pos.push_back(Vector3(-p_size * 2 - 2, 0, -p_size * 2 - 2));
+	p_offset_data.trim_b_pos.push_back(Vector3(-p_size * 2, 0, -p_size * 2 - 2));
+	p_offset_data.trim_b_pos.push_back(Vector3(-p_size * 2 - 2, 0, p_size * 2));
 
 	// LOD1+: 4x4 Ring of mesh size tiles, with one 2 unit wide gap on each axis for fill meshes.
-	_tile_pos.push_back(Vector3(2, 0, p_size + 2));
-	_tile_pos.push_back(Vector3(p_size + 2, 0, p_size + 2));
-	_tile_pos.push_back(Vector3(p_size + 2, 0, -2));
-	_tile_pos.push_back(Vector3(p_size + 2, 0, -p_size - 2));
-	_tile_pos.push_back(Vector3(p_size + 2, 0, -p_size * 2 - 2));
-	_tile_pos.push_back(Vector3(-2, 0, -p_size * 2 - 2));
-	_tile_pos.push_back(Vector3(-p_size - 2, 0, -p_size * 2 - 2));
-	_tile_pos.push_back(Vector3(-p_size * 2 - 2, 0, -p_size * 2 - 2));
-	_tile_pos.push_back(Vector3(-p_size * 2 - 2, 0, -p_size + 2));
-	_tile_pos.push_back(Vector3(-p_size * 2 - 2, 0, +2));
-	_tile_pos.push_back(Vector3(-p_size * 2 - 2, 0, p_size + 2));
-	_tile_pos.push_back(Vector3(-p_size + 2, 0, p_size + 2));
+	p_offset_data.tile_pos.push_back(Vector3(2, 0, p_size + 2));
+	p_offset_data.tile_pos.push_back(Vector3(p_size + 2, 0, p_size + 2));
+	p_offset_data.tile_pos.push_back(Vector3(p_size + 2, 0, -2));
+	p_offset_data.tile_pos.push_back(Vector3(p_size + 2, 0, -p_size - 2));
+	p_offset_data.tile_pos.push_back(Vector3(p_size + 2, 0, -p_size * 2 - 2));
+	p_offset_data.tile_pos.push_back(Vector3(-2, 0, -p_size * 2 - 2));
+	p_offset_data.tile_pos.push_back(Vector3(-p_size - 2, 0, -p_size * 2 - 2));
+	p_offset_data.tile_pos.push_back(Vector3(-p_size * 2 - 2, 0, -p_size * 2 - 2));
+	p_offset_data.tile_pos.push_back(Vector3(-p_size * 2 - 2, 0, -p_size + 2));
+	p_offset_data.tile_pos.push_back(Vector3(-p_size * 2 - 2, 0, +2));
+	p_offset_data.tile_pos.push_back(Vector3(-p_size * 2 - 2, 0, p_size + 2));
+	p_offset_data.tile_pos.push_back(Vector3(-p_size + 2, 0, p_size + 2));
 
 	// Edge offsets set edge pair positions to either both before, straddle, or both after
 	// Depending on current LOD position within the next LOD, (via test_x or test_z in snap())
-	_offset_a = real_t(p_size * 2) + 2.f;
-	_offset_b = real_t(p_size * 2) + 4.f;
-	_offset_c = real_t(p_size * 2) + 6.f;
-	_edge_pos.push_back(Vector3(_offset_a, _offset_a, -_offset_b));
-	_edge_pos.push_back(Vector3(_offset_b, -_offset_b, -_offset_c));
+	p_offset_data.offset_a = real_t(p_size * 2) + 2.f;
+	p_offset_data.offset_b = real_t(p_size * 2) + 4.f;
+	p_offset_data.offset_c = real_t(p_size * 2) + 6.f;
+	p_offset_data.edge_pos.push_back(Vector3(p_offset_data.offset_a, p_offset_data.offset_a, -p_offset_data.offset_b));
+	p_offset_data.edge_pos.push_back(Vector3(p_offset_data.offset_b, -p_offset_data.offset_b, -p_offset_data.offset_c));
 
 	// Fills: Occupies the gaps between tiles for LOD1+ to complete the ring.
-	_fill_a_pos.push_back(Vector3(p_size - 2, 0, -p_size * 2 - 2));
-	_fill_a_pos.push_back(Vector3(-p_size - 2, 0, p_size + 2));
-	_fill_b_pos.push_back(Vector3(p_size + 2, 0, p_size - 2));
-	_fill_b_pos.push_back(Vector3(-p_size * 2 - 2, 0, -p_size - 2));
+	p_offset_data.fill_a_pos.push_back(Vector3(p_size - 2, 0, -p_size * 2 - 2));
+	p_offset_data.fill_a_pos.push_back(Vector3(-p_size - 2, 0, p_size + 2));
+	p_offset_data.fill_b_pos.push_back(Vector3(p_size + 2, 0, p_size - 2));
+	p_offset_data.fill_b_pos.push_back(Vector3(-p_size * 2 - 2, 0, -p_size - 2));
 
+	return;
+}
+
+void Terrain3DMesher::_update_mesh_transforms(const Array &p_instance_rids, const MeshOffsetData &p_offset_data, const real_t p_vertex_spacing, const Vector3 &p_snapped_pos) {
+	Vector3 pos = V3_ZERO;
+	for (int lod = 0; lod < p_instance_rids.size(); ++lod) {
+		real_t snap_step = pow(2.f, lod + 1.f) * p_vertex_spacing;
+		Vector3 lod_scale = Vector3(pow(2.f, lod) * p_vertex_spacing, 1.f, pow(2.f, lod) * p_vertex_spacing);
+
+		// Snap pos.xz
+		pos.x = round(p_snapped_pos.x / snap_step) * snap_step;
+		pos.z = round(p_snapped_pos.z / snap_step) * snap_step;
+
+		LOG(EXTREME, "Snapping clipmap LOD", lod, " to position: ", pos);
+
+		// test_x and test_z for edge strip positions
+		real_t next_snap_step = pow(2.f, lod + 2.f) * p_vertex_spacing;
+		real_t next_x = round(p_snapped_pos.x / next_snap_step) * next_snap_step;
+		real_t next_z = round(p_snapped_pos.z / next_snap_step) * next_snap_step;
+		int test_x = CLAMP(int(round((pos.x - next_x) / snap_step)) + 1, 0, 2);
+		int test_z = CLAMP(int(round((pos.z - next_z) / snap_step)) + 1, 0, 2);
+		Array lod_array = p_instance_rids[lod];
+		for (int mesh = 0; mesh < lod_array.size(); ++mesh) {
+			Array mesh_array = lod_array[mesh];
+			for (int instance = 0; instance < mesh_array.size(); ++instance) {
+				Transform3D t = Transform3D();
+				switch (mesh) {
+					case TILE: {
+						t.origin = (lod == 0) ? p_offset_data.tile_pos_lod_0[instance] : p_offset_data.tile_pos[instance];
+						break;
+					}
+					case EDGE_A: {
+						Vector3 edge_pos_instance = p_offset_data.edge_pos[instance];
+						t.origin.z -= p_offset_data.offset_a + (test_z * 2.f);
+						t.origin.x = edge_pos_instance[test_x];
+						break;
+					}
+					case EDGE_B: {
+						Vector3 edge_pos_instance = p_offset_data.edge_pos[instance];
+						t.origin.z = edge_pos_instance[test_z];
+						t.origin.x -= p_offset_data.offset_a;
+						break;
+					}
+					// LOD0 doesnt have fills so the trims share the same index.
+					case FILL_A: {
+						if (lod > 0) {
+							t.origin = p_offset_data.fill_a_pos[instance];
+						} else {
+							t.origin = p_offset_data.trim_a_pos[instance];
+						}
+						break;
+					}
+					case FILL_B: {
+						if (lod > 0) {
+							t.origin = p_offset_data.fill_b_pos[instance];
+						} else {
+							t.origin = p_offset_data.trim_b_pos[instance];
+						}
+						break;
+					}
+					default: {
+						break;
+					}
+				}
+				t = t.scaled(lod_scale);
+				t.origin += pos;
+				RS->instance_set_transform(mesh_array[instance], t);
+// Deprecated Godot 4.5+
+#if GODOT_VERSION_MAJOR == 4 && GODOT_VERSION_MINOR == 4
+				RS->instance_reset_physics_interpolation(mesh_array[instance]);
+#endif
+			}
+		}
+	}
 	return;
 }
 
 // Frees all clipmap instance RIDs. Mesh rids must be freed seperatley.
-void Terrain3DMesher::_clear_clipmap() {
+void Terrain3DMesher::_clear_clipmap(Array &p_instance_rids) {
 	LOG(INFO, "Freeing all clipmap instances");
-	for (Array lod_array : _clipmap_rids) {
-		for (Array mesh_array : lod_array) {
-			for (const RID &rid : mesh_array) {
-				RS->free_rid(rid);
+	for (const Array &lod_array : p_instance_rids) {
+		for (const Array &mesh_array : lod_array) {
+			for (const RID &instance : mesh_array) {
+				RS->free_rid(instance);
 			}
-			mesh_array.clear();
 		}
-		lod_array.clear();
 	}
-	_clipmap_rids.clear();
+	p_instance_rids.clear();
 	return;
 }
 
 // Frees all Mesh RIDs use for clipmap instances.
-void Terrain3DMesher::_clear_mesh_types() {
+void Terrain3DMesher::_clear_mesh_types(Array &p_mesh_rids) {
 	LOG(INFO, "Freeing all clipmap meshes");
-	for (const RID &rid : _mesh_rids) {
-		RS->free_rid(rid);
+	for (const RID &mesh_rid : p_mesh_rids) {
+		RS->free_rid(mesh_rid);
 	}
-	_mesh_rids.clear();
+	p_mesh_rids.clear();
 	return;
+}
+
+void Terrain3DMesher::_clear_offset_data(MeshOffsetData &p_data) {
+	p_data.tile_pos_lod_0.clear();
+	p_data.trim_a_pos.clear();
+	p_data.trim_b_pos.clear();
+	p_data.edge_pos.clear();
+	p_data.fill_a_pos.clear();
+	p_data.fill_b_pos.clear();
 }
 
 ///////////////////////////
@@ -293,7 +378,12 @@ void Terrain3DMesher::initialize(Terrain3D *p_terrain) {
 	LOG(INFO, "Initializing GeoMesh");
 	int size = _terrain->get_mesh_size();
 	int lods = _terrain->get_mesh_lods() + _terrain->get_tessellation_level();
-	_generate_clipmap(size, lods, _terrain->get_world_3d()->get_scenario());
+	_generate_clipmap(_clipmap_rids, _mesh_rids, _terrain_mesh_offset_data, size, lods, _terrain->get_world_3d()->get_scenario(), _terrain->get_material()->get_material_rid());
+	if (_ocean_enabled) {
+		size = _terrain->get_ocean_mesh_size();
+		lods = _terrain->get_ocean_mesh_lods() + _terrain->get_ocean_tessellation_level();
+		_generate_clipmap(_ocean_clipmap_rids, _ocean_mesh_rids, _ocean_mesh_offset_data, size, lods, _terrain->get_world_3d()->get_scenario(), _terrain->get_ocean_material_rid());
+	}
 	update();
 	update_aabbs();
 	reset_target_position();
@@ -302,14 +392,12 @@ void Terrain3DMesher::initialize(Terrain3D *p_terrain) {
 
 void Terrain3DMesher::destroy() {
 	LOG(INFO, "Destroying clipmap");
-	_clear_clipmap();
-	_clear_mesh_types();
-	_tile_pos_lod_0.clear();
-	_trim_a_pos.clear();
-	_trim_b_pos.clear();
-	_edge_pos.clear();
-	_fill_a_pos.clear();
-	_fill_b_pos.clear();
+	_clear_clipmap(_clipmap_rids);
+	_clear_mesh_types(_mesh_rids);
+	_clear_offset_data(_terrain_mesh_offset_data);
+	_clear_clipmap(_ocean_clipmap_rids);
+	_clear_mesh_types(_ocean_mesh_rids);
+	_clear_offset_data(_ocean_mesh_offset_data);
 }
 
 void Terrain3DMesher::snap() {
@@ -329,77 +417,10 @@ void Terrain3DMesher::snap() {
 	// Recenter terrain on the target
 	_last_target_position = target_pos_2d;
 	Vector3 snapped_pos = (target_pos / vertex_spacing).floor() * vertex_spacing;
-	Vector3 pos = V3_ZERO;
-	for (int lod = 0; lod < _clipmap_rids.size(); ++lod) {
-		real_t snap_step = pow(2.f, lod + 1.f) * vertex_spacing;
-		Vector3 lod_scale = Vector3(pow(2.f, lod) * vertex_spacing, 1.f, pow(2.f, lod) * vertex_spacing);
-
-		// Snap pos.xz
-		pos.x = round(snapped_pos.x / snap_step) * snap_step;
-		pos.z = round(snapped_pos.z / snap_step) * snap_step;
-
-		LOG(EXTREME, "Snapping clipmap LOD", lod, " to position: ", pos);
-
-		// test_x and test_z for edge strip positions
-		real_t next_snap_step = pow(2.f, lod + 2.f) * vertex_spacing;
-		real_t next_x = round(snapped_pos.x / next_snap_step) * next_snap_step;
-		real_t next_z = round(snapped_pos.z / next_snap_step) * next_snap_step;
-		int test_x = CLAMP(int(round((pos.x - next_x) / snap_step)) + 1, 0, 2);
-		int test_z = CLAMP(int(round((pos.z - next_z) / snap_step)) + 1, 0, 2);
-		Array lod_array = _clipmap_rids[lod];
-		for (int mesh = 0; mesh < lod_array.size(); ++mesh) {
-			Array mesh_array = lod_array[mesh];
-			for (int instance = 0; instance < mesh_array.size(); ++instance) {
-				Transform3D t = Transform3D();
-				switch (mesh) {
-					case TILE: {
-						t.origin = (lod == 0) ? _tile_pos_lod_0[instance] : _tile_pos[instance];
-						break;
-					}
-					case EDGE_A: {
-						Vector3 edge_pos_instance = _edge_pos[instance];
-						t.origin.z -= _offset_a + (test_z * 2.f);
-						t.origin.x = edge_pos_instance[test_x];
-						break;
-					}
-					case EDGE_B: {
-						Vector3 edge_pos_instance = _edge_pos[instance];
-						t.origin.z = edge_pos_instance[test_z];
-						t.origin.x -= _offset_a;
-						break;
-					}
-					// LOD0 doesnt have fills so the trims share the same index.
-					case FILL_A: {
-						if (lod > 0) {
-							t.origin = _fill_a_pos[instance];
-						} else {
-							t.origin = _trim_a_pos[instance];
-						}
-						break;
-					}
-					case FILL_B: {
-						if (lod > 0) {
-							t.origin = _fill_b_pos[instance];
-						} else {
-							t.origin = _trim_b_pos[instance];
-						}
-						break;
-					}
-					default: {
-						break;
-					}
-				}
-				t = t.scaled(lod_scale);
-				t.origin += pos;
-				RS->instance_set_transform(mesh_array[instance], t);
-// Deprecated Godot 4.5+
-#if GODOT_VERSION_MAJOR == 4 && GODOT_VERSION_MINOR == 4
-				RS->instance_reset_physics_interpolation(mesh_array[instance]);
-#endif
-			}
-		}
+	_update_mesh_transforms(_clipmap_rids, _terrain_mesh_offset_data, vertex_spacing, snapped_pos);
+	if (_ocean_enabled && _terrain->get_ocean_material_rid().is_valid()) {
+		_update_mesh_transforms(_ocean_clipmap_rids, _ocean_mesh_offset_data, vertex_spacing, snapped_pos);
 	}
-	return;
 }
 
 // Iterates over every instance of every mesh and updates all properties.
@@ -432,16 +453,29 @@ void Terrain3DMesher::update() {
 	RenderingServer::ShadowCastingSetting cast_shadows = _terrain->get_cast_shadows();
 	bool visible = _terrain->is_visible_in_tree();
 
-	LOG(INFO, "Updating all mesh instances for ", _clipmap_rids.size(), " LODs");
-	for (Array lod_array : _clipmap_rids) {
-		for (Array mesh_array : lod_array) {
-			for (const RID &rid : mesh_array) {
-				RS->instance_set_visible(rid, visible);
-				RS->instance_set_scenario(rid, scenario);
-				RS->instance_set_layer_mask(rid, render_layers);
-				RS->instance_geometry_set_cast_shadows_setting(rid, cast_shadows);
-				RS->instance_geometry_set_flag(rid, RenderingServer::INSTANCE_FLAG_USE_BAKED_LIGHT, baked_light);
-				RS->instance_geometry_set_flag(rid, RenderingServer::INSTANCE_FLAG_USE_DYNAMIC_GI, dynamic_gi);
+	LOG(INFO, "Updating all mesh instances for ", _clipmap_rids.size(), " LODs for terrain clipmap");
+	for (const Array &lod_array : _clipmap_rids) {
+		for (const Array &mesh_array : lod_array) {
+			for (const RID &mesh_rid : mesh_array) {
+				RS->instance_set_visible(mesh_rid, visible);
+				RS->instance_set_scenario(mesh_rid, scenario);
+				RS->instance_set_layer_mask(mesh_rid, render_layers);
+				RS->instance_geometry_set_cast_shadows_setting(mesh_rid, cast_shadows);
+				RS->instance_geometry_set_flag(mesh_rid, RenderingServer::INSTANCE_FLAG_USE_BAKED_LIGHT, baked_light);
+				RS->instance_geometry_set_flag(mesh_rid, RenderingServer::INSTANCE_FLAG_USE_DYNAMIC_GI, dynamic_gi);
+			}
+		}
+	}
+	LOG(INFO, "Updating all mesh instances for ", _ocean_clipmap_rids.size(), " LODs for ocean clipmap");
+	for (const Array &lod_array : _ocean_clipmap_rids) {
+		for (const Array &mesh_array : lod_array) {
+			for (const RID &mesh_rid : mesh_array) {
+				RS->instance_set_visible(mesh_rid, visible);
+				RS->instance_set_scenario(mesh_rid, scenario);
+				RS->instance_set_layer_mask(mesh_rid, render_layers);
+				RS->instance_geometry_set_cast_shadows_setting(mesh_rid, RenderingServer::SHADOW_CASTING_SETTING_OFF);
+				RS->instance_geometry_set_flag(mesh_rid, RenderingServer::INSTANCE_FLAG_USE_BAKED_LIGHT, baked_light);
+				RS->instance_geometry_set_flag(mesh_rid, RenderingServer::INSTANCE_FLAG_USE_DYNAMIC_GI, dynamic_gi);
 			}
 		}
 	}
@@ -463,5 +497,30 @@ void Terrain3DMesher::update_aabbs() {
 		aabb.size.y = height_range.y + cull_margin * 2.f;
 		RS->mesh_set_custom_aabb(rid, aabb);
 	}
+	LOG(INFO, "Updating ", _ocean_mesh_rids.size(), " shadow meshes AABBs")
+	for (const RID &rid : _mesh_rids) {
+		AABB aabb = RS->mesh_get_custom_aabb(rid);
+		aabb.position.y = height_range.x - cull_margin;
+		aabb.size.y = height_range.y + cull_margin * 2.f;
+		RS->mesh_set_custom_aabb(rid, aabb);
+	}
 	return;
+}
+
+void Terrain3DMesher::set_ocean_material(const Ref<Material> &p_mat) {
+	IS_DATA_INIT(VOID);
+	LOG(INFO, "Updating ", _ocean_clipmap_rids.size(), " instances override materials")
+	for (const RID &instance : _ocean_clipmap_rids) {
+		if (!instance.is_valid()) {
+			continue;
+		}
+		RS->instance_geometry_set_material_override(instance, p_mat.is_valid() ? p_mat->get_rid() : RID());
+	}
+	return;
+}
+
+void Terrain3DMesher::set_ocean_enabled(const bool p_enabled) {
+	SET_IF_DIFF(_ocean_enabled, p_enabled);
+	destroy();
+	initialize(_terrain);
 }

--- a/src/terrain_3d_mesher.h
+++ b/src/terrain_3d_mesher.h
@@ -7,6 +7,22 @@
 
 class Terrain3D;
 
+struct MeshOffsetData {
+	// LOD0 only
+	PackedVector3Array trim_a_pos;
+	PackedVector3Array trim_b_pos;
+	PackedVector3Array tile_pos_lod_0;
+	// LOD1 +
+	PackedVector3Array fill_a_pos;
+	PackedVector3Array fill_b_pos;
+	PackedVector3Array tile_pos;
+	// All LOD Levels
+	real_t offset_a = 0.f;
+	real_t offset_b = 0.f;
+	real_t offset_c = 0.f;
+	PackedVector3Array edge_pos;
+};
+
 class Terrain3DMesher {
 	CLASS_NAME_STATIC("Terrain3DMesher");
 
@@ -29,32 +45,27 @@ private:
 	Vector2 _last_target_position = V2_MAX;
 
 	Array _mesh_rids;
+	Array _ocean_mesh_rids;
 	// LODs -> MeshTypes -> Instances
 	Array _clipmap_rids;
+	Array _ocean_clipmap_rids;
 
-	// Mesh offset data
-	// LOD0 only
-	PackedVector3Array _trim_a_pos;
-	PackedVector3Array _trim_b_pos;
-	PackedVector3Array _tile_pos_lod_0;
-	// LOD1 +
-	PackedVector3Array _fill_a_pos;
-	PackedVector3Array _fill_b_pos;
-	PackedVector3Array _tile_pos;
-	// All LOD Levels
-	real_t _offset_a = 0.f;
-	real_t _offset_b = 0.f;
-	real_t _offset_c = 0.f;
-	PackedVector3Array _edge_pos;
+	MeshOffsetData _ocean_mesh_offset_data;
+	MeshOffsetData _terrain_mesh_offset_data;
 
-	void _generate_mesh_types(const int p_mesh_size);
-	RID _generate_mesh(const Vector2i &p_size, const bool p_standard_grid = false);
-	RID _instantiate_mesh(const PackedVector3Array &p_vertices, const PackedInt32Array &p_indices, const AABB &p_aabb);
-	void _generate_clipmap(const int p_size, const int p_lods, const RID &scenario);
-	void _generate_offset_data(const int p_mesh_size);
+	bool _ocean_enabled = false;
 
-	void _clear_clipmap();
-	void _clear_mesh_types();
+	void _generate_mesh_types(Array &p_mesh_rids_array, const int p_size, const RID &p_mat);
+	RID _generate_mesh(const Vector2i &p_size, const bool p_standard_grid = false, const RID &p_mat = RID());
+	RID _instantiate_mesh(const PackedVector3Array &p_vertices, const PackedInt32Array &p_indices, const AABB &p_aabb, const RID &p_mat);
+	void _generate_clipmap(Array &p_instance_rids, Array &p_mesh_rids, MeshOffsetData &p_offset_data, const int p_size, const int p_lods, const RID &p_scenario, const RID &p_mat);
+	void _generate_instances(Array &p_instance_rids, Array &p_mesh_rids, const int p_lods, const RID &p_scenario);
+	void _generate_offset_data(MeshOffsetData &data, const int p_mesh_size);
+	void _update_mesh_transforms(const Array &p_instance_rids, const MeshOffsetData &p_offset_data, const real_t p_vertex_spacing, const Vector3 &p_snapped_pos);
+
+	void _clear_clipmap(Array &p_instances);
+	void _clear_mesh_types(Array &p_mesh_rids);
+	void _clear_offset_data(MeshOffsetData &p_data);
 
 public:
 	Terrain3DMesher() {}
@@ -67,6 +78,9 @@ public:
 	void reset_target_position() { _last_target_position = V2_MAX; }
 	void update();
 	void update_aabbs();
+	void set_ocean_material(const Ref<Material> &p_mat);
+	void set_ocean_enabled(const bool p_enabled);
+	bool is_ocean_enabled() const { return _ocean_enabled; }
 };
 // Inline Functions
 


### PR DESCRIPTION
This PR adds a second clipmap and exposes the material, so that it can be used as an ocean mesh. The Mesher has been reworked so that it is easier to add further clipmaps if desired (shadow imposters, ceilings?)

I have included an example ocean shader - which needs improvement. The LOD edges are very visible from above. 