### PR TITLE
Add update_region() for per-region collision updates

### DIFF
--- a/doc/api/class_terrain3dcollision.rst
+++ b/doc/api/class_terrain3dcollision.rst
@@ -51,21 +51,21 @@ Methods
 .. table::
    :widths: auto
 
-   +----------+-----------------------------------------------------------------------------------------+
-   | |void|   | :ref:`build<class_Terrain3DCollision_method_build>`\ (\ )                               |
-   +----------+-----------------------------------------------------------------------------------------+
-   | |void|   | :ref:`destroy<class_Terrain3DCollision_method_destroy>`\ (\ )                           |
-   +----------+-----------------------------------------------------------------------------------------+
-   | ``RID``  | :ref:`get_rid<class_Terrain3DCollision_method_get_rid>`\ (\ ) |const|                   |
-   +----------+-----------------------------------------------------------------------------------------+
-   | ``bool`` | :ref:`is_dynamic_mode<class_Terrain3DCollision_method_is_dynamic_mode>`\ (\ ) |const|   |
-   +----------+-----------------------------------------------------------------------------------------+
-   | ``bool`` | :ref:`is_editor_mode<class_Terrain3DCollision_method_is_editor_mode>`\ (\ ) |const|     |
-   +----------+-----------------------------------------------------------------------------------------+
-   | ``bool`` | :ref:`is_enabled<class_Terrain3DCollision_method_is_enabled>`\ (\ ) |const|             |
-   +----------+-----------------------------------------------------------------------------------------+
-   | |void|   | :ref:`update<class_Terrain3DCollision_method_update>`\ (\ rebuild\: ``bool`` = false\ ) |
-   +----------+-----------------------------------------------------------------------------------------+
+   +----------+------------------------------------------------------------------------------------------------------------------------------------------------------------+
+   | |void|   | :ref:`build<class_Terrain3DCollision_method_build>`\ (\ )                                                                                                  |
+   +----------+------------------------------------------------------------------------------------------------------------------------------------------------------------+
+   | |void|   | :ref:`destroy<class_Terrain3DCollision_method_destroy>`\ (\ )                                                                                              |
+   +----------+------------------------------------------------------------------------------------------------------------------------------------------------------------+
+   | ``RID``  | :ref:`get_rid<class_Terrain3DCollision_method_get_rid>`\ (\ ) |const|                                                                                      |
+   +----------+------------------------------------------------------------------------------------------------------------------------------------------------------------+
+   | ``bool`` | :ref:`is_dynamic_mode<class_Terrain3DCollision_method_is_dynamic_mode>`\ (\ ) |const|                                                                      |
+   +----------+------------------------------------------------------------------------------------------------------------------------------------------------------------+
+   | ``bool`` | :ref:`is_editor_mode<class_Terrain3DCollision_method_is_editor_mode>`\ (\ ) |const|                                                                        |
+   +----------+------------------------------------------------------------------------------------------------------------------------------------------------------------+
+   | ``bool`` | :ref:`is_enabled<class_Terrain3DCollision_method_is_enabled>`\ (\ ) |const|                                                                                |
+   +----------+------------------------------------------------------------------------------------------------------------------------------------------------------------+
+   | |void|   | :ref:`update<class_Terrain3DCollision_method_update>`\ (\ region_location\: ``Vector2i`` = Vector2i(2147483647, 2147483647), rebuild\: ``bool`` = false\ ) |
+   +----------+------------------------------------------------------------------------------------------------------------------------------------------------------------+
 
 .. rst-class:: classref-section-separator
 
@@ -112,7 +112,7 @@ Collision shapes are generated around the camera as it moves; in the editor and 
 
 :ref:`CollisionMode<enum_Terrain3DCollision_CollisionMode>` **FULL_GAME** = ``3``
 
-Collision shapes are generated for all regions in game only.
+Collision shapes are generated for all regions in game only. One shape per region.
 
 .. _class_Terrain3DCollision_constant_FULL_EDITOR:
 
@@ -120,7 +120,7 @@ Collision shapes are generated for all regions in game only.
 
 :ref:`CollisionMode<enum_Terrain3DCollision_CollisionMode>` **FULL_EDITOR** = ``4``
 
-Collision shapes are generated for all regions in the editor and in game. This mode is necessary for some 3rd party plugins to detect the terrain using collision. Enable ``View Gizmos`` in the viewport menu to see the collision mesh.
+Collision shapes are generated for all regions in the editor and in game. One shape per region. This mode is necessary for some 3rd party plugins to detect the terrain using collision. Enable ``View Gizmos`` in the viewport menu to see the collision mesh.
 
 .. rst-class:: classref-section-separator
 
@@ -333,11 +333,11 @@ Returns true if :ref:`mode<class_Terrain3DCollision_property_mode>` is not ``Dis
 
 .. rst-class:: classref-method
 
-|void| **update**\ (\ rebuild\: ``bool`` = false\ ) :ref:`🔗<class_Terrain3DCollision_method_update>`
+|void| **update**\ (\ region_location\: ``Vector2i`` = Vector2i(2147483647, 2147483647), rebuild\: ``bool`` = false\ ) :ref:`🔗<class_Terrain3DCollision_method_update>`
 
-- If :ref:`mode<class_Terrain3DCollision_property_mode>` is Full, recalculates the existing collision shapes. If regions have been added or removed, set ``rebuild`` to true or call :ref:`build()<class_Terrain3DCollision_method_build>` instead. Can be slow.
+- If :ref:`mode<class_Terrain3DCollision_property_mode>` is Full, recalculates the specified or all existing collision shapes. Specify a ``region_location`` to update only that region, or omit it or use `Vector2i.MAX` to update all regions. If regions have been added or removed, set ``rebuild`` to true or call :ref:`build()<class_Terrain3DCollision_method_build>` instead. A full update can be slow.
 
-- If :ref:`mode<class_Terrain3DCollision_property_mode>` is Dynamic, repositions collision shapes around the camera and recalculates ones that moved. Set ``rebuild`` to true to recalculate all shapes within :ref:`radius<class_Terrain3DCollision_property_radius>`. This is very fast, and can be updated at 60fps for little cost.
+- If :ref:`mode<class_Terrain3DCollision_property_mode>` is Dynamic, repositions collision shapes around the camera and recalculates ones that moved. Set ``rebuild`` to true to recalculate all shapes within :ref:`radius<class_Terrain3DCollision_property_radius>`. ``region_location`` is ignored. This is very fast, and can be updated at 60fps for little cost.
 
 .. |virtual| replace:: :abbr:`virtual (This method should typically be overridden by the user to have any effect.)`
 .. |required| replace:: :abbr:`required (This method is required to be overridden when extending its base class.)`

--- a/doc/doc_classes/Terrain3DCollision.xml
+++ b/doc/doc_classes/Terrain3DCollision.xml
@@ -46,10 +46,11 @@
 		</method>
 		<method name="update">
 			<return type="void" />
-			<param index="0" name="rebuild" type="bool" default="false" />
+			<param index="0" name="region_location" type="Vector2i" default="Vector2i(2147483647, 2147483647)" />
+			<param index="1" name="rebuild" type="bool" default="false" />
 			<description>
-				- If [member mode] is Full, recalculates the existing collision shapes. If regions have been added or removed, set [code skip-lint]rebuild[/code] to true or call [method build] instead. Can be slow.
-				- If [member mode] is Dynamic, repositions collision shapes around the camera and recalculates ones that moved. Set [code skip-lint]rebuild[/code] to true to recalculate all shapes within [member radius]. This is very fast, and can be updated at 60fps for little cost.
+				- If [member mode] is Full, recalculates the specified or all existing collision shapes. Specify a [code skip-lint]region_location[/code] to update only that region, or omit it or use `Vector2i.MAX` to update all regions. If regions have been added or removed, set [code skip-lint]rebuild[/code] to true or call [method build] instead. A full update can be slow.
+				- If [member mode] is Dynamic, repositions collision shapes around the camera and recalculates ones that moved. Set [code skip-lint]rebuild[/code] to true to recalculate all shapes within [member radius]. [code skip-lint]region_location[/code] is ignored. This is very fast, and can be updated at 60fps for little cost.
 			</description>
 		</method>
 	</methods>
@@ -88,10 +89,10 @@
 			Collision shapes are generated around the camera as it moves; in the editor and in game. Enable [code skip-lint]View Gizmos[/code] in the viewport menu to see them.
 		</constant>
 		<constant name="FULL_GAME" value="3" enum="CollisionMode">
-			Collision shapes are generated for all regions in game only.
+			Collision shapes are generated for all regions in game only. One shape per region.
 		</constant>
 		<constant name="FULL_EDITOR" value="4" enum="CollisionMode">
-			Collision shapes are generated for all regions in the editor and in game. This mode is necessary for some 3rd party plugins to detect the terrain using collision. Enable [code skip-lint]View Gizmos[/code] in the viewport menu to see the collision mesh.
+			Collision shapes are generated for all regions in the editor and in game. One shape per region. This mode is necessary for some 3rd party plugins to detect the terrain using collision. Enable [code skip-lint]View Gizmos[/code] in the viewport menu to see the collision mesh.
 		</constant>
 	</constants>
 </class>

--- a/src/terrain_3d_collision.cpp
+++ b/src/terrain_3d_collision.cpp
@@ -318,7 +318,7 @@ void Terrain3DCollision::build() {
 	update();
 }
 
-void Terrain3DCollision::update(const bool p_rebuild) {
+void Terrain3DCollision::update(const Vector2i &p_region_loc, const bool p_rebuild) {
 	IS_INIT(VOID);
 	if (!_initialized) {
 		return;
@@ -433,6 +433,9 @@ void Terrain3DCollision::update(const bool p_rebuild) {
 		TypedArray<Vector2i> region_locs = _terrain->get_data()->get_region_locations();
 		for (int i = 0; i < region_locs.size(); i++) {
 			Vector2i region_loc = region_locs[i];
+			if (p_region_loc != V2I_MAX && region_loc != p_region_loc) {
+				continue;
+			}
 			Vector2i shape_pos = region_loc * region_size;
 			Dictionary shape_data = _get_shape_data(shape_pos, region_size);
 			if (shape_data.is_empty()) {
@@ -604,7 +607,7 @@ void Terrain3DCollision::_bind_methods() {
 	BIND_ENUM_CONSTANT(FULL_EDITOR);
 
 	ClassDB::bind_method(D_METHOD("build"), &Terrain3DCollision::build);
-	ClassDB::bind_method(D_METHOD("update", "rebuild"), &Terrain3DCollision::update, DEFVAL(false));
+	ClassDB::bind_method(D_METHOD("update", "region_location", "rebuild"), &Terrain3DCollision::update, DEFVAL(V2I_MAX), DEFVAL(false));
 	ClassDB::bind_method(D_METHOD("destroy"), &Terrain3DCollision::destroy);
 	ClassDB::bind_method(D_METHOD("set_mode", "mode"), &Terrain3DCollision::set_mode);
 	ClassDB::bind_method(D_METHOD("get_mode"), &Terrain3DCollision::get_mode);

--- a/src/terrain_3d_collision.h
+++ b/src/terrain_3d_collision.h
@@ -64,7 +64,7 @@ public:
 
 	void build();
 	void reset_target_position() { _last_snapped_pos = V2I_MAX; }
-	void update(const bool p_rebuild = false);
+	void update(const Vector2i &p_region_loc = V2I_MAX, const bool p_rebuild = false);
 	void destroy();
 
 	void set_mode(const CollisionMode p_mode);

--- a/src/terrain_3d_editor.cpp
+++ b/src/terrain_3d_editor.cpp
@@ -578,7 +578,7 @@ void Terrain3DEditor::_operate_map(const Vector3 &p_global_position, const real_
 	}
 	// Update Dynamic / Editor collision
 	if (_terrain->get_collision_mode() == Terrain3DCollision::DYNAMIC_EDITOR) {
-		_terrain->get_collision()->update(true);
+		_terrain->get_collision()->update(V2I_MAX, true);
 	}
 	if (_tool == HEIGHT || _tool == SCULPT || _tool == TEXTURE || _tool == AUTOSHADER) {
 		_terrain->snap();


### PR DESCRIPTION
Fixes #891 
Updates `update()` method to allow for individual update collision calls for a single region instead of rebuilding all regions.

Currently, runtime terrain modification (craters, explosions, deformation) requires calling `update()` which rebuilds collision for every region. This is expensive for large terrains.

Now update() has p_region_loc, for specific regions

- Only applicable in Full mode (FULL_GAME/FULL_EDITOR)
