### PR TITLE
Fix 1-4 keyboard shortcuts for 4.6, change assignments

### DIFF
--- a/doc/docs/keyboard_shortcuts.md
+++ b/doc/docs/keyboard_shortcuts.md
@@ -29,9 +29,10 @@ The following mouse and keyboard shortcuts or hotkeys are available.
 These toggle the Overlays found in the inspector. The mouse must be in the 3D Viewport with Terrain3D selected for these to work. 
 
 * <kbd>1</kbd> - Toggle **Region Grid**.
-* <kbd>2</kbd> - Toggle **Instancer Grid**.
-* <kbd>3</kbd> - Toggle **Vertex Grid**.
-* <kbd>4</kbd> - Toggle **Contour Lines**. Customize in the material when enabled.
+* <kbd>2</kbd> - Toggle **Region Label Distance** between 0 and 4096.
+* <kbd>3</kbd> - Toggle **Contour Lines**. Customize in the material when enabled.
+* <kbd>4</kbd> - Toggle **Instancer Grid**.
+* <kbd>5</kbd> - Toggle **Vertex Grid**.
 
 
 ## Tool Selection

--- a/project/addons/terrain_3d/src/editor_plugin.gd
+++ b/project/addons/terrain_3d/src/editor_plugin.gd
@@ -326,14 +326,16 @@ func _read_input(p_event: InputEvent = null) -> AfterGUIInput:
 # Returns true if hotkey matches and operation triggered
 func consume_hotkey(keycode: int) -> bool:
 	match keycode:
-		KEY_1:
+		KEY_1, KEY_KP_1:
 			terrain.material.set_show_region_grid(!terrain.material.get_show_region_grid())
-		KEY_2:
-			terrain.material.set_show_instancer_grid(!terrain.material.get_show_instancer_grid())
-		KEY_3:
-			terrain.material.set_show_vertex_grid(!terrain.material.get_show_vertex_grid())
-		KEY_4:
+		KEY_2, KEY_KP_2:
+			terrain.label_distance = 4096.0 if is_zero_approx(terrain.label_distance) else 0.0 
+		KEY_3, KEY_KP_3:
 			terrain.material.set_show_contours(!terrain.material.get_show_contours())
+		KEY_4, KEY_KP_4:
+			terrain.material.set_show_instancer_grid(!terrain.material.get_show_instancer_grid())
+		KEY_5, KEY_KP_5:
+			terrain.material.set_show_vertex_grid(!terrain.material.get_show_vertex_grid())
 		KEY_E:
 			ui.toolbar.get_button("AddRegion").set_pressed(true)
 		KEY_R:


### PR DESCRIPTION
Fixes #926 

4.4 [enables emulate keypad by default](https://github.com/godotengine/godot/pull/100059).
4.4-4.5 number row reports regular keys to _forward_3d_gui_input().
4.6 reports keypad to _forward_3d_gui_input().

This PR triggers the overlay hotkeys based on number row or keypad.
It also changes the overlay assignments. 