### PR TITLE
Update NDK version to r28b once 4.5

### DIFF
--- a/.github/actions/base-deps/action.yml
+++ b/.github/actions/base-deps/action.yml
@@ -23,7 +23,7 @@ runs:
       if: inputs.platform == 'android'
       uses: nttld/setup-ndk@v1
       with:
-        ndk-version: r23c
+        ndk-version: r28b
         link-to-sdk: true
 
     - name: Setup Windows Dependencies


### PR DESCRIPTION
updated ndk from r23c to r28b, as r28b is the one used is godot-cpp 4.5 on hold until ready for 4.5