### PR TITLE
Fix save crashes from Terrain3DMaterial

### DIFF
--- a/src/constants.h
+++ b/src/constants.h
@@ -3,6 +3,8 @@
 #ifndef CONSTANTS_CLASS_H
 #define CONSTANTS_CLASS_H
 
+#include <functional>
+
 // GDExtension uses the godot namespace, custom modules do not.
 #if defined(GDEXTENSION) && !defined(GODOT_MODULE)
 using namespace godot;

--- a/src/terrain_3d_material.cpp
+++ b/src/terrain_3d_material.cpp
@@ -1114,7 +1114,7 @@ void Terrain3DMaterial::_get_property_list(List<PropertyInfo> *p_list) const {
 		}
 	}
 
-	_active_params.clear();
+	TypedArray<StringName> new_active_params;
 	Dictionary grouped_params;
 	StringName current_group = StringName("shader_uniforms.general");
 	grouped_params[current_group] = Array();
@@ -1138,13 +1138,13 @@ void Terrain3DMaterial::_get_property_list(List<PropertyInfo> *p_list) const {
 				dict["usage"] = name.contains("::") ? PROPERTY_USAGE_SUBGROUP : PROPERTY_USAGE_GROUP;
 			} else {
 				// Filter out duplicate non-groups entries from displacement buffer shader
-				if (_active_params.has(name)) {
+				if (new_active_params.has(name)) {
 					continue;
 				}
 				dict["usage"] = PROPERTY_USAGE_EDITOR;
 			}
 			// Filter out extraneous parameters from the inspector if they are not present in the terrain shader.
-			if (i >= buffer_param && (!_active_params.has(name) && use != PROPERTY_USAGE_GROUP) && !current_group.contains("Displacement")) {
+			if (i >= buffer_param && (!new_active_params.has(name) && use != PROPERTY_USAGE_GROUP) && !current_group.contains("Displacement")) {
 				LOG(INFO, "Displacement buffer has active parameter: ", name, " not present in terrain shader.");
 				continue;
 			}
@@ -1160,7 +1160,7 @@ void Terrain3DMaterial::_get_property_list(List<PropertyInfo> *p_list) const {
 			grouped_params[current_group] = group;
 
 			// Populate list of public parameters for current shader
-			_active_params.push_back(name);
+			new_active_params.push_back(name);
 
 			// Store this param in a dictionary that is saved in the resource file
 			// Initially set with default value
@@ -1172,6 +1172,7 @@ void Terrain3DMaterial::_get_property_list(List<PropertyInfo> *p_list) const {
 			}
 		}
 	}
+	_active_params = new_active_params;
 
 	// Populate Godot's property list
 	Array keys = grouped_params.keys();


### PR DESCRIPTION
Fixes #945

The `_active_params` variable of the `Terrain3DMaterial` class was being modified during `_get_property_list`, which could happen while other threads are trying to read from the array. Because the array was cleared on each `_get_property_list` call and each resize of the array causes the invalidation of its internal pointer, there was a race condition that could lead to segmentation faults, double frees and the like.

The first commit of this PR fixes the crashing in most practical cases, it just makes it so the class variable is only modified when there are actual differences between the new set of parameters and the old one. This doesn't completely fix the race condition, it's still theoretically possible to have a thread read the variable just as it gets swapped and freed, but I'm not sure if this could actually happen with normal usage.

~The second commit is my attempt at completely eliminating the race condition. It uses `SafeNumeric` to make reads and writes to the `_active_params` variable atomic. This might be a bit convoluted, and it might also be a misuse of the `SafeNumeric` class (using it for pointers like this), but I'm not familiar enough with this code base to suggest any other solution. It might best to have the `_get_property_list` method not change any state, and only update `_active_params` when really necessary using some other trigger.~ Removed from PR.

As a side note, I had to add the include for `functional` to the `constants.h` file in order to build this, I'm not sure what's up with that. I can remove it from the PR if needed.