### PR TITLE
Add Windows on Arm build config, extension libraries

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -19,7 +19,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        identifier: [linux, windows, macos, ios, android-arm32, android-arm64, web-nothreads]
+        identifier: [linux, windows, windows-arm64, macos, ios, android-arm32, android-arm64, web-nothreads]
         target: [debug, release]
         include:
           - identifier: linux
@@ -33,6 +33,12 @@ jobs:
             name: 🪟 Windows
             runner: ubuntu-22.04
             flags: arch=x86_64
+
+          - identifier: windows-arm64
+            platform: windows
+            name: 🪟 Windows Arm64
+            runner: ubuntu-22.04
+            flags: arch=arm64 use_mingw=yes use_llvm=yes
 
           - identifier: macos
             platform: macos
@@ -87,6 +93,17 @@ jobs:
           cache-name: ${{ matrix.identifier }}-${{ matrix.target }}
         continue-on-error: true
 
+      - name: Setup LLVM-MinGW (Windows Arm64)
+        if: ${{ matrix.identifier == 'windows-arm64' }}
+        shell: sh
+        run: |
+          export LLVM_MINGW_VERSION=20251118
+          export LLVM_MINGW_NAME=llvm-mingw-${LLVM_MINGW_VERSION}-ucrt-ubuntu-22.04-x86_64
+          curl -LO https://github.com/mstorsjo/llvm-mingw/releases/download/${LLVM_MINGW_VERSION}/${LLVM_MINGW_NAME}.tar.xz
+          tar xf ${LLVM_MINGW_NAME}.tar.xz
+          rm -f ${LLVM_MINGW_NAME}.tar.xz
+          echo "$(pwd)/${LLVM_MINGW_NAME}/bin" >> $GITHUB_PATH
+
       - name: Build Terrain3D
         env:
             SCONS_CACHE: "${{ github.workspace }}/.scons-cache/"
@@ -95,12 +112,16 @@ jobs:
         run: |
             scons target=$TARGET platform='${{ matrix.platform }}' ${{ matrix.flags }} debug_symbols=no -j2
 
-      - name: Strip Libraries (Windows/Linux)
+      - name: Strip Libraries (Windows / Linux)
         if: ${{ matrix.platform == 'windows' || matrix.platform == 'linux' }}
         shell: sh
         run: |
+          STRIP="strip"
+          if [ "${{ matrix.identifier }}" = "windows-arm64" ]; then
+            STRIP="llvm-strip"
+          fi
           ls -l project/addons/terrain_3d/bin/
-          strip project/addons/terrain_3d/bin/libterrain.*
+          $STRIP project/addons/terrain_3d/bin/libterrain.*
           ls -l project/addons/terrain_3d/bin/
 
       - name: Prepare Files

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -10,7 +10,7 @@ jobs:
       matrix:
         platform: [windows]
         target: [debug, release]
-        arch: [x86_64]
+        arch: [x86_64, arm64]
 
     steps:
       - name: Checkout Terrain3D
@@ -26,8 +26,19 @@ jobs:
       - name: Setup Build Cache
         uses: ./.github/actions/build-cache
         with:
-          cache-name: ${{ matrix.platform }}-${{ matrix.target }}
+          cache-name: ${{ matrix.platform }}-${{ matrix.arch }}-${{ matrix.target }}
         continue-on-error: true
+
+      - name: Setup LLVM-MinGW (Arm64)
+        if: ${{ matrix.arch == 'arm64' }}
+        shell: sh
+        run: |
+          export LLVM_MINGW_VERSION=20251118
+          export LLVM_MINGW_NAME=llvm-mingw-${LLVM_MINGW_VERSION}-ucrt-ubuntu-22.04-x86_64
+          curl -LO https://github.com/mstorsjo/llvm-mingw/releases/download/${LLVM_MINGW_VERSION}/${LLVM_MINGW_NAME}.tar.xz
+          tar xf ${LLVM_MINGW_NAME}.tar.xz
+          rm -f ${LLVM_MINGW_NAME}.tar.xz
+          echo "$(pwd)/${LLVM_MINGW_NAME}/bin" >> $GITHUB_PATH
 
       - name: Build Terrain3D
         env:
@@ -36,13 +47,21 @@ jobs:
             ARCH: '${{ matrix.arch }}'
         shell: sh
         run: |
-            scons target=$TARGET platform='${{ matrix.platform }}' arch=$ARCH debug_symbols=no -j2
+            EXTRA_FLAGS=""
+            if [ "$ARCH" = "arm64" ]; then
+              EXTRA_FLAGS="use_mingw=yes use_llvm=yes"
+            fi
+            scons target=$TARGET platform='${{ matrix.platform }}' arch=$ARCH $EXTRA_FLAGS debug_symbols=no -j2
 
       - name: Prepare Files
         shell: sh
         run: |
+          STRIP="strip"
+          if [ "${{ matrix.arch }}" = "arm64" ]; then
+            STRIP="llvm-strip"
+          fi
           ls -l project/addons/terrain_3d/bin/
-          strip project/addons/terrain_3d/bin/libterrain.*
+          $STRIP project/addons/terrain_3d/bin/libterrain.*
           ls -l project/addons/terrain_3d/bin/
           rm -v project/*.*
           cp -v '${{ github.workspace }}/README.md' '${{ github.workspace }}/LICENSE.txt' ${{ github.workspace }}/project/addons/terrain_3d/

--- a/project/addons/terrain_3d/terrain.gdextension
+++ b/project/addons/terrain_3d/terrain.gdextension
@@ -11,6 +11,8 @@ Terrain3D = "res://addons/terrain_3d/icons/terrain3d.svg"
 
 windows.debug.x86_64 = "res://addons/terrain_3d/bin/libterrain.windows.debug.x86_64.dll"
 windows.release.x86_64 = "res://addons/terrain_3d/bin/libterrain.windows.release.x86_64.dll"
+windows.debug.arm64 = "res://addons/terrain_3d/bin/libterrain.windows.debug.arm64.dll"
+windows.release.arm64 = "res://addons/terrain_3d/bin/libterrain.windows.release.arm64.dll"
 
 linux.debug.x86_64 = "res://addons/terrain_3d/bin/libterrain.linux.debug.x86_64.so"
 linux.release.x86_64 = "res://addons/terrain_3d/bin/libterrain.linux.release.x86_64.so"


### PR DESCRIPTION
This PR adds Windows on Arm support in Terrain3D. The existing workflows use MinGW, but WoA support for that is still [in progress](https://linaro.atlassian.net/wiki/spaces/WOAR/pages/28802842658/MinGW+GNU+Toolchain). Therefore we use the same solution as Godot Engine itself, and use LLVM-MinGW to perform the build.

Godot Engine WoA workflow files for reference:
[build-containers](https://github.com/godotengine/build-containers/blob/main/Dockerfile.windows#L8)
[godot-build-scripts](https://github.com/godotengine/godot-build-scripts/blob/main/build-windows/build.sh#L46)

- [x] Tested workflow runs successfully
- [x] Tested in Godot 4.5.2
- [x] Tested Release in Godot 4.7
- [x] Tested Debug in Godot 4.7