### PR TITLE
Fix double precision building

### DIFF
--- a/src/terrain_3d_collision.cpp
+++ b/src/terrain_3d_collision.cpp
@@ -57,8 +57,8 @@ Dictionary Terrain3DCollision::_get_shape_data(const Vector2i &p_position, const
 
 		real_t blend_factor = 2.0f + 126.0f * (1.0f - region_blend);
 		Vector2 f = Vector2(uv2.x - Math::floor(uv2.x), uv2.y - Math::floor(uv2.y));
-		f.x = Math::clamp(f.x, 1e-8f, 1.f - 1e-8f);
-		f.y = Math::clamp(f.y, 1e-8f, 1.f - 1e-8f);
+		f.x = Math::clamp(f.x, real_t(1e-8), real_t(1.0 - 1e-8));
+		f.y = Math::clamp(f.y, real_t(1e-8), real_t(1.0 - 1e-8));
 		Vector2 w = Vector2(1.f / (1.f + Math::exp(blend_factor * Math::log((1.f - f.x) / f.x))),
 				1.f / (1.f + Math::exp(blend_factor * Math::log((1.f - f.y) / f.y))));
 		real_t blend = Math::lerp(Math::lerp(d, c, w.x), Math::lerp(a, b, w.x), w.y);

--- a/src/terrain_3d_collision.cpp
+++ b/src/terrain_3d_collision.cpp
@@ -57,8 +57,8 @@ Dictionary Terrain3DCollision::_get_shape_data(const Vector2i &p_position, const
 
 		real_t blend_factor = 2.0f + 126.0f * (1.0f - region_blend);
 		Vector2 f = Vector2(uv2.x - Math::floor(uv2.x), uv2.y - Math::floor(uv2.y));
-		f.x = Math::clamp(f.x, 1e-8f, 1.f - 1e-8f);
-		f.y = Math::clamp(f.y, 1e-8f, 1.f - 1e-8f);
+		f.x = Math::clamp(f.x, real_t(1e-8f), real_t(1.0f - 1e-8f));
+		f.y = Math::clamp(f.y, real_t(1e-8f), real_t(1.0f - 1e-8f));
 		Vector2 w = Vector2(1.f / (1.f + Math::exp(blend_factor * Math::log((1.f - f.x) / f.x))),
 				1.f / (1.f + Math::exp(blend_factor * Math::log((1.f - f.y) / f.y))));
 		real_t blend = Math::lerp(Math::lerp(d, c, w.x), Math::lerp(a, b, w.x), w.y);

--- a/src/terrain_3d_editor.cpp
+++ b/src/terrain_3d_editor.cpp
@@ -737,8 +737,8 @@ void Terrain3DEditor::_apply_undo(const Dictionary &p_data) {
 }
 
 // Returns average of height, blend (as real_t(0-255)), or roughness. Overloaded version handles average color
-real_t Terrain3DEditor::_average(const AverageMode p_mode, const Vector3 &p_global_position, const real_t p_base,
-		const real_t p_nan_val, bool p_alt) const {
+float Terrain3DEditor::_average(const AverageMode p_mode, const Vector3 &p_global_position, const float p_base,
+		const float p_nan_val, bool p_alt) const {
 	IS_DATA_INIT(NAN);
 	Terrain3DData *data = _terrain->get_data();
 	real_t vertex_spacing = _terrain->get_vertex_spacing();
@@ -767,7 +767,7 @@ real_t Terrain3DEditor::_average(const AverageMode p_mode, const Vector3 &p_glob
 	}
 
 	Color pixel;
-	real_t left, right, up, down;
+	float left, right, up, down;
 	pixel = data->get_pixel(map_type, left_position);
 	left = std::isnan(pixel.r) ? p_nan_val : pixel[index];
 	pixel = data->get_pixel(map_type, right_position);
@@ -779,9 +779,9 @@ real_t Terrain3DEditor::_average(const AverageMode p_mode, const Vector3 &p_glob
 
 	if (p_mode == AVG_BLEND) {
 		if (p_alt) {
-			return real_t(get_blend(p_base) + get_blend(left) + get_blend(right) + get_blend(up) + get_blend(down)) * 0.2f;
+			return (get_blend(p_base) + get_blend(left) + get_blend(right) + get_blend(up) + get_blend(down)) * 0.2f;
 		} else {
-			return Math::lerp(get_blend(p_base), 128.f, .1f);
+			return Math::lerp(float(get_blend(p_base)), 128.f, .1f);
 		}
 	} else {
 		return (p_base + left + right + up + down) * 0.2f;

--- a/src/terrain_3d_editor.h
+++ b/src/terrain_3d_editor.h
@@ -98,7 +98,7 @@ private:
 	Vector2 _get_rotated_uv(const Vector2 &p_uv, const real_t p_angle) const;
 	void _store_undo();
 	void _apply_undo(const Dictionary &p_data);
-	real_t _average(const AverageMode p_mode, const Vector3 &p_global_position, const real_t p_base, const real_t p_nan_val = 0.f, bool p_alt = false) const;
+	float _average(const AverageMode p_mode, const Vector3 &p_global_position, const float p_base, const float p_nan_val = 0.f, bool p_alt = false) const;
 	Color _average(const Vector3 &p_global_position, const Color &p_base) const;
 
 public:

--- a/src/terrain_3d_mesh_asset.cpp
+++ b/src/terrain_3d_mesh_asset.cpp
@@ -489,7 +489,7 @@ void Terrain3DMeshAsset::set_lod_range(const int p_lod, const real_t p_distance)
 		LOG(ERROR, "p_lod out of range. Valid range is 0 - ", _lod_ranges.size() - 1);
 		return;
 	}
-	SET_IF_DIFF(_lod_ranges[p_lod], CLAMP(p_distance, 0.f, 100000.f));
+	SET_IF_DIFF(_lod_ranges[p_lod], CLAMP(float(p_distance), 0.f, 100000.f));
 	LOG(INFO, "ID ", _id, ", ", _name, ": Setting LOD ", p_lod, " visibility range: ", _lod_ranges[p_lod]);
 	LOG(DEBUG, "Emitting instancer_setting_changed, ID: ", _id);
 	emit_signal("instancer_setting_changed", _id);

--- a/src/terrain_3d_util.h
+++ b/src/terrain_3d_util.h
@@ -7,6 +7,7 @@
 #include <godot_cpp/classes/node.hpp>
 #include <godot_cpp/classes/resource_loader.hpp>
 #include <godot_cpp/variant/utility_functions.hpp>
+#include <type_traits>
 
 #include "constants.h"
 #include "generated_texture.h"
@@ -231,46 +232,54 @@ inline uint32_t as_uint(const float p_value) { return *(uint32_t *)&p_value; }
 
 inline uint8_t get_base(const uint32_t p_pixel) { return p_pixel >> 27 & 0x1F; }
 inline uint8_t get_base(const float p_pixel) { return get_base(as_uint(p_pixel)); }
+inline uint8_t get_base(const double p_pixel) { return get_base(static_cast<float>(p_pixel)); }
 inline uint32_t enc_base(const uint8_t p_base) { return (p_base & 0x1F) << 27; }
 inline uint32_t gd_get_base(const uint32_t p_pixel) { return get_base(p_pixel); }
 inline uint32_t gd_enc_base(const uint32_t p_base) { return enc_base(p_base); }
 
 inline uint8_t get_overlay(const uint32_t p_pixel) { return p_pixel >> 22 & 0x1F; }
 inline uint8_t get_overlay(const float p_pixel) { return get_overlay(as_uint(p_pixel)); }
+inline uint8_t get_overlay(const double p_pixel) { return get_overlay(static_cast<float>(p_pixel)); }
 inline uint32_t enc_overlay(const uint8_t p_over) { return (p_over & 0x1F) << 22; }
 inline uint32_t gd_get_overlay(const uint32_t p_pixel) { return get_overlay(p_pixel); }
 inline uint32_t gd_enc_overlay(const uint32_t p_over) { return enc_overlay(p_over); }
 
 inline uint8_t get_blend(const uint32_t p_pixel) { return p_pixel >> 14 & 0xFF; }
 inline uint8_t get_blend(const float p_pixel) { return get_blend(as_uint(p_pixel)); }
+inline uint8_t get_blend(const double p_pixel) { return get_blend(static_cast<float>(p_pixel)); }
 inline uint32_t enc_blend(const uint8_t p_blend) { return (p_blend & 0xFF) << 14; }
 inline uint32_t gd_get_blend(const uint32_t p_pixel) { return get_blend(p_pixel); }
 inline uint32_t gd_enc_blend(const uint32_t p_blend) { return enc_blend(p_blend); }
 
 inline uint8_t get_uv_rotation(const uint32_t p_pixel) { return p_pixel >> 10 & 0xF; }
 inline uint8_t get_uv_rotation(const float p_pixel) { return get_uv_rotation(as_uint(p_pixel)); }
+inline uint8_t get_uv_rotation(const double p_pixel) { return get_uv_rotation(static_cast<float>(p_pixel)); }
 inline uint32_t enc_uv_rotation(const uint8_t p_rotation) { return (p_rotation & 0xF) << 10; }
 inline uint32_t gd_get_uv_rotation(const uint32_t p_pixel) { return get_uv_rotation(p_pixel); }
 inline uint32_t gd_enc_uv_rotation(const uint32_t p_rotation) { return enc_uv_rotation(p_rotation); }
 
 inline uint8_t get_uv_scale(const uint32_t p_pixel) { return p_pixel >> 7 & 0x7; }
 inline uint8_t get_uv_scale(const float p_pixel) { return get_uv_scale(as_uint(p_pixel)); }
+inline uint8_t get_uv_scale(const double p_pixel) { return get_uv_scale(static_cast<float>(p_pixel)); }
 inline uint32_t enc_uv_scale(const uint8_t p_scale) { return (p_scale & 0x7) << 7; }
 inline uint32_t gd_get_uv_scale(const uint32_t p_pixel) { return get_uv_scale(p_pixel); }
 inline uint32_t gd_enc_uv_scale(const uint32_t p_scale) { return enc_uv_scale(p_scale); }
 
 inline bool is_hole(const uint32_t p_pixel) { return (p_pixel >> 2 & 0x1) == 1; }
 inline bool is_hole(const float p_pixel) { return is_hole(as_uint(p_pixel)); }
+inline bool is_hole(const double p_pixel) { return is_hole(static_cast<float>(p_pixel)); }
 inline uint32_t enc_hole(const bool p_hole) { return (p_hole & 0x1) << 2; }
 inline bool gd_is_hole(const uint32_t p_pixel) { return is_hole(p_pixel); }
 
 inline bool is_nav(const uint32_t p_pixel) { return (p_pixel >> 1 & 0x1) == 1; }
 inline bool is_nav(const float p_pixel) { return is_nav(as_uint(p_pixel)); }
+inline bool is_nav(const double p_pixel) { return is_nav(static_cast<float>(p_pixel)); }
 inline uint32_t enc_nav(const bool p_nav) { return (p_nav & 0x1) << 1; }
 inline bool gd_is_nav(const uint32_t p_pixel) { return is_nav(p_pixel); }
 
 inline bool is_auto(const uint32_t p_pixel) { return (p_pixel & 0x1) == 1; }
 inline bool is_auto(const float p_pixel) { return is_auto(as_uint(p_pixel)); }
+inline bool is_auto(const double p_pixel) { return is_auto(static_cast<float>(p_pixel)); }
 inline uint32_t enc_auto(const bool p_auto) { return p_auto & 0x1; }
 inline bool gd_is_auto(const uint32_t p_pixel) { return is_auto(p_pixel); }
 
@@ -336,9 +345,10 @@ _FORCE_INLINE_ bool differs(const T &a, const T &b) {
 }
 
 // Sets A if different from B, otherwise returns
+// Cast b to a's type for precision=double builds.
 #define SET_IF_DIFF(a, b) \
-	if (differs(a, b)) {  \
-		a = b;            \
+	if (differs(a, static_cast<std::remove_reference_t<decltype(a)>>(b))) {  \
+		a = static_cast<std::remove_reference_t<decltype(a)>>(b);            \
 	} else {              \
 		return;           \
 	}


### PR DESCRIPTION
Fixes #977

-------- 

I've been working with Godot's [large world coordinates](https://docs.godotengine.org/en/stable/tutorials/physics/large_world_coordinates.html) build to try to address floating point imprecision issues with the large worlds that my game (Gunship Origins) requires. (Previous attempts include [origin shifting](https://github.com/TokisanGames/Terrain3D/compare/main...jamonholmgren:Terrain3D:jamon/origin-shifting), which comes with its own set of tradeoffs.)

When Godot is built with `precision=double`, `real_t` becomes `double` instead of `float`. This causes three categories of compile errors in Terrain3D:

## 1. Control-map pixel-unpacking helpers

The helpers `get_base`, `get_overlay`, `get_blend`, `get_uv_rotation`, `get_uv_scale`, `is_hole`, `is_nav`, `is_auto` only have `float` overloads. Callers pass `double` values from Godot's Image API, causing errors.

I added `double` overloads that cast to `float`.

## 2. `SET_IF_DIFF` errors

The `differs<T>` template errors when the types mismatch.

I switched to use `std::remove_reference_t`  + `static_cast` so both sides have the same type.

## 3. `Math::clamp` in collision code

`Math::clamp` uses `float` literals (`1e-8f`) but the first argument is `real_t` (now `double`), causing errors. 

I now wrap literals in `real_t()`.

Tested against Godot 4.6-stable built with `precision=double` and godot-cpp master. Terrain3D appears to work correctly, but more testing would be appreciated, whether you're using double precision builds or not.

<img width="400" alt="Terrain3D working in double Godot editor build" src="https://github.com/user-attachments/assets/00748671-5cc8-46f6-a2bc-69c76ecda9f3" />

My C++ skills aren't as good as they could be; feedback welcome.
