### PR TITLE
Splat map importer

### DIFF
--- a/src/terrain_3d_data.h
+++ b/src/terrain_3d_data.h
@@ -36,6 +36,15 @@ private:
 	AABB _edited_area;
 	Vector2 _master_height_range = V2_ZERO;
 
+	// Import splat map
+	PackedInt32Array _splat_channel_to_material_list;
+
+	struct ControlIds {
+		int base_id;
+		int overlay_id;
+		int blend;
+	};
+
 	/////////
 	// Terrain3DRegions house the maps, instances, and other data for each region.
 	// Regions are dual indexed:
@@ -183,6 +192,13 @@ public:
 			const real_t p_offset = 0.f, const real_t p_scale = 1.f);
 	Error export_image(const String &p_file_name, const MapType p_map_type = TYPE_HEIGHT) const;
 	Ref<Image> layered_to_image(const MapType p_map_type) const;
+
+	// Import splat map
+	void set_splat_channel_to_material_list(const PackedInt32Array &p_array, const int &p_splat_count);
+	PackedInt32Array get_splat_channel_to_material_list() { return _splat_channel_to_material_list; };
+	int splat_channel_to_material(const int p_channel_idx);
+	ControlIds compute_control_ids_and_blend(const PackedFloat32Array &p_weights);
+	void import_splat_map(const TypedArray<Image> &p_splat_images, const Vector3 &p_global_position = V3_ZERO);
 
 	// Utility
 	void dump(const bool verbose = false) const;

--- a/src/terrain_3d_util.h
+++ b/src/terrain_3d_util.h
@@ -46,6 +46,7 @@ public:
 			const Image::Format p_format = Image::FORMAT_MAX);
 	static Ref<Image> load_image(const String &p_file_name, const int p_cache_mode = ResourceLoader::CACHE_MODE_IGNORE,
 			const Vector2 &p_r16_height_range = Vector2(0.f, 255.f), const Vector2i &p_r16_size = V2I_ZERO);
+	static Ref<Image> load_raw_image(const String &p_file_name, const int p_width, const int p_height);
 	static Ref<Image> pack_image(const Ref<Image> &p_src_rgb,
 			const Ref<Image> &p_src_a,
 			const Ref<Image> &p_src_ao,


### PR DESCRIPTION
I have created this first draft to import splat maps in the Terrain3D importer. 

I have tested this for my use case, where I used 3 splat images (raw RGBA8) with the same size as the terrain/heightmap/colormap. Each splat image uses the 4 color channels to map to a detail texture like described [here](https://github.com/TokisanGames/Terrain3D/issues/135#issuecomment-2185318318):

> Example - Splat 01
> 
>     R - Grass
>     G - Rocks
>     B - Dirt
>     A - Peak (Snow)

You also have to specify a list that maps the index of each color channel to the corresponding texture asset list ids. If you have for example 3 splat images the list needs to be 12 for all color channels (so splat_count * 4), even if you don't use all of them (mark -1 for unused).

<img width="971" height="931" alt="image" src="https://github.com/user-attachments/assets/e732d8f9-99fa-4916-a911-d7ebff31771d" />

<img width="960" height="533" alt="image" src="https://github.com/user-attachments/assets/f56a5cd5-7a50-44b0-aa6c-0afd6b1b5251" />

The splat maps should be able to be imported as PNGs as well, but I started with raw because it's what my team uses. I can't share the splats we use unfortunately. 

I'm of course open to try to make this more usable for others if you have any advice, I don't have much knowledge about the usual formats of other terrain generators.