### PR TITLE
Fix instances appear in other scenes - and instance visibility should mirror terrain visibility

### DIFF
--- a/src/terrain_3d.cpp
+++ b/src/terrain_3d.cpp
@@ -1035,6 +1035,13 @@ void Terrain3D::_notification(const int p_what) {
 			if (_mesher) {
 				_mesher->update();
 			}
+			if (_instancer) {
+				if (!is_visible_in_tree()) {
+					_instancer->destroy();
+				} else {
+					_instancer->update_mmis(-1, V2I_MAX, true);
+				}
+			}
 			break;
 		}
 


### PR DESCRIPTION
A fix for the bug reported on Discord. RS instances are persistent and need to be destroyed when Terrain3D exits the scene tree. 

Also made a change so that the instances are destroyed and rebuilt when the Terrain3D node visibility changes. 