### PR TITLE
Add example ocean shader by default

### DIFF
--- a/project/addons/terrain_3d/extras/shaders/M_ocean.tres
+++ b/project/addons/terrain_3d/extras/shaders/M_ocean.tres
@@ -49,5 +49,5 @@ shader_parameter/_subdiv = 1.0
 shader_parameter/_vertex_spacing = 4.0
 shader_parameter/_vertex_density = 0.25
 shader_parameter/_target_pos = Vector3(0, 0, 0)
-shader_parameter/_light_direction = Vector3(0, 0.7671652, 0.64144963)
+shader_parameter/_light_direction = Vector3(0, 0.76604444, 0.64278764)
 shader_parameter/_light_color = Color(1, 1, 1, 1)

--- a/src/constants.h
+++ b/src/constants.h
@@ -15,6 +15,9 @@
 using namespace godot;
 #endif
 
+// File Paths (e.g. extras)
+#define OCEAN_MATERIAL_PATH "res://addons/terrain_3d/extras/shaders/M_ocean.tres"
+
 // Engine Shortcuts
 #define RS RenderingServer::get_singleton()
 #define PS PhysicsServer3D::get_singleton()

--- a/src/terrain_3d.cpp
+++ b/src/terrain_3d.cpp
@@ -9,6 +9,7 @@
 #include <godot_cpp/classes/os.hpp>
 #include <godot_cpp/classes/physics_direct_space_state3d.hpp>
 #include <godot_cpp/classes/physics_ray_query_parameters3d.hpp>
+#include <godot_cpp/classes/project_settings.hpp>
 #include <godot_cpp/classes/quad_mesh.hpp>
 #include <godot_cpp/classes/shader_material.hpp>
 #include <godot_cpp/classes/surface_tool.hpp>
@@ -804,6 +805,16 @@ void Terrain3D::set_ocean_enabled(const bool p_enabled) {
 	SET_IF_DIFF(_ocean_enabled, p_enabled);
 	LOG(INFO, "Setting ocean enabled: ", _ocean_enabled);
 	if (_ocean_enabled) {
+		if (_ocean_material.is_null()) {
+			String ocean_mat_path = ProjectSettings::get_singleton()->globalize_path(OCEAN_MATERIAL_PATH);
+			ResourceLoader *rl = ResourceLoader::get_singleton();
+			if (rl->exists(ocean_mat_path)) {
+				Ref<ShaderMaterial> ocean_mat = rl->load(ocean_mat_path);
+				if (ocean_mat.is_valid()) {
+					_ocean_material = ocean_mat;
+				}
+			}
+		}
 		_setup_ocean_mesher();
 	} else {
 		_destroy_ocean_mesher(false);


### PR DESCRIPTION
If the ocean material is null and the default ocean example material is present, it will automatically assign it when the ocean is enabled.