### PR TITLE
Add in place region modification methods to Terrain3DRegion

### DIFF
--- a/doc/api/class_terrain3dregion.rst
+++ b/doc/api/class_terrain3dregion.rst
@@ -64,9 +64,29 @@ Methods
    +-----------------------------------------------+--------------------------------------------------------------------------------------------------------------------------------------------------------+
    | |void|                                        | :ref:`calc_height_range<class_Terrain3DRegion_method_calc_height_range>`\ (\ )                                                                         |
    +-----------------------------------------------+--------------------------------------------------------------------------------------------------------------------------------------------------------+
+   | |void|                                        | :ref:`clear<class_Terrain3DRegion_method_clear>`\ (\ )                                                                                                 |
+   +-----------------------------------------------+--------------------------------------------------------------------------------------------------------------------------------------------------------+
    | |void|                                        | :ref:`dump<class_Terrain3DRegion_method_dump>`\ (\ verbose\: ``bool`` = false\ ) |const|                                                               |
    +-----------------------------------------------+--------------------------------------------------------------------------------------------------------------------------------------------------------+
    | :ref:`Terrain3DRegion<class_Terrain3DRegion>` | :ref:`duplicate<class_Terrain3DRegion_method_duplicate>`\ (\ deep\: ``bool`` = false\ )                                                                |
+   +-----------------------------------------------+--------------------------------------------------------------------------------------------------------------------------------------------------------+
+   | ``int``                                       | :ref:`get_control<class_Terrain3DRegion_method_get_control>`\ (\ x\: ``int``, y\: ``int``\ ) |const|                                                   |
+   +-----------------------------------------------+--------------------------------------------------------------------------------------------------------------------------------------------------------+
+   | ``float``                                     | :ref:`get_control_angle<class_Terrain3DRegion_method_get_control_angle>`\ (\ x\: ``int``, y\: ``int``\ ) |const|                                       |
+   +-----------------------------------------------+--------------------------------------------------------------------------------------------------------------------------------------------------------+
+   | ``bool``                                      | :ref:`get_control_auto<class_Terrain3DRegion_method_get_control_auto>`\ (\ x\: ``int``, y\: ``int``\ ) |const|                                         |
+   +-----------------------------------------------+--------------------------------------------------------------------------------------------------------------------------------------------------------+
+   | ``int``                                       | :ref:`get_control_base_id<class_Terrain3DRegion_method_get_control_base_id>`\ (\ x\: ``int``, y\: ``int``\ ) |const|                                   |
+   +-----------------------------------------------+--------------------------------------------------------------------------------------------------------------------------------------------------------+
+   | ``float``                                     | :ref:`get_control_blend<class_Terrain3DRegion_method_get_control_blend>`\ (\ x\: ``int``, y\: ``int``\ ) |const|                                       |
+   +-----------------------------------------------+--------------------------------------------------------------------------------------------------------------------------------------------------------+
+   | ``bool``                                      | :ref:`get_control_hole<class_Terrain3DRegion_method_get_control_hole>`\ (\ x\: ``int``, y\: ``int``\ ) |const|                                         |
+   +-----------------------------------------------+--------------------------------------------------------------------------------------------------------------------------------------------------------+
+   | ``bool``                                      | :ref:`get_control_navigation<class_Terrain3DRegion_method_get_control_navigation>`\ (\ x\: ``int``, y\: ``int``\ ) |const|                             |
+   +-----------------------------------------------+--------------------------------------------------------------------------------------------------------------------------------------------------------+
+   | ``int``                                       | :ref:`get_control_overlay_id<class_Terrain3DRegion_method_get_control_overlay_id>`\ (\ x\: ``int``, y\: ``int``\ ) |const|                             |
+   +-----------------------------------------------+--------------------------------------------------------------------------------------------------------------------------------------------------------+
+   | ``float``                                     | :ref:`get_control_scale<class_Terrain3DRegion_method_get_control_scale>`\ (\ x\: ``int``, y\: ``int``\ ) |const|                                       |
    +-----------------------------------------------+--------------------------------------------------------------------------------------------------------------------------------------------------------+
    | ``Dictionary``                                | :ref:`get_data<class_Terrain3DRegion_method_get_data>`\ (\ ) |const|                                                                                   |
    +-----------------------------------------------+--------------------------------------------------------------------------------------------------------------------------------------------------------+
@@ -79,6 +99,24 @@ Methods
    | |void|                                        | :ref:`sanitize_maps<class_Terrain3DRegion_method_sanitize_maps>`\ (\ )                                                                                 |
    +-----------------------------------------------+--------------------------------------------------------------------------------------------------------------------------------------------------------+
    | Error                                         | :ref:`save<class_Terrain3DRegion_method_save>`\ (\ path\: ``String`` = "", save_16_bit\: ``bool`` = false\ )                                           |
+   +-----------------------------------------------+--------------------------------------------------------------------------------------------------------------------------------------------------------+
+   | |void|                                        | :ref:`set_control<class_Terrain3DRegion_method_set_control>`\ (\ x\: ``int``, y\: ``int``, control\: ``int``\ )                                        |
+   +-----------------------------------------------+--------------------------------------------------------------------------------------------------------------------------------------------------------+
+   | |void|                                        | :ref:`set_control_angle<class_Terrain3DRegion_method_set_control_angle>`\ (\ x\: ``int``, y\: ``int``, angle\: ``float``\ )                            |
+   +-----------------------------------------------+--------------------------------------------------------------------------------------------------------------------------------------------------------+
+   | |void|                                        | :ref:`set_control_auto<class_Terrain3DRegion_method_set_control_auto>`\ (\ x\: ``int``, y\: ``int``, auto\: ``bool``\ )                                |
+   +-----------------------------------------------+--------------------------------------------------------------------------------------------------------------------------------------------------------+
+   | |void|                                        | :ref:`set_control_base_id<class_Terrain3DRegion_method_set_control_base_id>`\ (\ x\: ``int``, y\: ``int``, base\: ``int``\ )                           |
+   +-----------------------------------------------+--------------------------------------------------------------------------------------------------------------------------------------------------------+
+   | |void|                                        | :ref:`set_control_blend<class_Terrain3DRegion_method_set_control_blend>`\ (\ x\: ``int``, y\: ``int``, blend\: ``float``\ )                            |
+   +-----------------------------------------------+--------------------------------------------------------------------------------------------------------------------------------------------------------+
+   | |void|                                        | :ref:`set_control_hole<class_Terrain3DRegion_method_set_control_hole>`\ (\ x\: ``int``, y\: ``int``, hole\: ``bool``\ )                                |
+   +-----------------------------------------------+--------------------------------------------------------------------------------------------------------------------------------------------------------+
+   | |void|                                        | :ref:`set_control_navigation<class_Terrain3DRegion_method_set_control_navigation>`\ (\ x\: ``int``, y\: ``int``, navigation\: ``bool``\ )              |
+   +-----------------------------------------------+--------------------------------------------------------------------------------------------------------------------------------------------------------+
+   | |void|                                        | :ref:`set_control_overlay_id<class_Terrain3DRegion_method_set_control_overlay_id>`\ (\ x\: ``int``, y\: ``int``, overlay\: ``int``\ )                  |
+   +-----------------------------------------------+--------------------------------------------------------------------------------------------------------------------------------------------------------+
+   | |void|                                        | :ref:`set_control_scale<class_Terrain3DRegion_method_set_control_scale>`\ (\ x\: ``int``, y\: ``int``, scale\: ``float``\ )                            |
    +-----------------------------------------------+--------------------------------------------------------------------------------------------------------------------------------------------------------+
    | |void|                                        | :ref:`set_data<class_Terrain3DRegion_method_set_data>`\ (\ data\: ``Dictionary``\ )                                                                    |
    +-----------------------------------------------+--------------------------------------------------------------------------------------------------------------------------------------------------------+
@@ -402,6 +440,20 @@ Recalculates the height range for this region by looking at every pixel in the h
 
 ----
 
+.. _class_Terrain3DRegion_method_clear:
+
+.. rst-class:: classref-method
+
+|void| **clear**\ (\ ) :ref:`🔗<class_Terrain3DRegion_method_clear>`
+
+.. container:: contribute
+
+	There is currently no description for this method. Please help us by `contributing one <https://contributing.godotengine.org/en/latest/documentation/class_reference.html>`__!
+
+.. rst-class:: classref-item-separator
+
+----
+
 .. _class_Terrain3DRegion_method_dump:
 
 .. rst-class:: classref-method
@@ -423,6 +475,114 @@ Dumps information about the data in the region, including instance IDs, counts, 
 Returns a duplicate copy of this node, with references to the same image maps and multimeshes.
 
 - deep - Also make complete duplicates of the maps and multimeshes.
+
+.. rst-class:: classref-item-separator
+
+----
+
+.. _class_Terrain3DRegion_method_get_control:
+
+.. rst-class:: classref-method
+
+``int`` **get_control**\ (\ x\: ``int``, y\: ``int``\ ) |const| :ref:`🔗<class_Terrain3DRegion_method_get_control>`
+
+Gets the control ID at the provided pixel position.
+
+.. rst-class:: classref-item-separator
+
+----
+
+.. _class_Terrain3DRegion_method_get_control_angle:
+
+.. rst-class:: classref-method
+
+``float`` **get_control_angle**\ (\ x\: ``int``, y\: ``int``\ ) |const| :ref:`🔗<class_Terrain3DRegion_method_get_control_angle>`
+
+Gets the control angle at the provided pixel position.
+
+.. rst-class:: classref-item-separator
+
+----
+
+.. _class_Terrain3DRegion_method_get_control_auto:
+
+.. rst-class:: classref-method
+
+``bool`` **get_control_auto**\ (\ x\: ``int``, y\: ``int``\ ) |const| :ref:`🔗<class_Terrain3DRegion_method_get_control_auto>`
+
+Gets if the region uses the auto shader at the provided pixel position.
+
+.. rst-class:: classref-item-separator
+
+----
+
+.. _class_Terrain3DRegion_method_get_control_base_id:
+
+.. rst-class:: classref-method
+
+``int`` **get_control_base_id**\ (\ x\: ``int``, y\: ``int``\ ) |const| :ref:`🔗<class_Terrain3DRegion_method_get_control_base_id>`
+
+Gets the base texture ID at the provided pixel position.
+
+.. rst-class:: classref-item-separator
+
+----
+
+.. _class_Terrain3DRegion_method_get_control_blend:
+
+.. rst-class:: classref-method
+
+``float`` **get_control_blend**\ (\ x\: ``int``, y\: ``int``\ ) |const| :ref:`🔗<class_Terrain3DRegion_method_get_control_blend>`
+
+Gets the blend value at the provided pixel position.
+
+.. rst-class:: classref-item-separator
+
+----
+
+.. _class_Terrain3DRegion_method_get_control_hole:
+
+.. rst-class:: classref-method
+
+``bool`` **get_control_hole**\ (\ x\: ``int``, y\: ``int``\ ) |const| :ref:`🔗<class_Terrain3DRegion_method_get_control_hole>`
+
+Gets if the region has a hole at the provided pixel position.
+
+.. rst-class:: classref-item-separator
+
+----
+
+.. _class_Terrain3DRegion_method_get_control_navigation:
+
+.. rst-class:: classref-method
+
+``bool`` **get_control_navigation**\ (\ x\: ``int``, y\: ``int``\ ) |const| :ref:`🔗<class_Terrain3DRegion_method_get_control_navigation>`
+
+Gets if the region has navigation at the provided pixel position.
+
+.. rst-class:: classref-item-separator
+
+----
+
+.. _class_Terrain3DRegion_method_get_control_overlay_id:
+
+.. rst-class:: classref-method
+
+``int`` **get_control_overlay_id**\ (\ x\: ``int``, y\: ``int``\ ) |const| :ref:`🔗<class_Terrain3DRegion_method_get_control_overlay_id>`
+
+Gets the overlay texture ID at the provided pixel position.
+
+.. rst-class:: classref-item-separator
+
+----
+
+.. _class_Terrain3DRegion_method_get_control_scale:
+
+.. rst-class:: classref-method
+
+``float`` **get_control_scale**\ (\ x\: ``int``, y\: ``int``\ ) |const| :ref:`🔗<class_Terrain3DRegion_method_get_control_scale>`
+
+Gets the scale at the provided pixel position.
 
 .. rst-class:: classref-item-separator
 
@@ -504,6 +664,114 @@ Saves this region to the current file name.
 
 ----
 
+.. _class_Terrain3DRegion_method_set_control:
+
+.. rst-class:: classref-method
+
+|void| **set_control**\ (\ x\: ``int``, y\: ``int``, control\: ``int``\ ) :ref:`🔗<class_Terrain3DRegion_method_set_control>`
+
+Sets the regions control value at the provided pixel position.
+
+.. rst-class:: classref-item-separator
+
+----
+
+.. _class_Terrain3DRegion_method_set_control_angle:
+
+.. rst-class:: classref-method
+
+|void| **set_control_angle**\ (\ x\: ``int``, y\: ``int``, angle\: ``float``\ ) :ref:`🔗<class_Terrain3DRegion_method_set_control_angle>`
+
+Sets the regions control angle at the provided pixel position.
+
+.. rst-class:: classref-item-separator
+
+----
+
+.. _class_Terrain3DRegion_method_set_control_auto:
+
+.. rst-class:: classref-method
+
+|void| **set_control_auto**\ (\ x\: ``int``, y\: ``int``, auto\: ``bool``\ ) :ref:`🔗<class_Terrain3DRegion_method_set_control_auto>`
+
+Sets if the region uses the auto shader at the provided pixel position.
+
+.. rst-class:: classref-item-separator
+
+----
+
+.. _class_Terrain3DRegion_method_set_control_base_id:
+
+.. rst-class:: classref-method
+
+|void| **set_control_base_id**\ (\ x\: ``int``, y\: ``int``, base\: ``int``\ ) :ref:`🔗<class_Terrain3DRegion_method_set_control_base_id>`
+
+Sets the regions base texture id at the provided pixel position.
+
+.. rst-class:: classref-item-separator
+
+----
+
+.. _class_Terrain3DRegion_method_set_control_blend:
+
+.. rst-class:: classref-method
+
+|void| **set_control_blend**\ (\ x\: ``int``, y\: ``int``, blend\: ``float``\ ) :ref:`🔗<class_Terrain3DRegion_method_set_control_blend>`
+
+Sets the regions blend value at the provided pixel position.
+
+.. rst-class:: classref-item-separator
+
+----
+
+.. _class_Terrain3DRegion_method_set_control_hole:
+
+.. rst-class:: classref-method
+
+|void| **set_control_hole**\ (\ x\: ``int``, y\: ``int``, hole\: ``bool``\ ) :ref:`🔗<class_Terrain3DRegion_method_set_control_hole>`
+
+Sets if the region has a hole at the provided pixel position.
+
+.. rst-class:: classref-item-separator
+
+----
+
+.. _class_Terrain3DRegion_method_set_control_navigation:
+
+.. rst-class:: classref-method
+
+|void| **set_control_navigation**\ (\ x\: ``int``, y\: ``int``, navigation\: ``bool``\ ) :ref:`🔗<class_Terrain3DRegion_method_set_control_navigation>`
+
+Sets if the region has navigation at the provided pixel position.
+
+.. rst-class:: classref-item-separator
+
+----
+
+.. _class_Terrain3DRegion_method_set_control_overlay_id:
+
+.. rst-class:: classref-method
+
+|void| **set_control_overlay_id**\ (\ x\: ``int``, y\: ``int``, overlay\: ``int``\ ) :ref:`🔗<class_Terrain3DRegion_method_set_control_overlay_id>`
+
+Sets the overlay texture ID at the provided pixel position.
+
+.. rst-class:: classref-item-separator
+
+----
+
+.. _class_Terrain3DRegion_method_set_control_scale:
+
+.. rst-class:: classref-method
+
+|void| **set_control_scale**\ (\ x\: ``int``, y\: ``int``, scale\: ``float``\ ) :ref:`🔗<class_Terrain3DRegion_method_set_control_scale>`
+
+Sets the uv scale at the provided pixel position.
+
+.. rst-class:: classref-item-separator
+
+----
+
 .. _class_Terrain3DRegion_method_set_data:
 
 .. rst-class:: classref-method
@@ -573,6 +841,7 @@ When sculpting the terrain, this is called to provide both a low and high height
 This validates the map size according to previously loaded maps.
 
 .. |virtual| replace:: :abbr:`virtual (This method should typically be overridden by the user to have any effect.)`
+.. |required| replace:: :abbr:`required (This method is required to be overridden when extending its base class.)`
 .. |const| replace:: :abbr:`const (This method has no side effects. It doesn't modify any of the instance's member variables.)`
 .. |vararg| replace:: :abbr:`vararg (This method accepts any number of arguments after the ones described here.)`
 .. |constructor| replace:: :abbr:`constructor (This method is used to construct a type.)`

--- a/doc/doc_classes/Terrain3DRegion.xml
+++ b/doc/doc_classes/Terrain3DRegion.xml
@@ -14,6 +14,11 @@
 				Recalculates the height range for this region by looking at every pixel in the heightmap.
 			</description>
 		</method>
+		<method name="clear">
+			<return type="void" />
+			<description>
+			</description>
+		</method>
 		<method name="dump" qualifiers="const">
 			<return type="void" />
 			<param index="0" name="verbose" type="bool" default="false" />
@@ -27,6 +32,78 @@
 			<description>
 				Returns a duplicate copy of this node, with references to the same image maps and multimeshes.
 				- deep - Also make complete duplicates of the maps and multimeshes.
+			</description>
+		</method>
+		<method name="get_control" qualifiers="const">
+			<return type="int" />
+			<param index="0" name="x" type="int" />
+			<param index="1" name="y" type="int" />
+			<description>
+				Gets the control ID at the provided pixel position.
+			</description>
+		</method>
+		<method name="get_control_angle" qualifiers="const">
+			<return type="float" />
+			<param index="0" name="x" type="int" />
+			<param index="1" name="y" type="int" />
+			<description>
+				Gets the control angle at the provided pixel position.
+			</description>
+		</method>
+		<method name="get_control_auto" qualifiers="const">
+			<return type="bool" />
+			<param index="0" name="x" type="int" />
+			<param index="1" name="y" type="int" />
+			<description>
+				Gets if the region uses the auto shader at the provided pixel position.
+			</description>
+		</method>
+		<method name="get_control_base_id" qualifiers="const">
+			<return type="int" />
+			<param index="0" name="x" type="int" />
+			<param index="1" name="y" type="int" />
+			<description>
+				Gets the base texture ID at the provided pixel position.
+			</description>
+		</method>
+		<method name="get_control_blend" qualifiers="const">
+			<return type="float" />
+			<param index="0" name="x" type="int" />
+			<param index="1" name="y" type="int" />
+			<description>
+				Gets the blend value at the provided pixel position.
+			</description>
+		</method>
+		<method name="get_control_hole" qualifiers="const">
+			<return type="bool" />
+			<param index="0" name="x" type="int" />
+			<param index="1" name="y" type="int" />
+			<description>
+				Gets if the region has a hole at the provided pixel position.
+			</description>
+		</method>
+		<method name="get_control_navigation" qualifiers="const">
+			<return type="bool" />
+			<param index="0" name="x" type="int" />
+			<param index="1" name="y" type="int" />
+			<description>
+				Gets if the region has navigation at the provided pixel position.
+			</description>
+		</method>
+		<method name="get_control_overlay_id" qualifiers="const">
+			<return type="int" />
+			<param index="0" name="x" type="int" />
+			<param index="1" name="y" type="int" />
+			<description>
+				Gets the overlay texture ID at the provided pixel position.
+			</description>
+		</method>
+		<method name="get_control_scale" qualifiers="const">
+			<return type="float" />
+			<param index="0" name="x" type="int" />
+			<param index="1" name="y" type="int" />
+			<description>
+				Gets the scale at the provided pixel position.
 			</description>
 		</method>
 		<method name="get_data" qualifiers="const">
@@ -70,6 +147,87 @@
 				Saves this region to the current file name.
 				- path - specifies a directory and file name to use from now on.
 				- 16-bit - save this region with 16-bit height map instead of 32-bit. This process is lossy. Does not change the bit depth in memory.
+			</description>
+		</method>
+		<method name="set_control">
+			<return type="void" />
+			<param index="0" name="x" type="int" />
+			<param index="1" name="y" type="int" />
+			<param index="2" name="control" type="int" />
+			<description>
+				Sets the regions control value at the provided pixel position.
+			</description>
+		</method>
+		<method name="set_control_angle">
+			<return type="void" />
+			<param index="0" name="x" type="int" />
+			<param index="1" name="y" type="int" />
+			<param index="2" name="angle" type="float" />
+			<description>
+				Sets the regions control angle at the provided pixel position.
+			</description>
+		</method>
+		<method name="set_control_auto">
+			<return type="void" />
+			<param index="0" name="x" type="int" />
+			<param index="1" name="y" type="int" />
+			<param index="2" name="auto" type="bool" />
+			<description>
+				Sets if the region uses the auto shader at the provided pixel position.
+			</description>
+		</method>
+		<method name="set_control_base_id">
+			<return type="void" />
+			<param index="0" name="x" type="int" />
+			<param index="1" name="y" type="int" />
+			<param index="2" name="base" type="int" />
+			<description>
+				Sets the regions base texture id at the provided pixel position.
+			</description>
+		</method>
+		<method name="set_control_blend">
+			<return type="void" />
+			<param index="0" name="x" type="int" />
+			<param index="1" name="y" type="int" />
+			<param index="2" name="blend" type="float" />
+			<description>
+				Sets the regions blend value at the provided pixel position.
+			</description>
+		</method>
+		<method name="set_control_hole">
+			<return type="void" />
+			<param index="0" name="x" type="int" />
+			<param index="1" name="y" type="int" />
+			<param index="2" name="hole" type="bool" />
+			<description>
+				Sets if the region has a hole at the provided pixel position.
+			</description>
+		</method>
+		<method name="set_control_navigation">
+			<return type="void" />
+			<param index="0" name="x" type="int" />
+			<param index="1" name="y" type="int" />
+			<param index="2" name="navigation" type="bool" />
+			<description>
+				Sets if the region has navigation at the provided pixel position.
+			</description>
+		</method>
+		<method name="set_control_overlay_id">
+			<return type="void" />
+			<param index="0" name="x" type="int" />
+			<param index="1" name="y" type="int" />
+			<param index="2" name="overlay" type="int" />
+			<description>
+				Sets the overlay texture ID at the provided pixel position.
+			</description>
+		</method>
+		<method name="set_control_scale">
+			<return type="void" />
+			<param index="0" name="x" type="int" />
+			<param index="1" name="y" type="int" />
+			<param index="2" name="scale" type="float" />
+			<description>
+				Sets the uv scale at the provided pixel position.
 			</description>
 		</method>
 		<method name="set_data">

--- a/src/constants.h
+++ b/src/constants.h
@@ -3,6 +3,8 @@
 #ifndef CONSTANTS_CLASS_H
 #define CONSTANTS_CLASS_H
 
+#include <functional>
+
 // GDExtension uses the godot namespace, custom modules do not.
 #if defined(GDEXTENSION) && !defined(GODOT_MODULE)
 using namespace godot;

--- a/src/terrain_3d_region.h
+++ b/src/terrain_3d_region.h
@@ -90,6 +90,30 @@ public:
 	void update_heights(const Vector2 &p_low_high);
 	void calc_height_range();
 
+	// In Place Map Modification
+	real_t get_height(const int p_x, const int p_y) const;
+	void set_height(const int p_x, const int p_y, const real_t p_height);
+	Color get_color(const int p_x, const int p_y) const;
+	void set_color(const int p_x, const int p_y, const Color &p_color);
+	uint32_t get_control(const int p_x, const int p_y) const;
+	void set_control(const int p_x, const int p_y, uint32_t p_control);
+	uint8_t get_control_base_id(const int p_x, const int p_y) const;
+	void set_control_base_id(const int p_x, const int p_y, const uint8_t p_base);
+	uint8_t get_control_overlay_id(const int p_x, const int p_y) const;
+	void set_control_overlay_id(const int p_x, const int p_y, const uint8_t p_overlay);
+	real_t get_control_blend(const int p_x, const int p_y) const;
+	void set_control_blend(const int p_x, const int p_y, const real_t p_blend);
+	real_t get_control_angle(const int p_x, const int p_y) const;
+	void set_control_angle(const int p_x, const int p_y, const real_t p_angle);
+	real_t get_control_scale(const int p_x, const int p_y) const;
+	void set_control_scale(const int p_x, const int p_y, const real_t p_scale);
+	bool get_control_hole(const int p_x, const int p_y) const;
+	void set_control_hole(const int p_x, const int p_y, const bool p_hole);
+	bool get_control_navigation(const int p_x, const int p_y) const;
+	void set_control_navigation(const int p_x, const int p_y, const bool p_navigation);
+	bool get_control_auto(const int p_x, const int p_y) const;
+	void set_control_auto(const int p_x, const int p_y, const bool p_auto);
+
 	// Instancer
 	void set_instances(const Dictionary &p_instances);
 	Dictionary get_instances() const { return _instances; }


### PR DESCRIPTION
This PR is a draft for providing convenient methods of modifying the height, color and control map values directly in the Terrain3DRegion.

## The Usecase
I am currently experimenting with importing heightmaps and splat maps exported from WorldMachine into Terrain3D and using procedural noise textures inside Godot to provide slight variations to uv angle and scale.

Using the methods for control map variation exposed in Terrain3DData is slow when importing values for a large area.
I did not look too far into this part but having to make the global_position to region local pixel position for each pixel modification is probably part of this.

I feel like there should be a way to modify the regions data similar to the Terrain3DData methods but operation on the local (pixel) coordinate system which can then f.e. be used in a do_for_regions callback to vary a specific value across the terrain.

## The Alternatives
The Terrain3DUtils currently provide encode functions exposed to gdscript, but these do differ from the Terrain3DData API by expecting integer values for "float" values such as angle or scale, and would require knowing the control map format and bit masks for making modifications.

If these methods don't fit into Terrain3DRegion architecturally convenient methods could also be added in Terrain3DUtils that take an Image as parameter to achieve the same effect.

Open to suggestions! 