### PR TITLE
Fix search and pinned button

### DIFF
--- a/project/addons/terrain_3d/src/asset_dock.gd
+++ b/project/addons/terrain_3d/src/asset_dock.gd
@@ -233,7 +233,7 @@ func update_layout() -> void:
 		search_box.reparent(buttons)
 		buttons.move_child(search_box, 0)
 		size_slider.reparent(buttons)
-		buttons.move_child(size_slider, 4)
+		buttons.move_child(size_slider, 3)
 		pinned_btn.reparent(box)
 
 	pinned_btn.visible = is_instance_valid(window)


### PR DESCRIPTION
This fixes the search function in the asset dock in 4.6

For some reason, the asset dock is not fully initialized when _ready() is called - and _ready() exits early in this case, so the text_changed and button press signal connections, and the icon set up was being skipped. I moved all of this to the initialize function.

The pinned button - the asset dock was not finding a Window as grandparent therefore thought it was still docked - the new structure seems to have added another layer so now we need to look for the great-grandparent! 
Added a check so that we can reset the window variable to null if we are docked and use the validity of the window object to determine whether the pin button should be visible or not.

     