### PR TITLE
Fix #890 differs() crash

### DIFF
--- a/src/terrain_3d_material.cpp
+++ b/src/terrain_3d_material.cpp
@@ -754,14 +754,14 @@ void Terrain3DMaterial::set_shader_override_enabled(const bool p_enabled) {
 }
 
 void Terrain3DMaterial::set_shader_override(const Ref<Shader> &p_shader) {
-	LOG(INFO, "Setting override shader");
 	SET_IF_DIFF(_shader_override, p_shader);
+	LOG(INFO, "Setting override shader");
 	_update_shader();
 }
 
 void Terrain3DMaterial::set_buffer_shader_override_enabled(const bool p_enabled) {
+	SET_IF_DIFF(_buffer_shader_override_enabled, p_enabled);
 	LOG(INFO, "Enable shader override: ", p_enabled);
-	_buffer_shader_override_enabled = p_enabled;
 	if (_buffer_shader_override_enabled && _buffer_shader_override.is_null()) {
 		LOG(DEBUG, "Instantiating new _shader_override");
 		_buffer_shader_override.instantiate();
@@ -770,8 +770,8 @@ void Terrain3DMaterial::set_buffer_shader_override_enabled(const bool p_enabled)
 }
 
 void Terrain3DMaterial::set_buffer_shader_override(const Ref<Shader> &p_shader) {
+	SET_IF_DIFF(_buffer_shader_override, p_shader);
 	LOG(INFO, "Setting override shader");
-	_buffer_shader_override = p_shader;
 	_update_shader();
 }
 

--- a/src/unit_testing.cpp
+++ b/src/unit_testing.cpp
@@ -61,7 +61,9 @@ void test_differs() {
 		String s2 = s1; // Shared (COW)
 		String s3("test"); // Separate alloc, same value
 		String s4 = "diff";
-		log_differs(s1, s2, "String shared", false); // Same ptr
+		log_differs(String(), String(), "String() vs String()", false);
+		log_differs(String(), String("a"), "String() vs String('a')", true);
+		log_differs(s1, s2, "String shared", false);
 		log_differs(s1, s3, "String same value diff ptr", false); // Length match + == true
 		log_differs(s1, s4, "String diff value", true); // Length may match, but == false
 	}


### PR DESCRIPTION
Fixes #890

Crash in differs() when comparing empty strings. Now we no longer index into the array at all. Both time we tried with Strings and Arrays/Dictionaries caused problems.