### PR TITLE
Document Godot 4.5 workaround for texture flicker

### DIFF
--- a/doc/docs/troubleshooting.md
+++ b/doc/docs/troubleshooting.md
@@ -100,7 +100,11 @@ If you're using multiple cameras, or viewports, you need to tell Terrain3D which
 
 ### Textures flicker
 
-Disable temporal effects: FSR, TAA, and motion blur. The Terrain3D mesh is constantly moving which causes Godot to unnecessarily generate motion vectors for the terrain. A way to fix this is making it's way through Godot and will be included in a later version. Until then, temporal effects are unreliable.
+Disable temporal effects: FSR, TAA, and motion blur. The Terrain3D mesh is constantly moving which causes Godot to unnecessarily generate motion vectors for the terrain. This has been fixed in the Godot 4.5 API, but Terrain3D is built against the 4.4 API. We're not ready to abandon 4.4 yet, so to use Terrain3D with TAA, FSR2, or Motion Blur you must:
+* [Build Terrain3D](building_from_source.md) from source using the godot-cpp 4.5 branch
+* Use the Godot 4.5+ engine binary
+
+Once we offer builds against the 4.5 API, building from source won't be necessary.
 
 
 ### Intersecting meshes flicker


### PR DESCRIPTION
I had the issue #302 as well, and went to the documentation to see how to fix it. Upon discovering I could not use FSR 2.2, I was distraught, as I needed upscaling to run my heavy project on my potato. I was certain that Godot 4.5 had introduced a motion vector fix specifically for issues like this. After an hour of scouring the internet, I found issue 302 and learned that building Terrain3D against 4.5 would allow me to use FSR 2.2.

For other poor souls like me who need their games to support potato pcs and want to use Terrain3D, updating the documentation to reflect this temporary fix would be beneficial. 