### PR TITLE
Updated to Godot HashMap, HashSet, and Pair types

### DIFF
--- a/src/constants.h
+++ b/src/constants.h
@@ -46,32 +46,6 @@ static const Vector3 V3_ZERO{ 0.f, 0.f, 0.f };
 static const Vector3 V3_MAX{ FLT_MAX, FLT_MAX, FLT_MAX };
 static const Vector3 V3_NAN{ NAN, NAN, NAN };
 static const Vector3 V3_UP{ 0.f, 1.f, 0.f };
-//static const Vector3 V3_DOWN{ 0.f, -1.f, 0.f };
-
-struct Vector2iHash {
-	std::size_t operator()(const Vector2i &v) const {
-		std::size_t h1 = std::hash<int>()(v.x);
-		std::size_t h2 = std::hash<int>()(v.y);
-		return h1 ^ (h2 << 1);
-	}
-};
-
-struct PairVector2iIntHash {
-	std::size_t operator()(const std::pair<Vector2i, int> &p) const {
-		std::size_t h1 = Vector2iHash{}(p.first);
-		std::size_t h2 = std::hash<int>{}(p.second);
-		return h1 ^ (h2 << 1);
-	}
-};
-
-struct Vector3Hash {
-	std::size_t operator()(const Vector3 &v) const {
-		std::size_t h1 = std::hash<float>()(v.x);
-		std::size_t h2 = std::hash<float>()(v.y);
-		std::size_t h3 = std::hash<float>()(v.z);
-		return h1 ^ (h2 << 1) ^ (h3 << 2);
-	}
-};
 
 // Set class name for logger.h
 

--- a/src/terrain_3d_instancer.h
+++ b/src/terrain_3d_instancer.h
@@ -5,8 +5,9 @@
 
 #include <godot_cpp/classes/multi_mesh.hpp>
 #include <godot_cpp/classes/multi_mesh_instance3d.hpp>
-#include <unordered_map>
-#include <unordered_set>
+#include <godot_cpp/templates/hash_map.hpp>
+#include <godot_cpp/templates/hash_set.hpp>
+#include <godot_cpp/templates/pair.hpp>
 
 #include "constants.h"
 #include "terrain_3d_region.h"
@@ -37,16 +38,16 @@ private:
 	// A pair of MMI and MM RIDs, freed in destructor, stored as
 	// _mmi_rids{region_loc} -> mesh{v2i(mesh_id,lod)} -> cell{v2i} -> std::pair<mmi_RID, mm_RID>
 
-	using CellMMIDict = std::unordered_map<Vector2i, std::pair<RID, RID>, Vector2iHash>;
-	using MeshMMIDict = std::unordered_map<Vector2i, CellMMIDict, Vector2iHash>;
-	std::unordered_map<Vector2i, MeshMMIDict, Vector2iHash> _mmi_rids;
+	using CellMMIDict = HashMap<Vector2i, Pair<RID, RID>>;
+	using MeshMMIDict = HashMap<Vector2i, CellMMIDict>;
+	HashMap<Vector2i, MeshMMIDict> _mmi_rids;
 
 	// MMI Updates tracked in a unique Set of <region_location, mesh_id>
 	// <V2I_MAX, -2> means destroy first, then update everything
 	// <V2I_MAX, -1> means update everything
 	// <reg_loc, -1> means update all meshes in that region
 	// <V2I_MAX, N> means update mesh ID N in all regions
-	using V2IIntPair = std::unordered_set<std::pair<Vector2i, int>, PairVector2iIntHash>;
+	using V2IIntPair = HashSet<Pair<Vector2i, int>>;
 	V2IIntPair _queued_updates;
 
 	InstancerMode _mode = NORMAL;


### PR DESCRIPTION
Replace std::unordered_set/map with Godot containers:

Addition to #880

### Summary

Replace std::unordered_map and std::unordered_set with Godot's HashMap and HashSet in Terrain3DInstancer
Remove custom hash structs that are no longer needed (Godot's HashMapHasherDefault provides built-in hashing for Vector2i, Vector3, and Pair<F, S>)
This change prepares the codebase for C++20 compatibility

### Changes

constants.h
Removed Vector2iHash, PairVector2iIntHash, and Vector3Hash structs
terrain_3d_instancer.h
Replaced <unordered_map> and <unordered_set> includes with Godot templates
Changed type aliases to use HashMap<Vector2i, Pair<RID, RID>> and HashSet<Pair<Vector2i, int>>
terrain_3d_instancer.cpp
Updated API calls: .empty() → .is_empty(), .count() → .has(), .emplace() → .insert()
Changed std::make_pair to Pair<Vector2i, int>
Updated iteration patterns to use KeyValue<K, V> for HashMap and explicit Pair access for HashSet