### PR TITLE
Replace abs with std::abs

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -98,8 +98,12 @@ Pass by reference:
 
 * Floats:
 * Use `real_t` instead of `float`
-* Format float literals like `0.0f`
+* Format float literals like `0.0f` or `0.f`
 * Float literals and `real_t` variables can share operations (e.g. `mydouble += 1.0f`) unless the compiler complains. e.g. `Math::lerp(mydouble, real_t(0.0f), real_t(1.0f))`
+
+* Standard Library & Godot Functions:
+* Use `std::abs`, not `Math::abs` (same), and definitely not `abs` (broken on mingw)
+* Use `std::isnan`, not `Math::is_nan` (same)
 
 Braces:
 * Everything braced - no if/for one-liners. Including switch cases

--- a/src/terrain_3d.cpp
+++ b/src/terrain_3d.cpp
@@ -113,7 +113,7 @@ void Terrain3D::__physics_process(const double p_delta) {
 			Vector2 target_pos_2d = v3v2(get_clipmap_target_position());
 			real_t tessellation_density = 1.f / pow(2.f, _tessellation_level);
 			real_t vertex_spacing = _vertex_spacing * tessellation_density;
-			if (!(MAX(abs(_last_buffer_position.x - target_pos_2d.x), abs(_last_buffer_position.y - target_pos_2d.y)) < vertex_spacing)) {
+			if (!(MAX(std::abs(_last_buffer_position.x - target_pos_2d.x), std::abs(_last_buffer_position.y - target_pos_2d.y)) < vertex_spacing)) {
 				_last_buffer_position = target_pos_2d;
 				RS->material_set_param(_material->get_buffer_material_rid(), "_target_pos", get_clipmap_target_position());
 				_d_buffer_vp->set_update_mode(SubViewport::UPDATE_ONCE);

--- a/src/terrain_3d_data.cpp
+++ b/src/terrain_3d_data.cpp
@@ -883,7 +883,7 @@ void Terrain3DData::import_images(const TypedArray<Image> &p_images, const Vecto
 
 	Vector3 descaled_position = p_global_position / _vertex_spacing;
 	int max_dimension = _region_size * REGION_MAP_SIZE / 2;
-	if ((abs(descaled_position.x) > max_dimension) || (abs(descaled_position.z) > max_dimension)) {
+	if ((std::abs(descaled_position.x) > max_dimension) || (std::abs(descaled_position.z) > max_dimension)) {
 		LOG(ERROR, "Specify a position within +/-", Vector3(max_dimension, 0.f, max_dimension) * _vertex_spacing);
 		return;
 	}

--- a/src/terrain_3d_instancer.cpp
+++ b/src/terrain_3d_instancer.cpp
@@ -705,11 +705,11 @@ void Terrain3DInstancer::add_instances(const Vector3 &p_global_position, const D
 			}
 		}
 		real_t spin = (fixed_spin + random_spin * UtilityFunctions::randf()) * Math_PI / 180.f;
-		if (abs(spin) > 0.001f) {
+		if (std::abs(spin) > 0.001f) {
 			t.basis = t.basis.rotated(normal, spin);
 		}
 		real_t tilt = (fixed_tilt + random_tilt * (2.f * UtilityFunctions::randf() - 1.f)) * Math_PI / 180.f;
-		if (abs(tilt) > 0.001f) {
+		if (std::abs(tilt) > 0.001f) {
 			t.basis = t.basis.rotated(t.basis.get_column(0), tilt); // Rotate pitch, X-axis
 		}
 

--- a/src/terrain_3d_mesher.cpp
+++ b/src/terrain_3d_mesher.cpp
@@ -322,7 +322,7 @@ void Terrain3DMesher::snap() {
 	Vector2 target_pos_2d = v3v2(target_pos);
 	real_t tessellation_density = 1.f / pow(2.f, _terrain->get_tessellation_level());
 	real_t vertex_spacing = _terrain->get_vertex_spacing() * tessellation_density;
-	if (MAX(abs(_last_target_position.x - target_pos_2d.x), abs(_last_target_position.y - target_pos_2d.y)) < vertex_spacing) {
+	if (MAX(std::abs(_last_target_position.x - target_pos_2d.x), std::abs(_last_target_position.y - target_pos_2d.y)) < vertex_spacing) {
 		return;
 	}
 
@@ -454,7 +454,7 @@ void Terrain3DMesher::update_aabbs() {
 	IS_DATA_INIT(VOID);
 	real_t cull_margin = _terrain->get_cull_margin();
 	Vector2 height_range = _terrain->get_data()->get_height_range();
-	height_range.y += abs(height_range.x);
+	height_range.y += std::abs(height_range.x);
 
 	LOG(INFO, "Updating ", _mesh_rids.size(), " meshes AABBs")
 	for (const RID &rid : _mesh_rids) {

--- a/src/terrain_3d_util.cpp
+++ b/src/terrain_3d_util.cpp
@@ -205,8 +205,8 @@ Ref<Image> Terrain3DUtil::get_thumbnail(const Ref<Image> &p_image, const Vector2
 	real_t hmin = minmax.x;
 	real_t hmax = minmax.y;
 	// Define maximum range
-	hmin = abs(hmin);
-	hmax = abs(hmax) + hmin;
+	hmin = std::abs(hmin);
+	hmax = std::abs(hmax) + hmin;
 	// Avoid divide by zero
 	hmax = (hmax == 0) ? 0.001f : hmax;
 


### PR DESCRIPTION
mingw `abs` is broken and overflows. `ABS` exists in godot, but is deprecated so produces build warnings. `Math::abs` is everywhere in Godot's code, and it has several types, but in our godot-cpp version it just goes to `std::abs`, so we can just use that. 
