### PR TITLE
Add support for instance teleport

### DIFF
--- a/src/terrain_3d_mesher.cpp
+++ b/src/terrain_3d_mesher.cpp
@@ -392,6 +392,9 @@ void Terrain3DMesher::snap() {
 				t = t.scaled(lod_scale);
 				t.origin += pos;
 				RS->instance_set_transform(mesh_array[instance], t);
+#if GODOT_VERSION_MAJOR == 4 && GODOT_VERSION_MINOR >= 5
+				RS->instance_teleport(mesh_array[instance]);
+#endif
 // Deprecated Godot 4.5+
 #if GODOT_VERSION_MAJOR == 4 && GODOT_VERSION_MINOR == 4
 				RS->instance_reset_physics_interpolation(mesh_array[instance]);


### PR DESCRIPTION
Fixes #302 

Adds the necessary code change to allow using TAA, FSR, and motion blur shaders. The required function is gated by version.

To use Terrain3D with TAA, FSR, or Motion Blur you must:
* [Build Terrain3D](https://terrain3d.readthedocs.io/en/latest/docs/building_from_source.html) from source using godot-cpp 4.5
* Use the Godot 4.5+ engine binary

Terrain3D currently builds against the 4.4 API, which works in later versions, but doesn't have the new function necessary for this. Once we offer builds against the 4.5 API, building from source won't be necessary.