### PR TITLE
WIP: Add Instancer push-pull feature

### DIFF
--- a/project/addons/terrain_3d/src/tool_settings.gd
+++ b/project/addons/terrain_3d/src/tool_settings.gd
@@ -4,6 +4,8 @@ extends PanelContainer
 
 signal picking(type: Terrain3DEditor.Tool, callback: Callable)
 signal setting_changed(setting: Variant)
+signal push_button_pressed
+signal pull_button_pressed
 
 enum Layout {
 	HORIZONTAL,
@@ -21,6 +23,7 @@ enum SettingType {
 	SLIDER,
 	LABEL,
 	TYPE_MAX,
+	BUTTON,
 }
 
 const MultiPicker: Script = preload("res://addons/terrain_3d/src/multi_picker.gd")
@@ -49,6 +52,7 @@ var scale_list: VBoxContainer
 var rotation_list: VBoxContainer
 var color_list: VBoxContainer
 var collision_list: VBoxContainer
+var pull_push_list: VBoxContainer
 var settings: Dictionary = {}
 
 
@@ -167,7 +171,10 @@ func _ready() -> void:
 							"default":true })
 	add_setting({ "name":"raycast_height", "label":"Raycast Height", "type":SettingType.SLIDER, 
 							"list":collision_list, "default":10, "unit":"m", "range":Vector3(0, 200, .25) })
-
+	pull_push_list = create_submenu(main_list, "Pull/Push", Layout.VERTICAL)
+	add_setting({"name":"pull", "label":"Pull from scene", "type":SettingType.BUTTON, "list":pull_push_list, "icon":"", "flags":NO_LABEL})
+	add_setting({"name":"push", "label":"Push from instancer", "type":SettingType.BUTTON, "list":pull_push_list, "icon":"", "flags":NO_LABEL})
+	
 	if DisplayServer.is_touchscreen_available():
 		add_setting({ "name":"invert", "label":"Invert", "type":SettingType.CHECKBOX, "list":main_list, "default":false, "flags":ADD_SEPARATOR })
 
@@ -481,6 +488,16 @@ func add_setting(p_args: Dictionary) -> void:
 			pending_children.push_back(option)
 			control = option
 
+		SettingType.BUTTON:
+			var button:= Button.new()
+			button.text = p_label
+			if p_name == "pull":
+				button.pressed.connect(pull_button_pressed.emit)
+			if p_name == "push":
+				button.pressed.connect(push_button_pressed.emit)
+			pending_children.push_back(button)
+			control = button
+			
 		SettingType.SLIDER, SettingType.DOUBLE_SLIDER:
 			var slider: Control
 			if p_type == SettingType.SLIDER:

--- a/project/addons/terrain_3d/src/ui.gd
+++ b/project/addons/terrain_3d/src/ui.gd
@@ -111,10 +111,18 @@ func _enter_tree() -> void:
 		get_tree().create_tween().tween_property(self, "editor_decal_fade", 0.0, 0.15))
 	add_child(editor_decal_timer)
 
-
+	if not tool_settings.pull_button_pressed.is_connected(_on_pull_button_pressed):
+		tool_settings.pull_button_pressed.connect(_on_pull_button_pressed)
+	if not tool_settings.push_button_pressed.is_connected(_on_push_button_pressed):
+		tool_settings.push_button_pressed.connect(_on_push_button_pressed)
+		
 func _exit_tree() -> void:
 	if plugin.debug:
 		print("Terrain3DUI: _exit_tree()")
+	if tool_settings.pull_button_pressed.is_connected(_on_pull_button_pressed):
+		tool_settings.pull_button_pressed.disconnect(_on_pull_button_pressed)
+	if tool_settings.push_button_pressed.is_connected(_on_push_button_pressed):
+		tool_settings.push_button_pressed.disconnect(_on_push_button_pressed)
 	plugin.remove_control_from_container(EditorPlugin.CONTAINER_SPATIAL_EDITOR_SIDE_LEFT, toolbar)
 	plugin.remove_control_from_container(EditorPlugin.CONTAINER_SPATIAL_EDITOR_BOTTOM, tool_settings)
 	toolbar.queue_free()
@@ -169,6 +177,7 @@ func _on_tool_changed(p_tool: Terrain3DEditor.Tool, p_operation: Terrain3DEditor
 	set_menu_visibility(tool_settings.height_list, false)
 	set_menu_visibility(tool_settings.color_list, false)
 	set_menu_visibility(tool_settings.collision_list, false)
+	set_menu_visibility(tool_settings.pull_push_list, false)
 
 	# Select which settings to show. Options in tool_settings.gd:_ready
 	var to_show: PackedStringArray = []
@@ -266,6 +275,9 @@ func _on_tool_changed(p_tool: Terrain3DEditor.Tool, p_operation: Terrain3DEditor
 			to_show.push_back("on_collision")
 			to_show.push_back("raycast_height")
 			to_show.push_back("invert")
+			set_menu_visibility(tool_settings.pull_push_list, true)
+			to_show.push_back("pull")
+			to_show.push_back("push")
 
 		_:
 			pass
@@ -648,5 +660,15 @@ func pick(p_global_position: Vector3) -> void:
 		operation_builder.pick(p_global_position, plugin.terrain)
 
 
+func _on_pull_button_pressed() -> void:
+	var id: int = brush_data.get("asset_id", -1)
+	plugin.terrain.instancer.pull_from_scene(id)
+	
+	
+func _on_push_button_pressed() -> void:
+	var id: int = brush_data.get("asset_id", -1)
+	plugin.terrain.instancer.push_from_instancer(id)
+	
+	
 func set_button_editor_icon(p_button: Button, p_icon_name: String) -> void:
 	p_button.icon = EditorInterface.get_base_control().get_theme_icon(p_icon_name, "EditorIcons")

--- a/src/terrain_3d_instancer.cpp
+++ b/src/terrain_3d_instancer.cpp
@@ -1337,6 +1337,79 @@ void Terrain3DInstancer::update_mmis(const int p_mesh_id, const Vector2i &p_regi
 	}
 }
 
+void Terrain3DInstancer::push_from_instancer(const int asset_id) {
+	Ref<Terrain3DMeshAsset> ma = _terrain->get_assets()->get_mesh_asset(asset_id);
+	if (!ma.is_valid()) {
+		LOG(ERROR, "Invalid asset ID: ", asset_id);
+		return;
+	}
+	LOG(INFO, "Exporting instances to scene for asset id: ", asset_id);
+	const Terrain3DData *data = _terrain->get_data();
+	if (!data) {
+		LOG(ERROR, "No terrain data found. Cannot export.");
+		return;
+	}
+	TypedArray<Vector2i> region_locations = data->get_region_locations();
+	for (const Vector2i &region_loc : region_locations) {
+		const Terrain3DRegion *region = data->get_region_ptr(region_loc);
+		if (!region) {
+			LOG(WARN, "Errant null region found at: ", region_loc);
+			continue;
+		}
+		auto pair = std::make_pair(region_loc, asset_id);
+		if (region->get_instances().has(asset_id)) {
+			//SPAWN INSTANC
+
+			Vector2i region_loc = region->get_location();
+			Dictionary mesh_inst_dict = region->get_instances();
+			// Process cells
+			Dictionary cell_inst_dict = mesh_inst_dict[asset_id];
+			Array cell_locations = cell_inst_dict.keys();
+
+			for (const Vector2i &cell : cell_locations) {
+				Array triple = cell_inst_dict[cell];
+				if (triple.size() < 3) {
+					LOG(WARN, "Triple is empty for region, ", region_loc, ", cell ", cell);
+					continue;
+				}
+				TypedArray<Transform3D> xforms = triple[0];
+				for (const Transform3D &xform : xforms) {
+					Transform3D global_xform;
+					global_xform.basis = xform.basis;
+					global_xform.origin = v2iv3(region_loc * real_t(region->get_region_size()) * _terrain->get_vertex_spacing()) + xform.origin;
+					Node *node_instance = ma->get_scene_file()->instantiate();
+					Node3D *instance = Object::cast_to<Node3D>(node_instance);
+					instance->set_name(ma->get_name());
+					_terrain->add_child(instance, true);
+					instance->set_global_transform(global_xform);
+					instance->set_owner(_terrain->get_owner());
+				}
+			}
+		}
+	}
+	clear_by_mesh(asset_id);
+}
+
+void Terrain3DInstancer::pull_from_scene(const int asset_id) {
+	Ref<Terrain3DMeshAsset> ma = _terrain->get_assets()->get_mesh_asset(asset_id);
+	if (!ma.is_valid()) {
+		LOG(ERROR, "Invalid asset ID: ", asset_id);
+		return;
+	}
+	LOG(INFO, "Importing instances from scene for asset id: ", asset_id);
+	TypedArray<Node> nodes = _terrain->get_children();
+	TypedArray<Transform3D> xforms;
+	for (int i = 0; i < nodes.size(); i++) {
+		Node *node = cast_to<Node>(nodes[i]);
+		if (node && node->get_scene_file_path() == ma->get_scene_file()->get_path()) {
+			LOG(INFO, "Found an instance of ", asset_id, " in scene");
+			xforms.push_back(Object::cast_to<Node3D>(node)->get_global_transform());
+			node->queue_free();
+		}
+	}
+	add_transforms(asset_id, xforms, PackedColorArray(), true);
+}
+
 ///////////////////////////
 // Protected Functions
 ///////////////////////////
@@ -1362,6 +1435,8 @@ void Terrain3DInstancer::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("get_closest_mesh_id", "global_position"), &Terrain3DInstancer::get_closest_mesh_id);
 	ClassDB::bind_method(D_METHOD("update_mmis", "mesh_id", "region_location", "rebuild_all"), &Terrain3DInstancer::update_mmis, DEFVAL(-1), DEFVAL(V2I_MAX), DEFVAL(false));
 	ClassDB::bind_method(D_METHOD("swap_ids", "src_id", "dest_id"), &Terrain3DInstancer::swap_ids);
+	ClassDB::bind_method(D_METHOD("pull_from_scene", "asset_id"), &Terrain3DInstancer::pull_from_scene);
+	ClassDB::bind_method(D_METHOD("push_from_instancer", "asset_id"), &Terrain3DInstancer::push_from_instancer);
 
 	ADD_PROPERTY(PropertyInfo(Variant::INT, "mode", PROPERTY_HINT_ENUM, "Disabled,Normal"), "set_mode", "get_mode");
 }

--- a/src/terrain_3d_instancer.h
+++ b/src/terrain_3d_instancer.h
@@ -97,6 +97,8 @@ public:
 	void update_mmis(const int p_mesh_id = -1, const Vector2i &p_region_loc = V2I_MAX, const bool p_rebuild = false);
 
 	void reset_density_counter() { _density_counter = 0; }
+	void push_from_instancer(const int asset_id);
+	void pull_from_scene(const int asset_id);
 
 protected:
 	static void _bind_methods();


### PR DESCRIPTION
An enhancement for the instancer:

### **Push**
Push meshes from the instancer to the scene - make manual transform edits 

1. Select the mesh you want to push, 
2. Hover the push/pull menu, click Push from Instancer
3. Instances will be added as children of Terrain3D node and removed from the instancer data (the MeshAsset remains in the list with a count of 0)

### **Pull**
Pull meshes from the scene to the instancer once finished editing, or can be used in case you already made a scene manually and want to bring it into Terrain3D 

1. Make sure the scene you want to Pull exists in the asset list and select it
2. Hover the push/pull menu, click Pull from Scene
3. Children of the Terrain3D will be checked for a match (if they are based on the same PackedScene) and they will be added to the instancer data and removed from the scene. 