### PR TITLE
Fixed uv scale problem in lightweight shader when using the control texture debug view

### DIFF
--- a/project/addons/terrain_3d/extras/shaders/lightweight.gdshader
+++ b/project/addons/terrain_3d/extras/shaders/lightweight.gdshader
@@ -266,12 +266,14 @@ void fragment() {
 	// Recover UVs
 	vec2 uv = UV;
 	vec2 uv2 = UV2;
+	vec2 uv_control = uv;
+    vec2 uv_tex = uv * _vertex_spacing;
 
 	// Lookup offsets, ID and blend weight
 	vec3 region_uv = get_index_uv(uv2);
 	const vec3 offsets = vec3(0, 1, 2);
-	vec2 index_id = floor(uv);
-	vec2 weight = fract(uv);
+	vec2 index_id = floor(uv_control);
+	vec2 weight = fract(uv_control);
 	vec2 invert = 1.0 - weight;
 	vec4 weights = vec4(
 		invert.x * weight.y, // 0
@@ -373,8 +375,6 @@ void fragment() {
 		uint id_read = 0u; // 1 bit per possible ID
 		// world normal adjustment requires acess to previous id during next iteration
 		vec4 nrm = vec4(0.0, 1.0, 0.0, 1.0);
-		// adjust uv scale to account for vertex spacing
-		uv *= _vertex_spacing;
 		for (int i = 0; i < 4; i++) {
 			for (int t = 0; t < 2; t++) {
 				int id = texture_ids[i][t];
@@ -384,7 +384,7 @@ void fragment() {
 					id_read |= mask;
 					float id_w = t_weights[i][t];
 					float id_scale = _texture_uv_scale_array[id] * 0.5;
-					vec2 id_uv = fma(uv, vec2(id_scale), vec2(0.5));
+					vec2 id_uv = fma(uv_tex, vec2(id_scale), vec2(0.5));
 					vec4 i_dd = base_dd * id_scale;
 					vec4 alb = textureGrad(_texture_array_albedo, vec3(id_uv, float(id)), i_dd.xy, i_dd.zw);
 					float world_normal = clamp(fma(TBN[0], vec3(nrm.x), fma(TBN[1], vec3(nrm.z), v_normal * vec3(nrm.y))).y, 0., 1.);


### PR DESCRIPTION
When using the debug view to look at the control texture, I noticed that the control texture didn't match up to the actual terrain/color map after using the newest version of the lightweight shader. 

I figured that it's because the uv variable was scaled with _vertex_spacing on line 377, and somehow used for the control texture in the debug_view shader.

I also noticed problems with other debug views, such as the PBR views because the shader expects the material struct (mat).

But maybe the shader is not finished yet, and everyone already knows this, but I thought I would say it here just in case!