### PR TITLE
Create dummy texture array to stop error spam

### DIFF
--- a/src/terrain_3d.cpp
+++ b/src/terrain_3d.cpp
@@ -484,6 +484,7 @@ void Terrain3D::_generate_triangle_pair(PackedVector3Array &p_vertices, PackedVe
 ///////////////////////////
 
 Terrain3D::Terrain3D() {
+	LOG(INFO, "Terrain3D v", _version, " - https://github.com/TokisanGames/Terrain3D");
 	// Process the command line
 	PackedStringArray args = OS::get_singleton()->get_cmdline_args();
 	for (int i = args.size() - 1; i >= 0; i--) {

--- a/src/terrain_3d_material.cpp
+++ b/src/terrain_3d_material.cpp
@@ -654,13 +654,21 @@ void Terrain3DMaterial::_update_uniforms(const RID &p_material, const uint32_t p
 	LOG(EXTREME, "Setting region size in material: ", region_size);
 	RS->material_set_param(p_material, "_region_size", region_size);
 	RS->material_set_param(p_material, "_region_texel_size", 1.0f / region_size);
+
 	if (p_flags & REGION_ARRAYS) {
-		RS->material_set_param(p_material, "_height_maps", data->get_height_maps_rid());
-		RS->material_set_param(p_material, "_control_maps", data->get_control_maps_rid());
-		RS->material_set_param(p_material, "_color_maps", data->get_color_maps_rid());
-		LOG(EXTREME, "Height map RID: ", data->get_height_maps_rid());
-		LOG(EXTREME, "Control map RID: ", data->get_control_maps_rid());
-		LOG(EXTREME, "Color map RID: ", data->get_color_maps_rid());
+		if (data->get_region_count() > 0) {
+			RS->material_set_param(p_material, "_height_maps", data->get_height_maps_rid());
+			RS->material_set_param(p_material, "_control_maps", data->get_control_maps_rid());
+			RS->material_set_param(p_material, "_color_maps", data->get_color_maps_rid());
+			LOG(EXTREME, "Height map RID: ", data->get_height_maps_rid());
+			LOG(EXTREME, "Control map RID: ", data->get_control_maps_rid());
+			LOG(EXTREME, "Color map RID: ", data->get_color_maps_rid());
+		} else {
+			// Send dummy texture array to stop compatibility error spam
+			RS->material_set_param(p_material, "_height_maps", _generated_dummy.get_rid());
+			RS->material_set_param(p_material, "_control_maps", _generated_dummy.get_rid());
+			RS->material_set_param(p_material, "_color_maps", _generated_dummy.get_rid());
+		}
 	}
 
 	real_t spacing = _terrain->get_vertex_spacing();
@@ -685,10 +693,25 @@ void Terrain3DMaterial::_update_uniforms(const RID &p_material, const uint32_t p
 		return;
 	}
 
-	if (p_flags & TEXTURE_ARRAYS) {
-		RS->material_set_param(p_material, "_texture_array_albedo", asset_list->get_albedo_array_rid());
-		RS->material_set_param(p_material, "_texture_array_normal", asset_list->get_normal_array_rid());
+	if (asset_list->get_generated_array_size() > 0) {
+		if (p_flags & TEXTURE_ARRAYS) {
+			RS->material_set_param(p_material, "_texture_array_albedo", asset_list->get_albedo_array_rid());
+			RS->material_set_param(p_material, "_texture_array_normal", asset_list->get_normal_array_rid());
+		}
+		set_show_checkered(false);
+		LOG(DEBUG, "Texture count >0: ", asset_list->get_generated_array_size(), ", disabling checkered view");
+	} else {
+		// Send dummy texture array to stop compatibility error spam
+		RS->material_set_param(p_material, "_texture_array_albedo", _generated_dummy.get_rid());
+		RS->material_set_param(p_material, "_texture_array_normal", _generated_dummy.get_rid());
+
+		// Enable checkered view if texture_count is 0, disable if not
+		if (_debug_view_checkered == false) {
+			set_show_checkered(true);
+			LOG(DEBUG, "No textures, enabling checkered view");
+		}
 	}
+
 	RS->material_set_param(p_material, "_texture_color_array", asset_list->get_texture_colors());
 	RS->material_set_param(p_material, "_texture_normal_depth_array", asset_list->get_texture_normal_depths());
 	RS->material_set_param(p_material, "_texture_ao_strength_array", asset_list->get_texture_ao_strengths());
@@ -697,17 +720,6 @@ void Terrain3DMaterial::_update_uniforms(const RID &p_material, const uint32_t p
 	RS->material_set_param(p_material, "_texture_uv_scale_array", asset_list->get_texture_uv_scales());
 	RS->material_set_param(p_material, "_texture_detile_array", asset_list->get_texture_detiles());
 	RS->material_set_param(p_material, "_texture_displacement_array", asset_list->get_texture_displacements());
-
-	// Enable checkered view if texture_count is 0, disable if not
-	if (asset_list->get_generated_array_size() == 0) {
-		if (_debug_view_checkered == false) {
-			set_show_checkered(true);
-			LOG(DEBUG, "No textures, enabling checkered view");
-		}
-	} else {
-		set_show_checkered(false);
-		LOG(DEBUG, "Texture count >0: ", asset_list->get_generated_array_size(), ", disabling checkered view");
-	}
 }
 
 void Terrain3DMaterial::_set_shader_parameters(const Dictionary &p_dict) {
@@ -739,6 +751,12 @@ void Terrain3DMaterial::initialize(Terrain3D *p_terrain) {
 	}
 	_shader.instantiate();
 	_buffer_shader.instantiate();
+	{ // Create dummy texture array to avoid empty sampler2DArrays
+		Ref<Image> img = Image::create(1, 1, false, Image::FORMAT_RF);
+		TypedArray<Image> ia = { img };
+		_generated_dummy.create(ia);
+	}
+
 	update(FULL_REBUILD);
 }
 
@@ -755,6 +773,7 @@ void Terrain3DMaterial::destroy() {
 	_shader_code.clear();
 	_active_params.clear();
 	_shader_params.clear();
+	_generated_dummy.clear();
 	if (_material.is_valid()) {
 		RS->free_rid(_material);
 		_material = RID();

--- a/src/terrain_3d_material.h
+++ b/src/terrain_3d_material.h
@@ -53,6 +53,7 @@ private:
 	Ref<Shader> _buffer_shader_override; // User's shader we copy code from
 	real_t _displacement_scale = 1.0f;
 	real_t _displacement_sharpness = 0.5f;
+	GeneratedTexture _generated_dummy;
 
 	// Material Features
 	WorldBackground _world_background = FLAT;


### PR DESCRIPTION
Fixes #924 
* Prints Terrain3D version on debug
* Creates a dummy texture array and sends it to the shader texture arrays when the texture list is empty, or there are no regions.



~~This is only a partial fix so far.  A dummy texture array is fed into the ground texture arrays, which solves the error spam when assets is empty.~~

~~However the same trick doesn't work for the maps arrays. I haven't figured out why yet. Perhaps the other arrays need dummy values. Perhaps some injected code is triggering it. I've started hacking up the shader and material to eliminate uniforms.~~