### PR TITLE
Redesign Asset dock for Godot 4.6

### DIFF
--- a/project/addons/terrain_3d/src/asset_dock.tscn
+++ b/project/addons/terrain_3d/src/asset_dock.tscn
@@ -1,22 +1,22 @@
-[gd_scene load_steps=2 format=3 uid="uid://dkb6hii5e48m2"]
+[gd_scene format=3 uid="uid://dkb6hii5e48m2"]
 
 [ext_resource type="Script" uid="uid://bgoifepft1hjw" path="res://addons/terrain_3d/src/asset_dock.gd" id="1_e23pg"]
 
-[node name="Terrain3D" type="PanelContainer"]
+[node name="Terrain3D" type="PanelContainer" unique_id=571456222]
 custom_minimum_size = Vector2(256, 95)
 offset_right = 766.0
 offset_bottom = 100.0
 script = ExtResource("1_e23pg")
 
-[node name="Box" type="BoxContainer" parent="."]
+[node name="Box" type="BoxContainer" parent="." unique_id=882207693]
 layout_mode = 2
 size_flags_vertical = 3
 vertical = true
 
-[node name="Buttons" type="BoxContainer" parent="Box"]
+[node name="Buttons" type="BoxContainer" parent="Box" unique_id=1555094601]
 layout_mode = 2
 
-[node name="SearchBox" type="TextEdit" parent="Box/Buttons"]
+[node name="SearchBox" type="TextEdit" parent="Box/Buttons" unique_id=1736296123]
 custom_minimum_size = Vector2(100, 30)
 layout_mode = 2
 placeholder_text = "Search"
@@ -25,7 +25,7 @@ scroll_fit_content_height = true
 caret_blink = true
 caret_multiple = false
 
-[node name="SearchButton" type="Button" parent="Box/Buttons/SearchBox"]
+[node name="SearchButton" type="Button" parent="Box/Buttons/SearchBox" unique_id=391818197]
 layout_mode = 1
 anchors_preset = 6
 anchor_left = 1.0
@@ -40,7 +40,7 @@ grow_horizontal = 0
 grow_vertical = 2
 action_mode = 0
 
-[node name="TexturesBtn" type="Button" parent="Box/Buttons"]
+[node name="TexturesBtn" type="Button" parent="Box/Buttons" unique_id=1047137833]
 custom_minimum_size = Vector2(80, 30)
 layout_mode = 2
 size_flags_horizontal = 3
@@ -50,7 +50,7 @@ toggle_mode = true
 button_pressed = true
 text = "Textures"
 
-[node name="MeshesBtn" type="Button" parent="Box/Buttons"]
+[node name="MeshesBtn" type="Button" parent="Box/Buttons" unique_id=1371189354]
 custom_minimum_size = Vector2(80, 30)
 layout_mode = 2
 size_flags_horizontal = 3
@@ -59,33 +59,7 @@ theme_override_font_sizes/font_size = 16
 toggle_mode = true
 text = "Meshes"
 
-[node name="PlacementOpt" type="OptionButton" parent="Box/Buttons"]
-custom_minimum_size = Vector2(80, 30)
-layout_mode = 2
-size_flags_horizontal = 3
-size_flags_vertical = 0
-selected = 7
-item_count = 9
-popup/item_0/text = "Left_UL"
-popup/item_0/id = 0
-popup/item_1/text = "Left_BL"
-popup/item_1/id = 1
-popup/item_2/text = "Left_UR"
-popup/item_2/id = 2
-popup/item_3/text = "Left_BR"
-popup/item_3/id = 3
-popup/item_4/text = "Right_UL"
-popup/item_4/id = 4
-popup/item_5/text = "Right_BL "
-popup/item_5/id = 5
-popup/item_6/text = "Right_UR"
-popup/item_6/id = 6
-popup/item_7/text = "Right_BR"
-popup/item_7/id = 7
-popup/item_8/text = "Bottom"
-popup/item_8/id = 8
-
-[node name="SizeSlider" type="HSlider" parent="Box/Buttons"]
+[node name="SizeSlider" type="HSlider" parent="Box/Buttons" unique_id=1029408434]
 custom_minimum_size = Vector2(80, 10)
 layout_mode = 2
 size_flags_horizontal = 3
@@ -93,16 +67,7 @@ min_value = 90.0
 max_value = 512.0
 value = 90.0
 
-[node name="Floating" type="Button" parent="Box/Buttons"]
-layout_mode = 2
-size_flags_horizontal = 0
-size_flags_vertical = 0
-tooltip_text = "Pop this dock out to a floating window."
-toggle_mode = true
-text = "F"
-flat = true
-
-[node name="Pinned" type="Button" parent="Box/Buttons"]
+[node name="Pinned" type="Button" parent="Box/Buttons" unique_id=696271205]
 layout_mode = 2
 size_flags_horizontal = 0
 size_flags_vertical = 0
@@ -111,7 +76,7 @@ toggle_mode = true
 text = "P"
 flat = true
 
-[node name="ScrollContainer" type="ScrollContainer" parent="Box"]
+[node name="ScrollContainer" type="ScrollContainer" parent="Box" unique_id=2066057751]
 layout_mode = 2
 size_flags_horizontal = 3
 size_flags_vertical = 3

--- a/project/addons/terrain_3d/src/asset_dock_45.gd
+++ b/project/addons/terrain_3d/src/asset_dock_45.gd
@@ -1,4 +1,4 @@
-# Copyright © 2023-2026 Cory Petkovsek, Roope Palmroos, and Contributors.
+# Copyright © 2025 Cory Petkovsek, Roope Palmroos, and Contributors.
 # Asset Dock for Terrain3D
 @tool
 extends PanelContainer
@@ -7,8 +7,12 @@ signal confirmation_closed
 signal confirmation_confirmed
 signal confirmation_canceled
 
+const ES_DOCK_SLOT: String = "terrain3d/dock/slot"
 const ES_DOCK_TILE_SIZE: String = "terrain3d/dock/tile_size"
+const ES_DOCK_FLOATING: String = "terrain3d/dock/floating"
 const ES_DOCK_PINNED: String = "terrain3d/dock/always_on_top"
+const ES_DOCK_WINDOW_POSITION: String = "terrain3d/dock/window_position"
+const ES_DOCK_WINDOW_SIZE: String = "terrain3d/dock/window_size"
 const ES_DOCK_TAB: String = "terrain3d/dock/tab"
 
 var texture_list: ListContainer
@@ -16,6 +20,8 @@ var mesh_list: ListContainer
 var current_list: ListContainer
 var _updating_list: bool
 
+var placement_opt: OptionButton
+var floating_btn: Button
 var pinned_btn: Button
 var size_slider: HSlider
 var box: BoxContainer
@@ -28,40 +34,43 @@ var _confirmed: bool = false
 var search_box: TextEdit
 var search_button: Button
 
-#DEPRECATED 4.5
-#class EdDock extends EditorDock:
-	#func _update_layout(layout: int) -> void:
-		#layout 1 vertical, 2 horizontal, 4 window
-		#print("Terrain3DAssetDock: _update_layout called with: ", layout)
+# Used only for editor, so change to single visible/hiddden
+enum {
+	HIDDEN = -1,
+	SIDEBAR = 0,
+	BOTTOM = 1,
+	WINDOWED = 2,
+}
+var state: int = HIDDEN
 
-var _dock: MarginContainer #DEPRECATED 4.5 - Use EdDock
+enum {
+	POS_LEFT_UL = 0,
+	POS_LEFT_BL = 1,
+	POS_LEFT_UR = 2,
+	POS_LEFT_BR = 3,
+	POS_RIGHT_UL = 4,
+	POS_RIGHT_BL = 5,
+	POS_RIGHT_UR = 6,
+	POS_RIGHT_BR = 7,
+	POS_BOTTOM = 8,
+	POS_MAX = 9,
+}
+var slot: int = POS_RIGHT_BR
 var _initialized: bool = false
 var plugin: EditorPlugin
 var window: Window
+var _godot_last_state: Window.Mode = Window.MODE_FULLSCREEN
 
 
-func _notification(what: int) -> void:
-	if what == NOTIFICATION_ENTER_TREE:
-		await get_tree().process_frame
-		update_layout()
-		
-		
 func initialize(p_plugin: EditorPlugin) -> void:
 	if p_plugin:
 		plugin = p_plugin
-
-	_dock = ClassDB.instantiate("EditorDock") #DEPRECATED 4.5 - EdDock.new()
-	_dock.title = "Terrain3D"
-	_dock.dock_icon = preload("../icons/terrain3d.svg")
-	_dock.default_slot = 8 #DEPRECATED 4.5 - EditorDock.DockSlot.DOCK_SLOT_BOTTOM
-	_dock.closable = false
-	_dock.available_layouts = 0x7 #DEPRECATED 4.5 - EditorDock.DOCK_LAYOUT_ALL
-	_dock.add_child(self)
-	plugin.add_dock(_dock)
-	_dock.open()
-	_dock.make_visible()
-
+	
+	_godot_last_state = plugin.godot_editor_window.mode
+	placement_opt = $Box/Buttons/PlacementOpt
 	pinned_btn = $Box/Buttons/Pinned
+	floating_btn = $Box/Buttons/Floating
+	floating_btn.owner = null # Godot complains about buttons that are reparented
 	size_slider = $Box/Buttons/SizeSlider
 	size_slider.owner = null
 	box = $Box
@@ -71,9 +80,6 @@ func initialize(p_plugin: EditorPlugin) -> void:
 	asset_container = $Box/ScrollContainer
 	search_box = $Box/Buttons/SearchBox
 	search_box.owner = null
-	# Scale left column width to editor scale
-	var editor_scale: float = EditorInterface.get_editor_scale()
-	search_box.custom_minimum_size = Vector2(100. * editor_scale, 30. * editor_scale)
 	search_button = $Box/Buttons/SearchBox/SearchButton
 	
 	texture_list = ListContainer.new()
@@ -95,14 +101,36 @@ func initialize(p_plugin: EditorPlugin) -> void:
 	resized.connect(update_layout)
 	textures_btn.pressed.connect(_on_textures_pressed)
 	meshes_btn.pressed.connect(_on_meshes_pressed)
+	placement_opt.item_selected.connect(set_slot)
+	floating_btn.pressed.connect(make_dock_float)
 	pinned_btn.toggled.connect(_on_pin_changed)
+	pinned_btn.visible = ( window != null )
 	pinned_btn.owner = null
 	size_slider.value_changed.connect(_on_slider_changed)
 	plugin.ui.toolbar.tool_changed.connect(_on_tool_changed)
 
-	meshes_btn.add_theme_font_size_override("font_size", int(16. * EditorInterface.get_editor_scale()))
-	textures_btn.add_theme_font_size_override("font_size", int(16. * EditorInterface.get_editor_scale()))
+	meshes_btn.add_theme_font_size_override("font_size", 16 * EditorInterface.get_editor_scale())
+	textures_btn.add_theme_font_size_override("font_size", 16 * EditorInterface.get_editor_scale())
 
+	_initialized = true
+	update_dock()
+	update_layout()
+
+
+func _ready() -> void:
+	if not _initialized:
+		return
+		
+	# Setup styles
+	set("theme_override_styles/panel", get_theme_stylebox("panel", "Panel"))
+	# Avoid saving icon resources in tscn when editing w/ a tool script
+	if EditorInterface.get_edited_scene_root() != self:
+		pinned_btn.icon = get_theme_icon("Pin", "EditorIcons")
+		pinned_btn.text = ""
+		floating_btn.icon = get_theme_icon("MakeFloating", "EditorIcons")
+		floating_btn.text = ""
+		search_button.icon = get_theme_icon("Search", "EditorIcons")
+	
 	search_box.text_changed.connect(_on_search_text_changed)
 	search_button.pressed.connect(_on_search_button_pressed)
 	
@@ -110,23 +138,11 @@ func initialize(p_plugin: EditorPlugin) -> void:
 	add_child(confirm_dialog, true)
 	confirm_dialog.hide()
 	confirm_dialog.confirmed.connect(func(): _confirmed = true; \
-		confirmation_closed.emit(); \
-		confirmation_confirmed.emit() )
+		emit_signal("confirmation_closed"); \
+		emit_signal("confirmation_confirmed") )
 	confirm_dialog.canceled.connect(func(): _confirmed = false; \
-		confirmation_closed.emit(); \
-		confirmation_canceled.emit() )
-
-	# Setup styles
-	set("theme_override_styles/panel", get_theme_stylebox("panel", "Panel"))
-	# Avoid saving icon resources in tscn when editing w/ a tool script
-	if EditorInterface.get_edited_scene_root() != self:
-		pinned_btn.icon = get_theme_icon("Pin", "EditorIcons")
-		pinned_btn.text = ""
-		search_button.icon = get_theme_icon("Search", "EditorIcons")
-
-	_initialized = true
-	update_dock()
-	update_layout()
+		emit_signal("confirmation_closed"); \
+		emit_signal("confirmation_canceled") )
 
 
 func _gui_input(p_event: InputEvent) -> void:
@@ -140,44 +156,87 @@ func _gui_input(p_event: InputEvent) -> void:
 ## Dock placement
 
 
+func set_slot(p_slot: int) -> void:
+	if plugin.debug:
+		print("Terrain3DAssetDock: set_slot: ", p_slot)
+	p_slot = clamp(p_slot, 0, POS_MAX-1)
+	
+	if slot != p_slot:
+		slot = p_slot
+		placement_opt.selected = slot
+		save_editor_settings()
+		plugin.select_terrain()
+		update_dock()
+
+
 func remove_dock(p_force: bool = false) -> void:
-	plugin.remove_dock(_dock)
+	if state == SIDEBAR:
+		plugin.remove_control_from_docks(self)
+		state = HIDDEN
+
+	elif state == BOTTOM:
+		plugin.remove_control_from_bottom_panel(self)
+		state = HIDDEN
+
+	# If windowed and destination is not window or final exit, otherwise leave
+	elif state == WINDOWED and p_force and window:
+		var parent: Node = get_parent()
+		if parent:
+			parent.remove_child(self)
+		plugin.godot_editor_window.mouse_entered.disconnect(_on_godot_window_entered)
+		plugin.godot_editor_window.focus_entered.disconnect(_on_godot_focus_entered)
+		plugin.godot_editor_window.focus_exited.disconnect(_on_godot_focus_exited)
+		window.hide()
+		window.queue_free()
+		window = null
+		floating_btn.button_pressed = false
+		floating_btn.visible = true
+		pinned_btn.visible = false
+		placement_opt.visible = true
+		state = HIDDEN
+		update_dock() # return window to side/bottom
 
 
 func update_dock() -> void:
-	if not _initialized:
+	if not _initialized or window:
 		return
+
 	update_assets()
-	_dock.make_visible()
+
+	# Move dock to new destination
+	remove_dock()
+	# Sidebar
+	if slot < POS_BOTTOM:
+		state = SIDEBAR
+		plugin.add_control_to_dock(slot, self)
+	# Bottom
+	elif slot == POS_BOTTOM:
+		state = BOTTOM
+		plugin.add_control_to_bottom_panel(self, "Terrain3D")
+		plugin.make_bottom_panel_item_visible(self)
 
 
 func update_layout() -> void:
-	if not _initialized:
-		return
 	if plugin.debug > 1:
 		print("Terrain3DAssetDock: update_layout")	
+	if not _initialized:
+		return
 
-	## Detect if we have a new window from `Make floating` and grab it
-	if not window:
-		if get_parent().get_parent().get_parent() is Window:
-			window = get_parent().get_parent().get_parent()
-			_on_pin_changed(pinned_btn.button_pressed)
-			plugin.godot_editor_window.mouse_entered.connect(_on_godot_window_entered)
-			return # Displaying will call this function again
-		# Check if window was just freed. Freed objects have a different hash than null
-		elif hash(window) != hash(null):
-			window = null
-			plugin.godot_editor_window.mouse_entered.disconnect(_on_godot_window_entered)
-			return # Will call this function again upon display
+	# Detect if we have a new window from Make floating, grab it so we can free it properly
+	if not window and get_parent() and get_parent().get_parent() is Window:
+		window = get_parent().get_parent()
+		make_dock_float()
+		return # Will call this function again upon display
 
-	## Vertical layout: buttons on top
-	if size.x < 700:
+	# Vertical layout: buttons on top
+	if size.x < 500 or ( not window and slot < POS_BOTTOM ):
 		box.vertical = true
 		buttons.vertical = false
 		search_box.reparent(box)
 		box.move_child(search_box, 1)
 		size_slider.reparent(box)
 		box.move_child(size_slider, 2)
+		floating_btn.reparent(buttons)
 		pinned_btn.reparent(buttons)
 	else:
 	# Wide layout: buttons on left
@@ -186,19 +245,11 @@ func update_layout() -> void:
 		search_box.reparent(buttons)
 		buttons.move_child(search_box, 0)
 		size_slider.reparent(buttons)
-		buttons.move_child(size_slider, 3)
+		buttons.move_child(size_slider, 4)
+		floating_btn.reparent(box)
 		pinned_btn.reparent(box)
 
-	pinned_btn.visible = is_instance_valid(window)
 	save_editor_settings()
-
-
-# When a floating asset dock has focus and the mouse returns, grab focus so cursor decal works
-func _on_godot_window_entered() -> void:
-	if plugin.debug > 1:
-		print("Terrain3DAssetDock: _on_godot_window_entered")
-	if is_instance_valid(window) and window.has_focus():
-		plugin.godot_editor_window.grab_focus()
 
 
 func set_selected_by_asset_id(p_id: int) -> void:
@@ -335,17 +386,106 @@ func remove_all_highlights():
 			resource.set_highlighted(false)
 
 
+## Window Management
+
+
+func make_dock_float() -> void:
+	# If not already created (eg from editor panel 'Make Floating' button)	
+	if not window:
+		remove_dock()
+		create_window()
+
+	state = WINDOWED
+	visible = true # Asset dock contents are hidden when popping out of the bottom!
+	pinned_btn.visible = true
+	floating_btn.visible = false
+	placement_opt.visible = false
+	window.title = "Terrain3D Asset Dock"
+	window.always_on_top = pinned_btn.button_pressed
+	window.close_requested.connect(remove_dock.bind(true))
+	window.window_input.connect(_on_window_input)
+	window.focus_exited.connect(save_editor_settings)
+	window.mouse_exited.connect(save_editor_settings)
+	window.size_changed.connect(save_editor_settings)
+	plugin.godot_editor_window.mouse_entered.connect(_on_godot_window_entered)
+	plugin.godot_editor_window.focus_entered.connect(_on_godot_focus_entered)
+	plugin.godot_editor_window.focus_exited.connect(_on_godot_focus_exited)
+	plugin.godot_editor_window.grab_focus()
+	update_assets()
+	save_editor_settings()
+
+
+func create_window() -> void:
+	window = Window.new()
+	window.wrap_controls = true
+	var mc := MarginContainer.new()
+	mc.set_anchors_preset(PRESET_FULL_RECT, false)
+	mc.add_child(self, true)
+	window.add_child(mc, true)
+	window.set_transient(false)
+	window.set_size(plugin.get_setting(ES_DOCK_WINDOW_SIZE, Vector2i(512, 512)))
+	window.set_position(plugin.get_setting(ES_DOCK_WINDOW_POSITION, Vector2i(704, 284)))
+	plugin.add_child(window, true)
+	window.show()
+
+
+func clamp_window_position() -> void:
+	if window and window.visible:
+		var bounds: Vector2i
+		if EditorInterface.get_editor_settings().get_setting("interface/editor/single_window_mode"):
+			bounds = EditorInterface.get_base_control().size
+		else:
+			bounds = DisplayServer.screen_get_position(window.current_screen)
+			bounds += DisplayServer.screen_get_size(window.current_screen)
+		var margin: int = 40
+		window.position.x = clamp(window.position.x, -window.size.x + 2*margin, bounds.x - margin)
+		window.position.y = clamp(window.position.y, 25, bounds.y - margin)
+
+
+func _on_window_input(event: InputEvent) -> void:
+	# Capture CTRL+S when doc focused to save scene
+	if event is InputEventKey and event.keycode == KEY_S and event.pressed and event.is_command_or_control_pressed():
+		save_editor_settings()
+		EditorInterface.save_scene()
+
+
+func _on_godot_window_entered() -> void:
+	if plugin.debug > 1:
+		print("Terrain3DAssetDock: _on_godot_window_entered")
+	if is_instance_valid(window) and window.has_focus():
+		plugin.godot_editor_window.grab_focus()
+
+
+func _on_godot_focus_entered() -> void:
+	if plugin.debug > 1:
+		print("Terrain3DAssetDock: _on_godot_focus_entered")
+	# If asset dock is windowed, and Godot was minimized, and now is not, restore asset dock window
+	if is_instance_valid(window):
+		if _godot_last_state == Window.MODE_MINIMIZED and plugin.godot_editor_window.mode != Window.MODE_MINIMIZED:
+			window.show()
+			_godot_last_state = plugin.godot_editor_window.mode
+			plugin.godot_editor_window.grab_focus()
+
+
+func _on_godot_focus_exited() -> void:
+	if plugin.debug > 1:
+		print("Terrain3DAssetDock: _on_godot_focus_exited")
+	if is_instance_valid(window) and plugin.godot_editor_window.mode == Window.MODE_MINIMIZED:
+		window.hide()
+		_godot_last_state = plugin.godot_editor_window.mode
+
+
 ## Manage Editor Settings
 
 
 func load_editor_settings() -> void:
-	# Remove old editor settings
-	const ES_DOCK: String = "terrain3d/dock/"
-	for setting in [ "slot", "floating", "window_position", "window_size" ]:
-		plugin.erase_setting(ES_DOCK + setting)
+	floating_btn.button_pressed = plugin.get_setting(ES_DOCK_FLOATING, false)
 	pinned_btn.button_pressed = plugin.get_setting(ES_DOCK_PINNED, true)
 	size_slider.value = plugin.get_setting(ES_DOCK_TILE_SIZE, 90)
 	_on_slider_changed(size_slider.value)
+	set_slot(plugin.get_setting(ES_DOCK_SLOT, POS_BOTTOM))
+	if floating_btn.button_pressed:
+		make_dock_float()
 	# TODO Don't save tab until thumbnail generation more reliable
 	#if plugin.get_setting(ES_DOCK_TAB, 0) == 1:
 	#	_on_meshes_pressed()
@@ -354,10 +494,16 @@ func load_editor_settings() -> void:
 func save_editor_settings() -> void:
 	if not _initialized:
 		return
+	clamp_window_position()
+	plugin.set_setting(ES_DOCK_SLOT, slot)
 	plugin.set_setting(ES_DOCK_TILE_SIZE, size_slider.value)
+	plugin.set_setting(ES_DOCK_FLOATING, floating_btn.button_pressed)
 	plugin.set_setting(ES_DOCK_PINNED, pinned_btn.button_pressed)
 	# TODO Don't save tab until thumbnail generation more reliable
 	# plugin.set_setting(ES_DOCK_TAB, 0 if current_list == texture_list else 1)
+	if window:
+		plugin.set_setting(ES_DOCK_WINDOW_SIZE, window.size)
+		plugin.set_setting(ES_DOCK_WINDOW_POSITION, window.position)
 
 
 ##############################################################
@@ -535,8 +681,7 @@ class ListContainer extends Container:
 
 
 	func set_entry_width(value: float) -> void:
-		var min_width: float = 90.0 * max(1.0, EditorInterface.get_editor_scale())
-		width = clamp(value, min_width, 512.0)
+		width = clamp(value, 90., 512.)
 		redraw()
 
 
@@ -551,8 +696,8 @@ class ListContainer extends Container:
 		var columns: int = 3
 		columns = clamp(size.x / width, 1, 100)
 		var tile_size: Vector2 = Vector2(width, width) - Vector2(separation, separation)
-		var count_font_size := int(clamp(tile_size.x/11., 11., 16.) * EditorInterface.get_editor_scale())
-		var name_font_size := int(clamp(tile_size.x/12., 12., 16.) * EditorInterface.get_editor_scale())
+		var count_font_size = clamp(tile_size.x/11, 11, 16)
+		var name_font_size = clamp(tile_size.x/12, 12, 18)
 		for c in get_children():
 			if is_instance_valid(c):
 				c.size = tile_size
@@ -735,7 +880,7 @@ class ListEntry extends MarginContainer:
 		name_label.vertical_alignment = VERTICAL_ALIGNMENT_CENTER
 		name_label.size_flags_horizontal = Control.SIZE_EXPAND_FILL
 		name_label.size_flags_vertical = Control.SIZE_EXPAND_FILL
-		name_label.add_theme_font_size_override("font_size", int(14. * EditorInterface.get_editor_scale()))
+		name_label.add_theme_font_size_override("font_size", 14)
 		name_label.add_theme_color_override("font_color", Color.WHITE)
 		name_label.add_theme_color_override("font_shadow_color", Color.BLACK)
 		name_label.add_theme_constant_override("shadow_offset_x", 1)
@@ -754,7 +899,7 @@ class ListEntry extends MarginContainer:
 		count_label.vertical_alignment = VERTICAL_ALIGNMENT_BOTTOM
 		count_label.size_flags_horizontal = Control.SIZE_EXPAND_FILL
 		count_label.size_flags_vertical = Control.SIZE_EXPAND_FILL
-		count_label.add_theme_font_size_override("font_size", int(14. * EditorInterface.get_editor_scale()))
+		count_label.add_theme_font_size_override("font_size", 14)
 		count_label.add_theme_color_override("font_color", Color.WHITE)
 		count_label.add_theme_color_override("font_shadow_color", Color.BLACK)
 		count_label.add_theme_constant_override("shadow_offset_x", 1)
@@ -910,9 +1055,6 @@ class ListEntry extends MarginContainer:
 
 
 	func set_selected(value: bool) -> void:
-		if not is_inside_tree():
-			#push_error("not in tree")
-			return
 		is_selected = value
 		if is_selected:
 			# Handle scrolling to show the selected item

--- a/project/addons/terrain_3d/src/asset_dock_45.gd.uid
+++ b/project/addons/terrain_3d/src/asset_dock_45.gd.uid
@@ -1,0 +1,1 @@
+uid://cjku1fss3cvk1

--- a/project/addons/terrain_3d/src/asset_dock_45.tscn
+++ b/project/addons/terrain_3d/src/asset_dock_45.tscn
@@ -1,0 +1,117 @@
+[gd_scene format=3 uid="uid://4uav4e01yvf0"]
+
+[ext_resource type="Script" uid="uid://cjku1fss3cvk1" path="res://addons/terrain_3d/src/asset_dock_45.gd" id="1_40j30"]
+
+[node name="Terrain3D" type="PanelContainer" unique_id=1972618697]
+custom_minimum_size = Vector2(256, 95)
+offset_right = 766.0
+offset_bottom = 100.0
+script = ExtResource("1_40j30")
+
+[node name="Box" type="BoxContainer" parent="." unique_id=80894714]
+layout_mode = 2
+size_flags_vertical = 3
+vertical = true
+
+[node name="Buttons" type="BoxContainer" parent="Box" unique_id=1217984527]
+layout_mode = 2
+
+[node name="SearchBox" type="TextEdit" parent="Box/Buttons" unique_id=1974980129]
+custom_minimum_size = Vector2(100, 30)
+layout_mode = 2
+placeholder_text = "Search"
+emoji_menu_enabled = false
+scroll_fit_content_height = true
+caret_blink = true
+caret_multiple = false
+
+[node name="SearchButton" type="Button" parent="Box/Buttons/SearchBox" unique_id=1345860255]
+layout_mode = 1
+anchors_preset = 6
+anchor_left = 1.0
+anchor_top = 0.5
+anchor_right = 1.0
+anchor_bottom = 0.5
+offset_left = -13.0
+offset_top = -4.0
+offset_right = -5.0
+offset_bottom = 4.0
+grow_horizontal = 0
+grow_vertical = 2
+action_mode = 0
+
+[node name="TexturesBtn" type="Button" parent="Box/Buttons" unique_id=1510989918]
+custom_minimum_size = Vector2(80, 30)
+layout_mode = 2
+size_flags_horizontal = 3
+size_flags_vertical = 0
+theme_override_font_sizes/font_size = 16
+toggle_mode = true
+button_pressed = true
+text = "Textures"
+
+[node name="MeshesBtn" type="Button" parent="Box/Buttons" unique_id=711516840]
+custom_minimum_size = Vector2(80, 30)
+layout_mode = 2
+size_flags_horizontal = 3
+size_flags_vertical = 0
+theme_override_font_sizes/font_size = 16
+toggle_mode = true
+text = "Meshes"
+
+[node name="PlacementOpt" type="OptionButton" parent="Box/Buttons" unique_id=838727421]
+custom_minimum_size = Vector2(80, 30)
+layout_mode = 2
+size_flags_horizontal = 3
+size_flags_vertical = 0
+selected = 7
+item_count = 9
+popup/item_0/text = "Left_UL"
+popup/item_0/id = 0
+popup/item_1/text = "Left_BL"
+popup/item_1/id = 1
+popup/item_2/text = "Left_UR"
+popup/item_2/id = 2
+popup/item_3/text = "Left_BR"
+popup/item_3/id = 3
+popup/item_4/text = "Right_UL"
+popup/item_4/id = 4
+popup/item_5/text = "Right_BL "
+popup/item_5/id = 5
+popup/item_6/text = "Right_UR"
+popup/item_6/id = 6
+popup/item_7/text = "Right_BR"
+popup/item_7/id = 7
+popup/item_8/text = "Bottom"
+popup/item_8/id = 8
+
+[node name="SizeSlider" type="HSlider" parent="Box/Buttons" unique_id=1191207131]
+custom_minimum_size = Vector2(80, 10)
+layout_mode = 2
+size_flags_horizontal = 3
+min_value = 90.0
+max_value = 512.0
+value = 90.0
+
+[node name="Floating" type="Button" parent="Box/Buttons" unique_id=1694067289]
+layout_mode = 2
+size_flags_horizontal = 0
+size_flags_vertical = 0
+tooltip_text = "Pop this dock out to a floating window."
+toggle_mode = true
+text = "F"
+flat = true
+
+[node name="Pinned" type="Button" parent="Box/Buttons" unique_id=270093481]
+layout_mode = 2
+size_flags_horizontal = 0
+size_flags_vertical = 0
+tooltip_text = "Make this window \"Always on top\"."
+toggle_mode = true
+text = "P"
+flat = true
+
+[node name="ScrollContainer" type="ScrollContainer" parent="Box" unique_id=158339753]
+layout_mode = 2
+size_flags_horizontal = 3
+size_flags_vertical = 3

--- a/project/addons/terrain_3d/src/editor_plugin.gd
+++ b/project/addons/terrain_3d/src/editor_plugin.gd
@@ -7,6 +7,7 @@ extends EditorPlugin
 # Includes
 const Terrain3DUI: Script = preload("res://addons/terrain_3d/src/ui.gd")
 const ASSET_DOCK: String = "res://addons/terrain_3d/src/asset_dock.tscn"
+const ASSET_DOCK_45: String = "res://addons/terrain_3d/src/asset_dock_45.tscn"
 
 # Editor Plugin
 var debug: int = 0 # Set in _edit()
@@ -58,7 +59,11 @@ func _enter_tree() -> void:
 
 	scene_changed.connect(_on_scene_changed)
 
-	asset_dock = load(ASSET_DOCK).instantiate()
+	# Load Godot 4.6+ asset dock or pre-4.6
+	if Engine.get_version_info().hex >= 0x040600:
+		asset_dock = load(ASSET_DOCK).instantiate()
+	else:
+		asset_dock = load(ASSET_DOCK_45).instantiate()
 	asset_dock.initialize(self)
 
 


### PR DESCRIPTION
Fixes #921 

https://github.com/godotengine/godot/pull/106503 (presumably) broke the asset dock by improperly deprecating the old functions and breaking them, and redesigning new functions.

This PR make a 4.6 compatible asset dock and switches between the new in 4.6+ and old in <=4.5.

Pre 4.5 the editor docks were quite clunky and I wrote a lot of code to handle it's quirks. In 4.6 the system has been redesigned and things that didn't work now do. We no longer need our own dock selector as the built in one finally works properly.

Pending:
* [x] 4.6 and 4.5 dual compatibility
* [x] Search filter
* [x] Search/pin getting icon from editor
* [x] Pin button missing
* [x] Verify update_layout() child ordering
* [x] Instancer Asset icons going too small and crowding buttons (it may be my editor scale, which it should adjust min/max for) 
* [x] Search box too narrow
* [x] Always on top pin for window mode doesn't work (from pin)
* [x] Review old code that handled changing slots, window mode, editor settings and adjust or remove. 
* Testing

Contributions by @aidandavey squashed in

Cherry-pick for 1.0.2 in #971 
