### PR TITLE
[4.6] Make shortcuts configurable in editor settings

### DIFF
--- a/doc/docs/keyboard_shortcuts.md
+++ b/doc/docs/keyboard_shortcuts.md
@@ -1,7 +1,7 @@
 Keyboard Shortcuts
 =================
 
-The following mouse and keyboard shortcuts or hotkeys are available.
+The following mouse and keyboard shortcuts or hotkeys are available. In Godot 4.6 and later, shortcuts can be customized in **Editor > Editor Settings > Shortcuts > Terrain 3D**.
 
 
 **Table of Contents**
@@ -152,8 +152,8 @@ All operations *except smoothing* are performed within the slope range on the [s
 
 ## Special Cases
 
-**macOS Users:** Use <kbd>Cmd</kbd> instead of <kbd>Ctrl</kbd>.
+**macOS Users:** By default, use <kbd>Cmd</kbd> instead of <kbd>Ctrl</kbd>.
 
 **Touchscreen Users:** You'll see an `Invert` checkbox on the settings bar which acts like <kbd>Ctrl</kbd> to inverse operations.
 
-**Maya Users:** The <kbd>Alt</kbd> key can be changed to Space, Meta (Windows key), or Capslock in `Editor Settings / Terrain3D / Config / Alt Key Bind` so it does not conflict with Maya input settings `Editor Settings / 3D / Navigation / Navigation Scheme`.
+**Maya Users:** Consider changing the <kbd>Alt</kbd> key in **Editor Settings > Shorcuts** (Godot 4.6+) or **Editor settings > Terrain3D > Config**, so it does not conflict with Maya input settings `Editor Settings / 3D / Navigation / Navigation Scheme`.

--- a/project/addons/terrain_3d/src/editor_plugin.gd
+++ b/project/addons/terrain_3d/src/editor_plugin.gd
@@ -33,26 +33,96 @@ var modifier_shift: bool
 var _last_modifiers: int = 0
 var _input_mode: int = 0 # -1: camera move, 0: none, 1: operating
 var rmb_release_time: int = 0
-var _use_meta: bool = false
+var shortcut_defaults: Dictionary[String, Variant] = {
+	"Invert Tool": KEY_CTRL,
+	"Sculpt Smooth": KEY_SHIFT,
+	"Alternate Mode": KEY_ALT,
+	"Decrease Tool Size": KEY_BRACKETLEFT,
+	"Increase Tool Size": KEY_BRACKETRIGHT,
+	"Decrease Tool Strength": KEY_MINUS,
+	"Increase Tool Strength": KEY_EQUAL,
+	"Toggle Region Grid": [KEY_1, KEY_KP_1],
+	"Toggle Region Labels": [KEY_2, KEY_KP_2],
+	"Toggle Contour Lines": [KEY_3, KEY_KP_3],
+	"Toggle Instancer Grid": [KEY_4, KEY_KP_4],
+	"Toggle Vertex Grid": [KEY_5, KEY_KP_5],
+	"Add or Remove Region": KEY_E,
+	"Sculpt Raise or Lower": KEY_R,
+	"Sculpt Height": KEY_H,
+	"Sculpt Slope": KEY_S,
+	"Paint Color": KEY_C,
+	"Paint Navigable Area": KEY_N,
+	"Instance Meshes": KEY_I,
+	"Add Holes": KEY_X,
+	"Paint Wetness": KEY_W,
+	"Paint Texture": KEY_B,
+	"Spray Texture": KEY_V,
+	"Paint Autoshader": KEY_A,
+	"Inverse Slope Range": KEY_T,
+}
+var shortcuts: Dictionary[String, Shortcut]
+var version: int # < 4.6 compatibility
 
 
 func _init() -> void:
 	if debug:
 		print("Terrain3DEditorPlugin: _init")
-	if OS.get_name() == "macOS":
-		_use_meta = true
+	if OS.has_feature("macos"):
+		shortcut_defaults["Invert Tool"] = KEY_META
 	
 	# Get the Godot Editor window. Structure is root:Window/EditorNode/Base Control
 	godot_editor_window = EditorInterface.get_base_control().get_parent().get_parent()
 	godot_editor_window.focus_entered.connect(_on_godot_focus_entered)
 	EditorInterface.get_inspector().mouse_entered.connect(func(): mouse_in_main = false)
+	
+	# Load shortcuts
+	version = Engine.get_version_info().hex
+	setup_editor_settings()
+	if version >= 0x040600:
+		var editor_settings:EditorSettings = EditorInterface.get_editor_settings()
+		for shortcut_name in shortcut_defaults.keys():
+			var saved_shortcut:Shortcut = editor_settings.get_shortcut("terrain_3d/" + shortcut_name)
+			if not saved_shortcut:
+				var shortcut := Shortcut.new()
+				var binding:Variant = shortcut_defaults[shortcut_name]
+				if binding is Key: # Single keycode
+					var shortcut_event := InputEventKey.new()
+					shortcut_event.physical_keycode = binding
+					shortcut.events.append(shortcut_event)
+				elif binding is Array: # Multiple keycodes
+					for key in binding:
+						var shortcut_event := InputEventKey.new()
+						shortcut_event.physical_keycode = key
+						shortcut.events.append(shortcut_event)
+				else:
+					push_error("Default shortcut keybind type is incorrect, must be Key or an array of Keys")
+				editor_settings.add_shortcut("terrain_3d/" + shortcut_name, shortcut)
+				shortcuts[shortcut_name] = shortcut
+			else:
+				# BUG: Saved shortcuts aren't automatically added to shortcuts menu, re-add manually
+				editor_settings.add_shortcut("terrain_3d/" + shortcut_name, saved_shortcut)
+				shortcuts[shortcut_name] = saved_shortcut
+	else: # < 4.6 compatiblility
+		for shortcut_name in shortcut_defaults.keys():
+			var shortcut := Shortcut.new()
+			var binding:Variant = shortcut_defaults[shortcut_name]
+			if binding is Key: # Single keycode
+				var shortcut_event := InputEventKey.new()
+				shortcut_event.physical_keycode = binding
+				shortcut.events.append(shortcut_event)
+			elif binding is Array: # Multiple keycodes
+				for key in binding:
+					var shortcut_event := InputEventKey.new()
+					shortcut_event.physical_keycode = key
+					shortcut.events.append(shortcut_event)
+			shortcuts[shortcut_name] = shortcut
+	apply_editor_settings()
 
 
 func _enter_tree() -> void:
 	if debug:
 		print("Terrain3DEditorPlugin: _enter_tree")
 	editor = Terrain3DEditor.new()
-	setup_editor_settings()
 	ui = Terrain3DUI.new()
 	ui.plugin = self
 	add_child(ui)
@@ -124,6 +194,7 @@ func _edit(p_object: Object) -> void:
 		editor.set_terrain(terrain)
 		terrain.set_meta("_edit_lock_", true)
 		ui.set_visible(true)
+		ui.toolbar.update_tooltips()
 
 		# Get alerted when a new asset list is loaded
 		if not terrain.assets_changed.is_connected(asset_dock.update_assets):
@@ -139,7 +210,7 @@ func _edit(p_object: Object) -> void:
 		else:
 			nav_region = null
 
-	
+
 func _make_visible(p_visible: bool, p_redraw: bool = false) -> void:
 	if debug:
 		print("Terrain3DEditorPlugin: _make_visible(%s, %s)" % [ p_visible, p_redraw ])
@@ -270,7 +341,7 @@ func _read_input(p_event: InputEvent = null) -> AfterGUIInput:
 	match get_setting("editors/3d/navigation/navigation_scheme", 0):
 		2, 1: # Modo, Maya
 			if Input.is_mouse_button_pressed(MOUSE_BUTTON_RIGHT) or \
-	 			( Input.is_key_pressed(KEY_ALT) and Input.is_mouse_button_pressed(MOUSE_BUTTON_LEFT) ):
+				( Input.is_key_pressed(KEY_ALT) and Input.is_mouse_button_pressed(MOUSE_BUTTON_LEFT) ):
 					_input_mode = -1 
 			if p_event is InputEventMouseButton and p_event.is_released() and \
 				( p_event.get_button_index() == MOUSE_BUTTON_RIGHT or \
@@ -289,22 +360,16 @@ func _read_input(p_event: InputEvent = null) -> AfterGUIInput:
 		return AFTER_GUI_INPUT_PASS
 
 	## Determine modifiers pressed
-	modifier_shift = Input.is_key_pressed(KEY_SHIFT)
+	if shortcuts["Sculpt Smooth"].matches_event(p_event):
+		modifier_shift = p_event.is_pressed()
 	
-	# Editor responds to modifier_ctrl so we must register touchscreen Invert 
-	if _use_meta:
-		modifier_ctrl = Input.is_key_pressed(KEY_META) || ui.inverted_input
-	else:
-		modifier_ctrl = Input.is_key_pressed(KEY_CTRL) || ui.inverted_input
-	
-	# Keybind enum: Alt,Space,Meta,Capslock
-	var alt_key: int
-	match get_setting("terrain3d/config/alt_key_bind", 0):
-		3: alt_key = KEY_CAPSLOCK
-		2: alt_key = KEY_META
-		1: alt_key = KEY_SPACE
-		0, _: alt_key = KEY_ALT
-	modifier_alt = Input.is_key_pressed(alt_key)
+	elif shortcuts["Invert Tool"].matches_event(p_event):
+		# Editor responds to modifier_ctrl so we must register touchscreen Invert
+		modifier_ctrl = p_event.is_pressed() || ui.inverted_input
+		
+	elif shortcuts["Alternate Mode"].matches_event(p_event):
+		modifier_alt = p_event.is_pressed()
+		
 	var current_mods: int = int(modifier_shift) | int(modifier_ctrl) << 1 | int(modifier_alt) << 2
 
 	## Process Hotkeys
@@ -332,63 +397,61 @@ func _read_input(p_event: InputEvent = null) -> AfterGUIInput:
 # Returns true if hotkey matches and operation triggered
 func consume_hotkey(p_event: InputEventKey) -> bool:
 	# Handle repeatable keys
-	match p_event.keycode:
-		KEY_BRACKETLEFT:
-			ui.tool_settings.set_setting("size", ui.tool_settings.get_setting("size") - 1)
-			return true
-		KEY_BRACKETRIGHT:
-			ui.tool_settings.set_setting("size", ui.tool_settings.get_setting("size") + 1)
-			return true
-		KEY_MINUS:
-			ui.tool_settings.set_setting("strength", ui.tool_settings.get_setting("strength") - 1)
-			return true
-		KEY_EQUAL:
-			ui.tool_settings.set_setting("strength", ui.tool_settings.get_setting("strength") + 1)
-			return true
+	if shortcuts["Decrease Tool Size"].matches_event(p_event):
+		ui.tool_settings.set_setting("size", ui.tool_settings.get_setting("size") - 1)
+		return true
+	elif shortcuts["Increase Tool Size"].matches_event(p_event):
+		ui.tool_settings.set_setting("size", ui.tool_settings.get_setting("size") + 1)
+		return true
+	elif shortcuts["Decrease Tool Strength"].matches_event(p_event):
+		ui.tool_settings.set_setting("strength", ui.tool_settings.get_setting("strength") - 1)
+		return true
+	elif shortcuts["Increase Tool Strength"].matches_event(p_event):
+		ui.tool_settings.set_setting("strength", ui.tool_settings.get_setting("strength") + 1)
+		return true
 		
 	if p_event.is_echo():
 		return false
-		
+	
 	# Handle non-repeatable keys
-	match p_event.keycode:
-		KEY_1, KEY_KP_1:
-			terrain.material.set_show_region_grid(!terrain.material.get_show_region_grid())
-		KEY_2, KEY_KP_2:
-			terrain.label_distance = 4096.0 if is_zero_approx(terrain.label_distance) else 0.0 
-		KEY_3, KEY_KP_3:
-			terrain.material.set_show_contours(!terrain.material.get_show_contours())
-		KEY_4, KEY_KP_4:
-			terrain.material.set_show_instancer_grid(!terrain.material.get_show_instancer_grid())
-		KEY_5, KEY_KP_5:
-			terrain.material.set_show_vertex_grid(!terrain.material.get_show_vertex_grid())
-		KEY_E:
-			ui.toolbar.get_button("AddRegion").set_pressed(true)
-		KEY_R:
-			ui.toolbar.get_button("Raise").set_pressed(true)
-		KEY_H:
-			ui.toolbar.get_button("Height").set_pressed(true)
-		KEY_S:
-			ui.toolbar.get_button("Slope").set_pressed(true)
-		KEY_C:
-			ui.toolbar.get_button("PaintColor").set_pressed(true)
-		KEY_N:
-			ui.toolbar.get_button("PaintNavigableArea").set_pressed(true)
-		KEY_I:
-			ui.toolbar.get_button("InstanceMeshes").set_pressed(true)
-		KEY_X:
-			ui.toolbar.get_button("AddHoles").set_pressed(true)
-		KEY_W:
-			ui.toolbar.get_button("PaintWetness").set_pressed(true)
-		KEY_B:
-			ui.toolbar.get_button("PaintTexture").set_pressed(true)
-		KEY_V:
-			ui.toolbar.get_button("SprayTexture").set_pressed(true)
-		KEY_A:
-			ui.toolbar.get_button("PaintAutoshader").set_pressed(true)
-		KEY_T:
-			ui.tool_settings.inverse_slope_range()
-		_:
-			return false
+	if shortcuts["Toggle Region Grid"].matches_event(p_event):
+		terrain.material.set_show_region_grid(!terrain.material.get_show_region_grid())
+	elif shortcuts["Toggle Region Labels"].matches_event(p_event):
+		terrain.label_distance = 4096.0 if is_zero_approx(terrain.label_distance) else 0.0
+	elif shortcuts["Toggle Contour Lines"].matches_event(p_event):
+		terrain.material.set_show_contours(!terrain.material.get_show_contours())
+	elif shortcuts["Toggle Instancer Grid"].matches_event(p_event):
+		terrain.material.set_show_instancer_grid(!terrain.material.get_show_instancer_grid())
+	elif shortcuts["Toggle Vertex Grid"].matches_event(p_event):
+		terrain.material.set_show_vertex_grid(!terrain.material.get_show_vertex_grid())
+	elif shortcuts["Add or Remove Region"].matches_event(p_event):
+		ui.toolbar.get_button("AddRegion").set_pressed(true)
+	elif shortcuts["Sculpt Raise or Lower"].matches_event(p_event):
+		ui.toolbar.get_button("Raise").set_pressed(true)
+	elif shortcuts["Sculpt Height"].matches_event(p_event):
+		ui.toolbar.get_button("Height").set_pressed(true)
+	elif shortcuts["Sculpt Slope"].matches_event(p_event):
+		ui.toolbar.get_button("Slope").set_pressed(true)
+	elif shortcuts["Paint Color"].matches_event(p_event):
+		ui.toolbar.get_button("PaintColor").set_pressed(true)
+	elif shortcuts["Paint Navigable Area"].matches_event(p_event):
+		ui.toolbar.get_button("PaintNavigableArea").set_pressed(true)
+	elif shortcuts["Instance Meshes"].matches_event(p_event):
+		ui.toolbar.get_button("InstanceMeshes").set_pressed(true)
+	elif shortcuts["Add Holes"].matches_event(p_event):
+		ui.toolbar.get_button("AddHoles").set_pressed(true)
+	elif shortcuts["Paint Wetness"].matches_event(p_event):
+		ui.toolbar.get_button("PaintWetness").set_pressed(true)
+	elif shortcuts["Paint Texture"].matches_event(p_event):
+		ui.toolbar.get_button("PaintTexture").set_pressed(true)
+	elif shortcuts["Spray Texture"].matches_event(p_event):
+		ui.toolbar.get_button("SprayTexture").set_pressed(true)
+	elif shortcuts["Paint Autoshader"].matches_event(p_event):
+		ui.toolbar.get_button("PaintAutoshader").set_pressed(true)
+	elif shortcuts["Inverse Slope Range"].matches_event(p_event):
+		ui.tool_settings.inverse_slope_range()
+	else:
+		return false
 	return true
 
 
@@ -458,7 +521,8 @@ func setup_editor_settings() -> void:
 		"hint_string": "Alt,Space,Meta,Capslock"
 	}
 	editor_settings.add_property_info(property_info)
-	
+	editor_settings.connect(&"settings_changed", apply_editor_settings)
+
 
 func set_setting(p_str: String, p_value: Variant) -> void:
 	editor_settings.set_setting(p_str, p_value)
@@ -477,6 +541,22 @@ func has_setting(p_str: String) -> bool:
 
 func erase_setting(p_str: String) -> void:
 	editor_settings.erase(p_str)
+	
+
+func apply_editor_settings() -> void:
+	# Keybind enum: Alt,Space,Meta,Capslock
+	var alt_key: int
+	match get_setting("terrain3d/config/alt_key_bind", 0):
+		3: alt_key = KEY_CAPSLOCK
+		2: alt_key = KEY_META
+		1: alt_key = KEY_SPACE
+		0, _: alt_key = KEY_ALT
+	var shortcut := Shortcut.new()
+	var binding:Variant = alt_key
+	var shortcut_event := InputEventKey.new()
+	shortcut_event.physical_keycode = binding
+	shortcut.events.append(shortcut_event)
+	shortcuts["Alternate Mode"] = shortcut
 
 
 ## Undo / Redo Functions

--- a/project/addons/terrain_3d/src/toolbar.gd
+++ b/project/addons/terrain_3d/src/toolbar.gd
@@ -22,73 +22,132 @@ const ICON_INSTANCER: String = "res://addons/terrain_3d/icons/multimesh.svg"
 
 var add_tool_group: ButtonGroup = ButtonGroup.new()
 var sub_tool_group: ButtonGroup = ButtonGroup.new()
-var buttons: Dictionary
+var buttons: Dictionary[String, Button]
 var plugin: EditorPlugin
+var editor_settings: EditorSettings
+# < 4.6 compatiblility
+var version: int
+var default_keybinds: Dictionary[String, String] = {
+	"Invert Tool": "Ctrl",
+	"Sculpt Smooth": "Shift",
+	"Alternate Mode": "Alt",
+	"Decrease Tool Size": "[",
+	"Increase Tool Size": "]",
+	"Decrease Tool Strength": "-",
+	"Increase Tool Strength": "=",
+	"Toggle Region Grid": "1",
+	"Toggle Region Labels": "2",
+	"Toggle Contour Lines": "3",
+	"Toggle Instancer Grid": "4",
+	"Toggle Vertex Grid": "5",
+	"Add or Remove Region": "E",
+	"Sculpt Raise or Lower": "R",
+	"Sculpt Height": "H",
+	"Sculpt Slope": "S",
+	"Paint Color": "C",
+	"Remove Color": "C",
+	"Paint Navigable Area": "N",
+	"Remove Navigable Area": "N",
+	"Instance Meshes": "I",
+	"Remove Meshes": "I",
+	"Add Holes": "X",
+	"Paint Wetness": "W",
+	"Remove Wetness": "W",
+	"Paint Texture": "B",
+	"Spray Texture": "V",
+	"Paint Autoshader": "A",
+	"Inverse Slope Range": "T",
+}
 
 
 func _init() -> void:
 	set_custom_minimum_size(Vector2(20, 0))
+	version = Engine.get_version_info().hex
 
 
 func _ready() -> void:
 	add_tool_group.pressed.connect(_on_tool_selected)
 	sub_tool_group.pressed.connect(_on_tool_selected)
-
-	add_tool_button({ "tool":Terrain3DEditor.REGION, 
-		"add_text":"Add Region (E)", "add_op":Terrain3DEditor.ADD, "add_icon":ICON_REGION_ADD,
-		"sub_text":"Remove Region", "sub_op":Terrain3DEditor.SUBTRACT, "sub_icon":ICON_REGION_REMOVE })
+	
+	editor_settings = EditorInterface.get_editor_settings()
+	
+	add_tool_button({ "tool":Terrain3DEditor.REGION,
+		"add_text":"Add Region (%s)" % get_shortcut_key("Add or Remove Region"), 
+		"add_op":Terrain3DEditor.ADD, "add_icon":ICON_REGION_ADD,
+		"sub_text":"Remove Region (%s)" % get_shortcut_key("Add or Remove Region"),
+		"sub_op":Terrain3DEditor.SUBTRACT, "sub_icon":ICON_REGION_REMOVE })
 	
 	add_child(HSeparator.new())
 	
-	add_tool_button({ "tool":Terrain3DEditor.SCULPT, 
-		"add_text":"Raise (R)", "add_op":Terrain3DEditor.ADD, "add_icon":ICON_HEIGHT_ADD,
-		"sub_text":"Lower (R)", "sub_op":Terrain3DEditor.SUBTRACT, "sub_icon":ICON_HEIGHT_SUB })
+	add_tool_button({ "tool":Terrain3DEditor.SCULPT,
+		"add_text":"Raise (%s)" % get_shortcut_key("Sculpt Raise or Lower"),
+		"add_op":Terrain3DEditor.ADD, "add_icon":ICON_HEIGHT_ADD,
+		"sub_text":"Lower (%s)" % get_shortcut_key("Sculpt Raise or Lower"),
+		"sub_op":Terrain3DEditor.SUBTRACT, "sub_icon":ICON_HEIGHT_SUB })
 
-	add_tool_button({ "tool":Terrain3DEditor.SCULPT, 
-		"add_text":"Smooth (Shift)", "add_op":Terrain3DEditor.AVERAGE, "add_icon":ICON_HEIGHT_SMOOTH })
+	add_tool_button({ "tool":Terrain3DEditor.SCULPT,
+		"add_text":"Smooth (%s)" % get_shortcut_key("Sculpt Smooth"),
+		"add_op":Terrain3DEditor.AVERAGE, "add_icon":ICON_HEIGHT_SMOOTH })
 
-	add_tool_button({ "tool":Terrain3DEditor.HEIGHT, 
-		"add_text":"Height (H)", "add_op":Terrain3DEditor.ADD, "add_icon":ICON_HEIGHT_FLAT,
-		"sub_text":"Height (H)", "sub_op":Terrain3DEditor.SUBTRACT, "sub_icon":ICON_HEIGHT_FLAT })
+	add_tool_button({ "tool":Terrain3DEditor.HEIGHT,
+		"add_text":"Height (%s)" % get_shortcut_key("Sculpt Height"),
+		"add_op":Terrain3DEditor.ADD, "add_icon":ICON_HEIGHT_FLAT,
+		"sub_text":"Height (%s)" % get_shortcut_key("Sculpt Height"),
+		"sub_op":Terrain3DEditor.SUBTRACT, "sub_icon":ICON_HEIGHT_FLAT })
 
-	add_tool_button({ "tool":Terrain3DEditor.SCULPT, 
-		"add_text":"Slope (S)", "add_op":Terrain3DEditor.GRADIENT, "add_icon":ICON_HEIGHT_SLOPE })
+	add_tool_button({ "tool":Terrain3DEditor.SCULPT,
+		"add_text":"Slope (%s)" % get_shortcut_key("Sculpt Slope"),
+		"add_op":Terrain3DEditor.GRADIENT, "add_icon":ICON_HEIGHT_SLOPE })
 
 	add_child(HSeparator.new())
 
-	add_tool_button({ "tool":Terrain3DEditor.TEXTURE, 
-		"add_text":"Paint Texture (B)", "add_op":Terrain3DEditor.REPLACE, "add_icon":ICON_PAINT_TEXTURE })
+	add_tool_button({ "tool":Terrain3DEditor.TEXTURE,
+		"add_text":"Paint Texture (%s)" % get_shortcut_key("Paint Texture"),
+		"add_op":Terrain3DEditor.REPLACE, "add_icon":ICON_PAINT_TEXTURE })
 
-	add_tool_button({ "tool":Terrain3DEditor.TEXTURE, 
-		"add_text":"Spray Texture (V)", "add_op":Terrain3DEditor.ADD, "add_icon":ICON_SPRAY_TEXTURE })
+	add_tool_button({ "tool":Terrain3DEditor.TEXTURE,
+		"add_text":"Spray Texture (%s)" % get_shortcut_key("Spray Texture"),
+		"add_op":Terrain3DEditor.ADD, "add_icon":ICON_SPRAY_TEXTURE })
 
 	add_tool_button({ "tool":Terrain3DEditor.AUTOSHADER,
-		"add_text":"Paint Autoshader (A)", "add_op":Terrain3DEditor.ADD, "add_icon":ICON_AUTOSHADER,
-		"sub_text":"Disable Autoshader (A)", "sub_op":Terrain3DEditor.SUBTRACT })
+		"add_text":"Paint Autoshader (%s)" % get_shortcut_key("Paint Autoshader"),
+		"add_op":Terrain3DEditor.ADD, "add_icon":ICON_AUTOSHADER,
+		"sub_text":"Disable Autoshader (%s)" % get_shortcut_key("Paint Autoshader"),
+		"sub_op":Terrain3DEditor.SUBTRACT })
 
 	add_child(HSeparator.new())
 
 	add_tool_button({ "tool":Terrain3DEditor.COLOR,
-		"add_text":"Paint Color (C)", "add_op":Terrain3DEditor.ADD, "add_icon":ICON_COLOR,
-		"sub_text":"Remove Color (C)", "sub_op":Terrain3DEditor.SUBTRACT })
+		"add_text":"Paint Color (%s)"  % get_shortcut_key("Paint Color"), 
+		"add_op":Terrain3DEditor.ADD, "add_icon":ICON_COLOR,
+		"sub_text":"Remove Color (%s)" % get_shortcut_key("Remove Color"),
+		"sub_op":Terrain3DEditor.SUBTRACT })
 	
 	add_tool_button({ "tool":Terrain3DEditor.ROUGHNESS,
-		"add_text":"Paint Wetness (W)", "add_op":Terrain3DEditor.ADD, "add_icon":ICON_WETNESS,
-		"sub_text":"Remove Wetness (W)", "sub_op":Terrain3DEditor.SUBTRACT })
+		"add_text":"Paint Wetness (%s)" % get_shortcut_key("Paint Wetness"),
+		"add_op":Terrain3DEditor.ADD, "add_icon":ICON_WETNESS,
+		"sub_text":"Remove Wetness (%s)" % get_shortcut_key("Remove Wetness"),
+		"sub_op":Terrain3DEditor.SUBTRACT })
 
 	add_child(HSeparator.new())
 
 	add_tool_button({ "tool":Terrain3DEditor.HOLES,
-		"add_text":"Add Holes (X)", "add_op":Terrain3DEditor.ADD, "add_icon":ICON_HOLES,
-		"sub_text":"Remove Holes (X)", "sub_op":Terrain3DEditor.SUBTRACT })
+		"add_text":"Add Holes (%s)" % get_shortcut_key("Add Holes"),
+		"add_op":Terrain3DEditor.ADD, "add_icon":ICON_HOLES,
+		"sub_text":"Remove Holes (%s)" % get_shortcut_key("Add Holes"),
+		"sub_op":Terrain3DEditor.SUBTRACT })
 
 	add_tool_button({ "tool":Terrain3DEditor.NAVIGATION,
-		"add_text":"Paint Navigable Area (N)", "add_op":Terrain3DEditor.ADD, "add_icon":ICON_NAVIGATION,
-		"sub_text":"Remove Navigable Area (N)", "sub_op":Terrain3DEditor.SUBTRACT })
+		"add_text":"Paint Navigable Area (%s)" % get_shortcut_key("Paint Navigable Area"),
+		"add_op":Terrain3DEditor.ADD, "add_icon":ICON_NAVIGATION,
+		"sub_text":"Remove Navigable Area (%s)" % get_shortcut_key("Remove Navigable Area"),
+		"sub_op":Terrain3DEditor.SUBTRACT })
 
 	add_tool_button({ "tool":Terrain3DEditor.INSTANCER,
-		"add_text":"Instance Meshes (I)", "add_op":Terrain3DEditor.ADD, "add_icon":ICON_INSTANCER,
-		"sub_text":"Remove Meshes (I)", "sub_op":Terrain3DEditor.SUBTRACT })
+		"add_text":"Instance Meshes (%s)" % get_shortcut_key("Instance Meshes"), 
+		"add_op":Terrain3DEditor.ADD, "add_icon":ICON_INSTANCER,
+		"sub_text":"Remove Meshes (%s)" % get_shortcut_key("Remove Meshes"), 
+		"sub_op":Terrain3DEditor.SUBTRACT })
 
 	# Select first button
 	var buttons: Array[BaseButton] = add_tool_group.get_buttons()
@@ -131,7 +190,7 @@ func add_tool_button(p_params: Dictionary) -> void:
 		button2 = button.duplicate()
 	button2.set_button_group(p_params.get("group", sub_tool_group))
 	add_child(button2, true)
-	buttons[button2.get_name()] = button
+	buttons[button2.get_name()] = button2
 
 
 func get_button(p_name: String) -> Button:
@@ -143,6 +202,43 @@ func show_add_buttons(p_enable: bool) -> void:
 		button.visible = p_enable
 	for button in sub_tool_group.get_buttons():
 		button.visible = !p_enable
+
+
+func update_tooltips() -> void:
+	buttons["AddRegion"].tooltip_text = "Add Region (%s)" % get_shortcut_key("Add or Remove Region")
+	buttons["RemoveRegion"].tooltip_text = "Remove Region (%s)" % get_shortcut_key("Add or Remove Region")
+	buttons["Raise"].tooltip_text = "Raise (%s)" % get_shortcut_key("Sculpt Raise or Lower")
+	buttons["Lower"].tooltip_text = "Lower (%s)" % get_shortcut_key("Sculpt Raise or Lower")
+	buttons["Height"].tooltip_text = "Height (%s)" % get_shortcut_key("Sculpt Height")
+	buttons["Slope"].tooltip_text = "Slope (%s)" % get_shortcut_key("Sculpt Slope")
+	buttons["PaintTexture"].tooltip_text = "Paint Texture (%s)" % get_shortcut_key("Paint Texture")
+	buttons["SprayTexture"].tooltip_text = "Spray Texture (%s)" % get_shortcut_key("Spray Texture")
+	buttons["PaintAutoshader"].tooltip_text = "Paint Autoshader (%s)" % get_shortcut_key("Paint Autoshader")
+	buttons["DisableAutoshader"].tooltip_text = "Disable Autoshader (%s)" % get_shortcut_key("Paint Autoshader")
+	buttons["PaintColor"].tooltip_text = "Paint Color (%s)"  % get_shortcut_key("Paint Color")
+	buttons["RemoveColor"].tooltip_text = "Remove Color (%s)"  % get_shortcut_key("Paint Color")
+	buttons["PaintWetness"].tooltip_text = "Paint Wetness (%s)" % get_shortcut_key("Paint Wetness")
+	buttons["RemoveWetness"].tooltip_text = "Remove Wetness (%s)" % get_shortcut_key("Paint Wetness")
+	buttons["AddHoles"].tooltip_text = "Add Holes (%s)" % get_shortcut_key("Add Holes")
+	buttons["RemoveHoles"].tooltip_text = "Remove Holes (%s)" % get_shortcut_key("Add Holes")
+	buttons["PaintNavigableArea"].tooltip_text = "Paint Navigable Area (%s)" % get_shortcut_key("Paint Navigable Area")
+	buttons["RemoveNavigableArea"].tooltip_text = "Remove Navigable Area (%s)" % get_shortcut_key("Paint Navigable Area")
+	buttons["InstanceMeshes"].tooltip_text = "Instance Meshes (%s)" % get_shortcut_key("Instance Meshes")
+	buttons["RemoveMeshes"].tooltip_text = "Remove Meshes (%s)" % get_shortcut_key("Instance Meshes")
+
+
+func get_shortcut_key(shortcut_name: String) -> String:
+	if version >= 0x040600:
+		var shortcut:Shortcut = editor_settings.get_shortcut("terrain_3d/" + shortcut_name)
+		if shortcut:
+			var event:InputEvent = shortcut.events[0]
+			var key:String = event.as_text()
+			key = key.rstrip(" - Physical")
+			return key
+		else:
+			return ""
+	else: # < 4.6 compatiblility
+		return default_keybinds[shortcut_name]
 
 
 func _on_tool_selected(p_button: BaseButton) -> void:


### PR DESCRIPTION
This PR exposes Terrain3D's hotkeys to the Shortcuts tab in the Editor Settings. The keybinds in the toolbar button tooltips update to new values after Terrain3D node is reselected (there is no signal on shortcut change in the editor settings yet). Additionally, although custom keybinds persist between sessions, their entries are not generated automatically, and they had to be re-created on plugin initialization, resulting in there being no 'reset to default' button in those entries.

<img width="1279" height="771" alt="Screenshot_20260526_002216" src="https://github.com/user-attachments/assets/9a272ac6-1887-4158-94fb-695261430bbf" />