### PR TITLE
Let Terrain3DMaterial limit the number of regions rendered

### DIFF
--- a/Terrain3D.vcxproj
+++ b/Terrain3D.vcxproj
@@ -229,6 +229,7 @@
     <None Include="src\shaders\displacement_buffer.glsl" />
     <None Include="src\shaders\macro_variation.glsl" />
     <None Include="src\shaders\main.glsl" />
+    <None Include="src\shaders\max_regions.glsl" />
     <None Include="src\shaders\overlays.glsl" />
     <None Include="src\shaders\pbr_views.glsl">
       <FileType>Document</FileType>

--- a/Terrain3D.vcxproj.filters
+++ b/Terrain3D.vcxproj.filters
@@ -298,6 +298,9 @@
     <None Include="doc\docs\contributing.md">
       <Filter>2. Docs</Filter>
     </None>
+    <None Include="src\shaders\max_regions.glsl">
+      <Filter>4. Shaders</Filter>
+    </None>
   </ItemGroup>
   <ItemGroup>
     <Text Include=".readthedocs.yaml">

--- a/doc/api/class_terrain3dmaterial.rst
+++ b/doc/api/class_terrain3dmaterial.rst
@@ -52,6 +52,8 @@ Properties
    +------------------------------------------------------------------+--------------------------------------------------------------------------------------------------------+-----------+
    | ``bool``                                                         | :ref:`macro_variation_enabled<class_Terrain3DMaterial_property_macro_variation_enabled>`               | ``false`` |
    +------------------------------------------------------------------+--------------------------------------------------------------------------------------------------------+-----------+
+   | :ref:`RegionMaximum<enum_Terrain3DMaterial_RegionMaximum>`       | :ref:`max_regions<class_Terrain3DMaterial_property_max_regions>`                                       | ``1024``  |
+   +------------------------------------------------------------------+--------------------------------------------------------------------------------------------------------+-----------+
    | ``bool``                                                         | :ref:`output_albedo<class_Terrain3DMaterial_property_output_albedo>`                                   | ``true``  |
    +------------------------------------------------------------------+--------------------------------------------------------------------------------------------------------+-----------+
    | ``bool``                                                         | :ref:`output_ambient_occlusion<class_Terrain3DMaterial_property_output_ambient_occlusion>`             | ``true``  |
@@ -181,6 +183,56 @@ Outside of the defined regions, show a flat terrain.
 :ref:`WorldBackground<enum_Terrain3DMaterial_WorldBackground>` **NOISE** = ``2``
 
 Outside of the defined regions, generate visual-only hills.
+
+.. rst-class:: classref-item-separator
+
+----
+
+.. _enum_Terrain3DMaterial_RegionMaximum:
+
+.. rst-class:: classref-enumeration
+
+enum **RegionMaximum**: :ref:`🔗<enum_Terrain3DMaterial_RegionMaximum>`
+
+.. _class_Terrain3DMaterial_constant_MAX_REGIONS_64:
+
+.. rst-class:: classref-enumeration-constant
+
+:ref:`RegionMaximum<enum_Terrain3DMaterial_RegionMaximum>` **MAX_REGIONS_64** = ``64``
+
+Renders the first 64 textures that are loaded.
+
+.. _class_Terrain3DMaterial_constant_MAX_REGIONS_128:
+
+.. rst-class:: classref-enumeration-constant
+
+:ref:`RegionMaximum<enum_Terrain3DMaterial_RegionMaximum>` **MAX_REGIONS_128** = ``128``
+
+Renders the first 128 textures that are loaded.
+
+.. _class_Terrain3DMaterial_constant_MAX_REGIONS_256:
+
+.. rst-class:: classref-enumeration-constant
+
+:ref:`RegionMaximum<enum_Terrain3DMaterial_RegionMaximum>` **MAX_REGIONS_256** = ``256``
+
+Renders the first 256 textures that are loaded.
+
+.. _class_Terrain3DMaterial_constant_MAX_REGIONS_512:
+
+.. rst-class:: classref-enumeration-constant
+
+:ref:`RegionMaximum<enum_Terrain3DMaterial_RegionMaximum>` **MAX_REGIONS_512** = ``512``
+
+Renders the first 512 textures that are loaded.
+
+.. _class_Terrain3DMaterial_constant_MAX_REGIONS_1024:
+
+.. rst-class:: classref-enumeration-constant
+
+:ref:`RegionMaximum<enum_Terrain3DMaterial_RegionMaximum>` **MAX_REGIONS_1024** = ``1024``
+
+Renders the first 1024 textures that are loaded.
 
 .. rst-class:: classref-item-separator
 
@@ -409,6 +461,23 @@ Enables selecting one texture ID that will have multiple scales applied based up
 - ``bool`` **get_macro_variation_enabled**\ (\ )
 
 Allows you to add a couple of noise patterns at different scales and colors to add variation to your terrain to avoid tiled textures.
+
+.. rst-class:: classref-item-separator
+
+----
+
+.. _class_Terrain3DMaterial_property_max_regions:
+
+.. rst-class:: classref-property
+
+:ref:`RegionMaximum<enum_Terrain3DMaterial_RegionMaximum>` **max_regions** = ``1024`` :ref:`🔗<class_Terrain3DMaterial_property_max_regions>`
+
+.. rst-class:: classref-property-setget
+
+- |void| **set_max_regions**\ (\ value\: :ref:`RegionMaximum<enum_Terrain3DMaterial_RegionMaximum>`\ )
+- :ref:`RegionMaximum<enum_Terrain3DMaterial_RegionMaximum>` **get_max_regions**\ (\ )
+
+Limits the number of regions that are rendered. Does not reduce VRAM. Regions loaded beyond this number are still present in memory and on disk, they just don't render. This is used to reduce uniform buffer consumption on mobiles. Set to the minimum you need for mobiles (e.g. 64-256) and test a variety of devices to ensure your target audience can render textures. It renders the first X number of regions that are loaded. Region order is not stable.
 
 .. rst-class:: classref-item-separator
 

--- a/doc/doc_classes/Terrain3DMaterial.xml
+++ b/doc/doc_classes/Terrain3DMaterial.xml
@@ -92,6 +92,9 @@
 		<member name="macro_variation_enabled" type="bool" setter="set_macro_variation_enabled" getter="get_macro_variation_enabled" default="false">
 			Allows you to add a couple of noise patterns at different scales and colors to add variation to your terrain to avoid tiled textures.
 		</member>
+		<member name="max_regions" type="int" setter="set_max_regions" getter="get_max_regions" enum="Terrain3DMaterial.RegionMaximum" default="1024">
+			This limits the material to rendering the first X number of regions that are loaded. Region order is not stable. It does not reduce VRAM. Regions loaded beyond this number are still present in memory, VRAM, and on disk, they just don't render. This is used to reduce uniform buffer consumption on mobile apps and web for mobile. Set to the minimum number of regions you need, keep your region count low (64-256), and test a variety of devices to ensure your target audience can render textures on the terrain.
+		</member>
 		<member name="output_albedo" type="bool" setter="set_output_albedo_enabled" getter="get_output_albedo_enabled" default="true">
 			Enables the Albedo, aka Base Color or Diffuse, output channel in the shader.
 		</member>
@@ -200,6 +203,21 @@
 		</constant>
 		<constant name="NOISE" value="2" enum="WorldBackground">
 			Outside of the defined regions, generate visual-only hills.
+		</constant>
+		<constant name="MAX_REGIONS_64" value="64" enum="RegionMaximum">
+			Renders only the first 64 regions that are loaded.
+		</constant>
+		<constant name="MAX_REGIONS_128" value="128" enum="RegionMaximum">
+			Renders only the first 128 regions that are loaded.
+		</constant>
+		<constant name="MAX_REGIONS_256" value="256" enum="RegionMaximum">
+			Renders only the first 256 regions that are loaded.
+		</constant>
+		<constant name="MAX_REGIONS_512" value="512" enum="RegionMaximum">
+			Renders only the first 512 regions that are loaded.
+		</constant>
+		<constant name="MAX_REGIONS_1024" value="1024" enum="RegionMaximum">
+			Renders only the first 1024 regions that are loaded.
 		</constant>
 		<constant name="LINEAR_ANISOTROPIC" value="0" enum="TextureFiltering">
 			Textures are filtered using a blend of 4 adjacent pixels, with anisotropic filtering which improves the sharpness of distant terrain off axis from the camera. Use this for most cases for high quality renders.

--- a/doc/docs/platforms.md
+++ b/doc/docs/platforms.md
@@ -54,6 +54,7 @@ If bypassing Apple security is not working, or if approaching a release date, ma
 
 As of Terrain3D 0.9.1 and Godot 4.2, iOS is reported to work with the following setup:
 
+* In Terrain3DMaterial, set max_regions to 64-256 and keep region count under that.
 * Use textures that Godot imports (converts) such as PNG or TGA, not DDS.
 * Enable `Project Settings/Rendering/Textures/VRAM Compression/Import ETC2 ASTC`.
 * Set `Project Settings/Application/Config/Icon` to a valid file (eg `res://icon.png` or svg).
@@ -82,6 +83,7 @@ Further reading:
 
 As of Terrain3D 0.9.1 and Godot 4.2, Android is reported to work. It is still a bit experimental.
 
+* In Terrain3DMaterial, set max_regions to 64-256 (128 has the broadest reported coverage) and keep region count under that.
 * Use textures that Godot imports (converts) such as PNG or TGA, not DDS.
 * Enable `Project Settings/Rendering/Textures/VRAM Compression/Import ETC2 ASTC`.
 
@@ -138,7 +140,6 @@ Support for Apple's Metal for iOS and macOS was merged into Godot 4.4-dev1. We d
 
 The Forward Vulkan Mobile renderer is fully supported.
 
-
 ## Compatibility
 
-The OpenGLES 3.0 Compatibility renderer is fully supported since Terrain3D 1.0 and Godot 4.4. A small set of shader pre-processor statements are used to override fma() and dFdxCoarse(). This allows the shader to work with the compatibility renderer without intrusive changes.
+The OpenGLES 3.0 Compatibility renderer is fully supported since Terrain3D 1.0 and Godot 4.4.

--- a/project/addons/terrain_3d/extras/shaders/lightweight.gdshader
+++ b/project/addons/terrain_3d/extras/shaders/lightweight.gdshader
@@ -16,6 +16,7 @@ render_mode blend_mix,depth_draw_opaque,cull_back,diffuse_burley,specular_schlic
  */
 
 // Defined Constants
+#define MAX_REGIONS 1024 // Match Terrain3DMaterial.max_regions. Set to 64-256 for mobile
 #define COLOR_MAP vec4(1.0, 1.0, 1.0, 0.5)
 #define DIV_255 0.003921568627450 // 1. / 255.
 
@@ -45,7 +46,7 @@ uniform float _region_size = 1024.0;
 uniform float _region_texel_size = 0.0009765625; // = 1./region_size
 uniform int _region_map_size = 32;
 uniform int _region_map[1024];
-uniform vec2 _region_locations[1024];
+uniform vec2 _region_locations[MAX_REGIONS];
 uniform float _texture_normal_depth_array[32];
 uniform float _texture_ao_strength_array[32];
 uniform float _texture_ao_affect_array[32];
@@ -106,8 +107,10 @@ ivec3 get_index_coord(const vec2 uv) {
 	vec2 r_uv = round(uv);
 	ivec2 pos = ivec2(floor(r_uv * _region_texel_size)) + (_region_map_size / 2);
 	int bounds = int(uint(pos.x | pos.y) < uint(_region_map_size));
-	int layer_index = _region_map[pos.y * _region_map_size + pos.x] * bounds - 1;
-	return ivec3(ivec2(mod(r_uv, _region_size)), layer_index);
+    int raw_index = _region_map[pos.y * _region_map_size + pos.x] - 1;
+    int is_region = bounds * int(raw_index >= 0) * int(raw_index < MAX_REGIONS);
+    int layer_index = (raw_index * is_region) - (1 - is_region);
+    return ivec3(ivec2(mod(r_uv, _region_size)), layer_index);
 }
 
 // Takes in descaled (world_space / region_size) world to region space XZ (UV2) coordinates, returns vec3 with:
@@ -116,7 +119,9 @@ ivec3 get_index_coord(const vec2 uv) {
 vec3 get_index_uv(const vec2 uv2) {
 	ivec2 pos = ivec2(floor(uv2)) + (_region_map_size / 2);
 	int bounds = int(uint(pos.x | pos.y) < uint(_region_map_size));
-	int layer_index = _region_map[ pos.y * _region_map_size + pos.x ] * bounds - 1;
+    int raw_index = _region_map[pos.y * _region_map_size + pos.x] - 1;
+    int is_region = bounds * int(raw_index >= 0) * int(raw_index < MAX_REGIONS);
+    int layer_index = (raw_index * is_region) - (1 - is_region);
 	return vec3(uv2 - _region_locations[layer_index], float(layer_index));
 }
 
@@ -133,11 +138,10 @@ bool is_none_bg(const vec2 uv) {
 // Takes in UV2 region space coordinates, returns 1.0 or 0.0 if a region is present or not.
 float check_region(const vec2 uv2) {
 	ivec2 pos = ivec2(floor(uv2)) + (_region_map_size / 2);
-	int layer_index = 0;
-	if (uint(pos.x | pos.y) < uint(_region_map_size)) {
-		layer_index = clamp(_region_map[ pos.y * _region_map_size + pos.x ] - 1, -1, 0) + 1;
-	}
-	return float(layer_index);
+    int bounds = int(uint(pos.x | pos.y) < uint(_region_map_size));
+    int raw_index = _region_map[pos.y * _region_map_size + pos.x] - 1;
+    int is_valid = bounds * int(raw_index >= 0) * int(raw_index < MAX_REGIONS);
+	return float(is_valid);
 }
 
 // Takes in UV2 region space coordinates, returns a blend value (0 - 1 range) between empty, and valid regions

--- a/project/addons/terrain_3d/extras/shaders/minimum.gdshader
+++ b/project/addons/terrain_3d/extras/shaders/minimum.gdshader
@@ -4,6 +4,10 @@
 shader_type spatial;
 render_mode blend_mix,depth_draw_opaque,cull_back,diffuse_burley,specular_schlick_ggx,skip_vertex_transform;
 
+// Defined Constants
+#define MAX_REGIONS 1024 // Match Terrain3DMaterial.max_regions. Set to 64-256 for mobile
+
+// Inline Functions
 #if CURRENT_RENDERER == RENDERER_COMPATIBILITY
     #define fma(a, b, c) ((a) * (b) + (c))
     #define dFdxCoarse(a) dFdx(a)
@@ -24,7 +28,7 @@ uniform float _region_size = 1024.0;
 uniform float _region_texel_size = 0.0009765625; // = 1./region_size
 uniform int _region_map_size = 32;
 uniform int _region_map[1024];
-//uniform vec2 _region_locations[1024];
+//uniform vec2 _region_locations[MAX_REGIONS];
 //uniform float _texture_normal_depth_array[32];
 //uniform float _texture_ao_strength_array[32];
 //uniform float _texture_ao_affect_array[32];
@@ -62,8 +66,10 @@ ivec3 get_index_coord(const vec2 uv) {
 	vec2 r_uv = round(uv);
 	ivec2 pos = ivec2(floor(r_uv * _region_texel_size)) + (_region_map_size / 2);
 	int bounds = int(uint(pos.x | pos.y) < uint(_region_map_size));
-	int layer_index = _region_map[pos.y * _region_map_size + pos.x] * bounds - 1;
-	return ivec3(ivec2(mod(r_uv, _region_size)), layer_index);
+    int raw_index = _region_map[pos.y * _region_map_size + pos.x] - 1;
+    int is_region = bounds * int(raw_index >= 0) * int(raw_index < MAX_REGIONS);
+    int layer_index = (raw_index * is_region) - (1 - is_region);
+    return ivec3(ivec2(mod(r_uv, _region_size)), layer_index);
 }
 
 // Takes in world space XZ (UV) and returns if the coordinate should be part of the NONE background.

--- a/project/demo/data/M_terrain.tres
+++ b/project/demo/data/M_terrain.tres
@@ -40,7 +40,6 @@ _shader_parameters = {
 "dual_scale_texture": 0,
 &"dual_scaling": null,
 "flat_terrain_normals": false,
-&"general": null,
 &"general_uniforms": null,
 "ground_level": -199.999962,
 &"macro_variation": null,

--- a/src/shaders/backgrounds.glsl
+++ b/src/shaders/backgrounds.glsl
@@ -22,11 +22,10 @@ uniform float region_blend : hint_range(.001, 1., 0.001) = 0.25;
 // Takes in UV2 region space coordinates, returns 1.0 or 0.0 if a region is present or not.
 float check_region(const vec2 uv2) {
 	ivec2 pos = ivec2(floor(uv2)) + (_region_map_size / 2);
-	int layer_index = 0;
-	if (uint(pos.x | pos.y) < uint(_region_map_size)) {
-		layer_index = clamp(_region_map[ pos.y * _region_map_size + pos.x ] - 1, -1, 0) + 1;
-	}
-	return float(layer_index);
+    int bounds = int(uint(pos.x | pos.y) < uint(_region_map_size));
+    int raw_index = _region_map[pos.y * _region_map_size + pos.x] - 1;
+    int is_valid = bounds * int(raw_index >= 0) * int(raw_index < MAX_REGIONS);
+	return float(is_valid);
 }
 
 // Takes in UV2 region space coordinates, returns a blend value (0 - 1 range) between empty, and valid regions

--- a/src/shaders/displacement_buffer.glsl
+++ b/src/shaders/displacement_buffer.glsl
@@ -45,7 +45,11 @@ uniform float _region_size = 1024.0;
 uniform float _region_texel_size = 0.0009765625; // = 1./region_size
 uniform int _region_map_size = 32;
 uniform int _region_map[1024];
-uniform vec2 _region_locations[1024];
+//INSERT: MAX_REGIONS_64
+//INSERT: MAX_REGIONS_128
+//INSERT: MAX_REGIONS_256
+//INSERT: MAX_REGIONS_512
+//INSERT: MAX_REGIONS_1024
 uniform float _texture_uv_scale_array[32];
 uniform vec2 _texture_detile_array[32];
 uniform vec2 _texture_displacement_array[32];

--- a/src/shaders/main.glsl
+++ b/src/shaders/main.glsl
@@ -55,7 +55,11 @@ uniform float _region_size = 1024.0;
 uniform float _region_texel_size = 0.0009765625; // = 1./region_size
 uniform int _region_map_size = 32;
 uniform int _region_map[1024];
-uniform vec2 _region_locations[1024];
+//INSERT: MAX_REGIONS_64
+//INSERT: MAX_REGIONS_128
+//INSERT: MAX_REGIONS_256
+//INSERT: MAX_REGIONS_512
+//INSERT: MAX_REGIONS_1024
 uniform float _texture_normal_depth_array[32];
 uniform float _texture_ao_strength_array[32];
 uniform float _texture_ao_affect_array[32];
@@ -126,8 +130,10 @@ ivec3 get_index_coord(const vec2 uv) {
 	vec2 r_uv = round(uv);
 	ivec2 pos = ivec2(floor(r_uv * _region_texel_size)) + (_region_map_size / 2);
 	int bounds = int(uint(pos.x | pos.y) < uint(_region_map_size));
-	int layer_index = _region_map[pos.y * _region_map_size + pos.x] * bounds - 1;
-	return ivec3(ivec2(mod(r_uv, _region_size)), layer_index);
+    int raw_index = _region_map[pos.y * _region_map_size + pos.x] - 1;
+    int is_region = bounds * int(raw_index >= 0) * int(raw_index < MAX_REGIONS);
+    int layer_index = (raw_index * is_region) - (1 - is_region);
+    return ivec3(ivec2(mod(r_uv, _region_size)), layer_index);
 }
 
 // Takes in descaled (world_space / region_size) world to region space XZ (UV2) coordinates, returns vec3 with:
@@ -136,7 +142,9 @@ ivec3 get_index_coord(const vec2 uv) {
 vec3 get_index_uv(const vec2 uv2) {
 	ivec2 pos = ivec2(floor(uv2)) + (_region_map_size / 2);
 	int bounds = int(uint(pos.x | pos.y) < uint(_region_map_size));
-	int layer_index = _region_map[ pos.y * _region_map_size + pos.x ] * bounds - 1;
+    int raw_index = _region_map[pos.y * _region_map_size + pos.x] - 1;
+    int is_region = bounds * int(raw_index >= 0) * int(raw_index < MAX_REGIONS);
+    int layer_index = (raw_index * is_region) - (1 - is_region);
 	return vec3(uv2 - _region_locations[layer_index], float(layer_index));
 }
 

--- a/src/shaders/max_regions.glsl
+++ b/src/shaders/max_regions.glsl
@@ -1,0 +1,25 @@
+// Copyright © 2023-2026 Cory Petkovsek, Roope Palmroos, and Contributors.
+
+R"(
+
+//INSERT: MAX_REGIONS_64
+uniform vec2 _region_locations[64];
+#define MAX_REGIONS 64
+
+//INSERT: MAX_REGIONS_128
+uniform vec2 _region_locations[128];
+#define MAX_REGIONS 128
+
+//INSERT: MAX_REGIONS_256
+uniform vec2 _region_locations[256];
+#define MAX_REGIONS 256
+
+//INSERT: MAX_REGIONS_512
+uniform vec2 _region_locations[512];
+#define MAX_REGIONS 512
+
+//INSERT: MAX_REGIONS_1024
+uniform vec2 _region_locations[1024];
+#define MAX_REGIONS 1024
+
+)"

--- a/src/shaders/projection.glsl
+++ b/src/shaders/projection.glsl
@@ -3,7 +3,7 @@
 R"(
 
 //INSERT: PROJECTION
-if (i_normal.y <= 0.7071067811865475) { // sqrt(0.5)
+	if (i_normal.y <= 0.7071067811865475) { // sqrt(0.5)
 		// Projected normal map alignment matrix
 		p_align = mat2(vec2(i_normal.z, -i_normal.x), vec2(i_normal.x, i_normal.z));
 		// Fast 45 degree snapping https://iquilezles.org/articles/noatan/

--- a/src/terrain_3d_material.cpp
+++ b/src/terrain_3d_material.cpp
@@ -21,38 +21,41 @@
 void Terrain3DMaterial::_preload_shaders() {
 	// Preprocessor loading of external shader inserts
 	_parse_shader(
-#include "shaders/samplers.glsl"
-			, "samplers");
+#include "shaders/auto_shader.glsl"
+			, "auto_shader");
 	_parse_shader(
 #include "shaders/backgrounds.glsl"
 			, "backgrounds");
 	_parse_shader(
-#include "shaders/auto_shader.glsl"
-			, "auto_shader");
-	_parse_shader(
-#include "shaders/dual_scaling.glsl"
-			, "dual_scaling");
-	_parse_shader(
-#include "shaders/overlays.glsl"
-			, "overlays");
-	_parse_shader(
-#include "shaders/displacement.glsl"
-			, "displacement");
-	_parse_shader(
-#include "shaders/macro_variation.glsl"
-			, "macro_variation");
-	_parse_shader(
-#include "shaders/projection.glsl"
-			, "projection");
+#include "shaders/editor_functions.glsl"
+			, "editor_functions");
 	_parse_shader(
 #include "shaders/debug_views.glsl"
 			, "debug_views");
 	_parse_shader(
+#include "shaders/displacement.glsl"
+			, "displacement");
+	_parse_shader(
+#include "shaders/dual_scaling.glsl"
+			, "dual_scaling");
+	_parse_shader(
+#include "shaders/macro_variation.glsl"
+			, "macro_variation");
+	_parse_shader(
+#include "shaders/max_regions.glsl"
+			, "macro_variation");
+	_parse_shader(
+#include "shaders/overlays.glsl"
+			, "overlays");
+	_parse_shader(
 #include "shaders/pbr_views.glsl"
 			, "pbr_views");
 	_parse_shader(
-#include "shaders/editor_functions.glsl"
-			, "editor_functions");
+#include "shaders/projection.glsl"
+			, "projection");
+	_parse_shader(
+#include "shaders/samplers.glsl"
+			, "samplers");
 
 	// Load main code
 	_shader_code["main"] = String(
@@ -139,6 +142,38 @@ String Terrain3DMaterial::_apply_inserts(const String &p_shader, const Array &p_
 String Terrain3DMaterial::_generate_shader_code() const {
 	LOG(INFO, "Generating default shader code");
 	Array excludes;
+	switch (_max_regions) {
+		case MAX_REGIONS_64:
+			excludes.push_back("MAX_REGIONS_128");
+			excludes.push_back("MAX_REGIONS_256");
+			excludes.push_back("MAX_REGIONS_512");
+			excludes.push_back("MAX_REGIONS_1024");
+			break;
+		case MAX_REGIONS_128:
+			excludes.push_back("MAX_REGIONS_64");
+			excludes.push_back("MAX_REGIONS_256");
+			excludes.push_back("MAX_REGIONS_512");
+			excludes.push_back("MAX_REGIONS_1024");
+			break;
+		case MAX_REGIONS_256:
+			excludes.push_back("MAX_REGIONS_64");
+			excludes.push_back("MAX_REGIONS_128");
+			excludes.push_back("MAX_REGIONS_512");
+			excludes.push_back("MAX_REGIONS_1024");
+			break;
+		case MAX_REGIONS_512:
+			excludes.push_back("MAX_REGIONS_64");
+			excludes.push_back("MAX_REGIONS_128");
+			excludes.push_back("MAX_REGIONS_256");
+			excludes.push_back("MAX_REGIONS_1024");
+			break;
+		case MAX_REGIONS_1024:
+			excludes.push_back("MAX_REGIONS_64");
+			excludes.push_back("MAX_REGIONS_128");
+			excludes.push_back("MAX_REGIONS_256");
+			excludes.push_back("MAX_REGIONS_512");
+			break;
+	}
 	if (_world_background != NONE) {
 		excludes.push_back("NONE_FUNCTIONS");
 		excludes.push_back("NONE_CHECK");
@@ -316,6 +351,38 @@ String Terrain3DMaterial::_strip_comments(const String &p_shader) const {
 String Terrain3DMaterial::_generate_buffer_shader_code() const {
 	LOG(INFO, "Generating default displacement buffer shader code");
 	Array excludes;
+	switch (_max_regions) {
+		case MAX_REGIONS_64:
+			excludes.push_back("MAX_REGIONS_128");
+			excludes.push_back("MAX_REGIONS_256");
+			excludes.push_back("MAX_REGIONS_512");
+			excludes.push_back("MAX_REGIONS_1024");
+			break;
+		case MAX_REGIONS_128:
+			excludes.push_back("MAX_REGIONS_64");
+			excludes.push_back("MAX_REGIONS_256");
+			excludes.push_back("MAX_REGIONS_512");
+			excludes.push_back("MAX_REGIONS_1024");
+			break;
+		case MAX_REGIONS_256:
+			excludes.push_back("MAX_REGIONS_64");
+			excludes.push_back("MAX_REGIONS_128");
+			excludes.push_back("MAX_REGIONS_512");
+			excludes.push_back("MAX_REGIONS_1024");
+			break;
+		case MAX_REGIONS_512:
+			excludes.push_back("MAX_REGIONS_64");
+			excludes.push_back("MAX_REGIONS_128");
+			excludes.push_back("MAX_REGIONS_256");
+			excludes.push_back("MAX_REGIONS_1024");
+			break;
+		case MAX_REGIONS_1024:
+			excludes.push_back("MAX_REGIONS_64");
+			excludes.push_back("MAX_REGIONS_128");
+			excludes.push_back("MAX_REGIONS_256");
+			excludes.push_back("MAX_REGIONS_512");
+			break;
+	}
 	if (_world_background != NONE) {
 		excludes.push_back("NONE_FUNCTIONS");
 		excludes.push_back("NONE_CHECK");
@@ -652,8 +719,12 @@ void Terrain3DMaterial::_update_uniforms(const RID &p_material, const uint32_t p
 	}
 
 	TypedArray<Vector2i> region_locations = data->get_region_locations();
-	LOG(EXTREME, "Region_locations size: ", region_locations.size(), " ", region_locations);
-	RS->material_set_param(p_material, "_region_locations", region_locations);
+	PackedVector2Array padded_locations;
+	padded_locations.resize(_max_regions);
+	for (int i = 0; i < MIN(region_locations.size(), _max_regions); ++i) {
+		padded_locations[i] = region_locations[i];
+	}
+	RS->material_set_param(p_material, "_region_locations", padded_locations);
 
 	real_t region_size = real_t(_terrain->get_region_size());
 	LOG(EXTREME, "Setting region size in material: ", region_size);
@@ -804,13 +875,13 @@ void Terrain3DMaterial::update(uint32_t p_flags) {
 
 void Terrain3DMaterial::set_displacement_scale(const real_t p_displacement_scale) {
 	SET_IF_DIFF(_displacement_scale, CLAMP(p_displacement_scale, 0.f, 2.f));
-	LOG(INFO, "Setting displacement scale: ", p_displacement_scale);
+	LOG(INFO, "Setting displacement scale: ", _displacement_scale);
 	update();
 }
 
 void Terrain3DMaterial::set_displacement_sharpness(const real_t p_displacement_sharpness) {
 	SET_IF_DIFF(_displacement_sharpness, CLAMP(p_displacement_sharpness, 0.f, 1.f));
-	LOG(INFO, "Setting displacement sharpness: ", p_displacement_sharpness);
+	LOG(INFO, "Setting displacement sharpness: ", _displacement_sharpness);
 	update();
 	if (_terrain) {
 		_terrain->snap();
@@ -819,43 +890,49 @@ void Terrain3DMaterial::set_displacement_sharpness(const real_t p_displacement_s
 
 void Terrain3DMaterial::set_world_background(const WorldBackground p_background) {
 	SET_IF_DIFF(_world_background, p_background);
-	LOG(INFO, "Enable world background: ", p_background);
+	LOG(INFO, "Enable world background: ", _world_background);
 	_update_shader();
 }
 
 void Terrain3DMaterial::set_texture_filtering(const TextureFiltering p_filtering) {
 	SET_IF_DIFF(_texture_filtering, p_filtering);
-	LOG(INFO, "Setting texture filtering: ", p_filtering);
+	LOG(INFO, "Setting texture filtering: ", _texture_filtering);
 	_update_shader();
 }
 
 void Terrain3DMaterial::set_auto_shader_enabled(const bool p_enabled) {
 	SET_IF_DIFF(_auto_shader_enabled, p_enabled);
-	LOG(INFO, "Enable auto shader: ", p_enabled);
+	LOG(INFO, "Enable auto shader: ", _auto_shader_enabled);
 	_update_shader();
 }
 
 void Terrain3DMaterial::set_dual_scaling_enabled(const bool p_enabled) {
 	SET_IF_DIFF(_dual_scaling_enabled, p_enabled);
-	LOG(INFO, "Enable dual scaling: ", p_enabled);
+	LOG(INFO, "Enable dual scaling: ", _dual_scaling_enabled);
 	_update_shader();
 }
 
 void Terrain3DMaterial::set_macro_variation_enabled(const bool p_enabled) {
 	SET_IF_DIFF(_macro_variation_enabled, p_enabled);
-	LOG(INFO, "Enable macro variation: ", p_enabled);
+	LOG(INFO, "Enable macro variation: ", _macro_variation_enabled);
 	_update_shader();
 }
 
 void Terrain3DMaterial::set_projection_enabled(const bool p_enabled) {
 	SET_IF_DIFF(_projection_enabled, p_enabled);
-	LOG(INFO, "Enable projection: ", p_enabled);
+	LOG(INFO, "Enable projection: ", _projection_enabled);
+	_update_shader();
+}
+
+void Terrain3DMaterial::set_max_regions(const RegionMaximum p_max) {
+	SET_IF_DIFF(_max_regions, RegionMaximum(CLAMP(closest_power_of_2(p_max), 64, 1024)));
+	LOG(INFO, "Set max region count: ", _max_regions);
 	_update_shader();
 }
 
 void Terrain3DMaterial::set_shader_override_enabled(const bool p_enabled) {
 	SET_IF_DIFF(_shader_override_enabled, p_enabled);
-	LOG(INFO, "Enable shader override: ", p_enabled);
+	LOG(INFO, "Enable shader override: ", _shader_override_enabled);
 	if (_shader_override_enabled && _shader_override.is_null()) {
 		LOG(DEBUG, "Instantiating new _shader_override");
 		_shader_override.instantiate();
@@ -871,7 +948,7 @@ void Terrain3DMaterial::set_shader_override(const Ref<Shader> &p_shader) {
 
 void Terrain3DMaterial::set_buffer_shader_override_enabled(const bool p_enabled) {
 	SET_IF_DIFF(_buffer_shader_override_enabled, p_enabled);
-	LOG(INFO, "Enable shader override: ", p_enabled);
+	LOG(INFO, "Enable shader override: ", _buffer_shader_override_enabled);
 	if (_buffer_shader_override_enabled && _buffer_shader_override.is_null()) {
 		LOG(DEBUG, "Instantiating new _shader_override");
 		_buffer_shader_override.instantiate();
@@ -886,7 +963,7 @@ void Terrain3DMaterial::set_buffer_shader_override(const Ref<Shader> &p_shader) 
 }
 
 void Terrain3DMaterial::set_shader_param(const StringName &p_name, const Variant &p_value) {
-	LOG(INFO, "Setting shader parameter: ", p_name);
+	LOG(INFO, "Setting shader parameter: ", p_name, " = ", p_value);
 	if (p_name.begins_with("_") && _material.is_valid()) {
 		RS->material_set_param(_material, p_name, p_value);
 	} else {
@@ -907,162 +984,163 @@ Variant Terrain3DMaterial::get_shader_param(const StringName &p_name) const {
 
 void Terrain3DMaterial::set_output_albedo_enabled(const bool p_enabled) {
 	SET_IF_DIFF(_output_albedo_enabled, p_enabled);
-	LOG(INFO, "Enable PBR output albedo: ", p_enabled);
+	LOG(INFO, "Enable PBR output albedo: ", _output_albedo_enabled);
 	_update_shader();
 }
 
 void Terrain3DMaterial::set_output_roughness_enabled(const bool p_enabled) {
 	SET_IF_DIFF(_output_roughness_enabled, p_enabled);
-	LOG(INFO, "Enable PBR output roughness: ", p_enabled);
+	LOG(INFO, "Enable PBR output roughness: ", _output_roughness_enabled);
 	_update_shader();
 }
 
 void Terrain3DMaterial::set_output_specular_enabled(const bool p_enabled) {
 	SET_IF_DIFF(_output_specular_enabled, p_enabled);
-	LOG(INFO, "Enable PBR output specular: ", p_enabled);
+	LOG(INFO, "Enable PBR output specular: ", _output_specular_enabled);
 	_update_shader();
 }
 
 void Terrain3DMaterial::set_output_normal_map_enabled(const bool p_enabled) {
 	SET_IF_DIFF(_output_normal_map_enabled, p_enabled);
-	LOG(INFO, "Enable PBR output normal map: ", p_enabled);
+	LOG(INFO, "Enable PBR output normal map: ", _output_normal_map_enabled);
 	_update_shader();
 }
 
 void Terrain3DMaterial::set_output_ambient_occlusion_enabled(const bool p_enabled) {
 	SET_IF_DIFF(_output_ambient_occlusion_enabled, p_enabled);
-	LOG(INFO, "Enable PBR output ambient occlusion: ", p_enabled);
+	LOG(INFO, "Enable PBR output ambient occlusion: ", _output_ambient_occlusion_enabled);
 	_update_shader();
 }
 
 void Terrain3DMaterial::set_show_region_grid(const bool p_enabled) {
 	SET_IF_DIFF(_show_region_grid, p_enabled);
-	LOG(INFO, "Enable show_region_grid: ", p_enabled);
+	LOG(INFO, "Enable show_region_grid: ", _show_region_grid);
 	_update_shader();
 }
 
 void Terrain3DMaterial::set_show_instancer_grid(const bool p_enabled) {
 	SET_IF_DIFF(_show_instancer_grid, p_enabled);
-	LOG(INFO, "Enable show_instancer_grid: ", p_enabled);
+	LOG(INFO, "Enable show_instancer_grid: ", _show_instancer_grid);
 	_update_shader();
 }
 
 void Terrain3DMaterial::set_show_vertex_grid(const bool p_enabled) {
 	SET_IF_DIFF(_show_vertex_grid, p_enabled);
-	LOG(INFO, "Enable show_vertex_grid: ", p_enabled);
+	LOG(INFO, "Enable show_vertex_grid: ", _show_vertex_grid);
 	_update_shader();
 }
 
 void Terrain3DMaterial::set_show_contours(const bool p_enabled) {
 	SET_IF_DIFF(_show_contours, p_enabled);
-	LOG(INFO, "Enable show_contours: ", p_enabled);
+	LOG(INFO, "Enable show_contours: ", _show_contours);
 	_update_shader();
 }
 
 void Terrain3DMaterial::set_show_navigation(const bool p_enabled) {
 	SET_IF_DIFF(_show_navigation, p_enabled);
-	LOG(INFO, "Enable show_navigation: ", p_enabled);
+	LOG(INFO, "Enable show_navigation: ", _show_navigation);
 	_update_shader();
 }
 
 void Terrain3DMaterial::set_show_checkered(const bool p_enabled) {
 	SET_IF_DIFF(_debug_view_checkered, p_enabled);
-	LOG(INFO, "Enable set_show_checkered: ", p_enabled);
+	LOG(INFO, "Enable set_show_checkered: ", _debug_view_checkered);
 	_update_shader();
 }
 
 void Terrain3DMaterial::set_show_grey(const bool p_enabled) {
 	SET_IF_DIFF(_debug_view_grey, p_enabled);
-	LOG(INFO, "Enable show_grey: ", p_enabled);
+	LOG(INFO, "Enable show_grey: ", _debug_view_grey);
 	_update_shader();
 }
 
 void Terrain3DMaterial::set_show_heightmap(const bool p_enabled) {
 	SET_IF_DIFF(_debug_view_heightmap, p_enabled);
-	LOG(INFO, "Enable show_heightmap: ", p_enabled);
+	LOG(INFO, "Enable show_heightmap: ", _debug_view_heightmap);
 	_update_shader();
 }
 
 void Terrain3DMaterial::set_show_jaggedness(const bool p_enabled) {
 	SET_IF_DIFF(_debug_view_jaggedness, p_enabled);
-	LOG(INFO, "Enable show_jaggedness: ", p_enabled);
+	LOG(INFO, "Enable show_jaggedness: ", _debug_view_jaggedness);
 	_update_shader();
 }
 
 void Terrain3DMaterial::set_show_autoshader(const bool p_enabled) {
 	SET_IF_DIFF(_debug_view_autoshader, p_enabled);
-	LOG(INFO, "Enable show_autoshader: ", p_enabled);
+	LOG(INFO, "Enable show_autoshader: ", _debug_view_autoshader);
 	_update_shader();
 }
 
 void Terrain3DMaterial::set_show_control_texture(const bool p_enabled) {
 	SET_IF_DIFF(_debug_view_control_texture, p_enabled);
-	LOG(INFO, "Enable show_control_texture: ", p_enabled);
+	LOG(INFO, "Enable show_control_texture: ", _debug_view_control_texture);
 	_update_shader();
 }
 
 void Terrain3DMaterial::set_show_control_blend(const bool p_enabled) {
 	SET_IF_DIFF(_debug_view_control_blend, p_enabled);
-	LOG(INFO, "Enable show_control_blend: ", p_enabled);
+	LOG(INFO, "Enable show_control_blend: ", _debug_view_control_blend);
 	_update_shader();
 }
 
 void Terrain3DMaterial::set_show_control_angle(const bool p_enabled) {
 	SET_IF_DIFF(_debug_view_control_angle, p_enabled);
-	LOG(INFO, "Enable show_control_angle: ", p_enabled);
+	LOG(INFO, "Enable show_control_angle: ", _debug_view_control_angle);
 	_update_shader();
 }
 
 void Terrain3DMaterial::set_show_control_scale(const bool p_enabled) {
 	SET_IF_DIFF(_debug_view_control_scale, p_enabled);
-	LOG(INFO, "Enable show_control_scale: ", p_enabled);
+	LOG(INFO, "Enable show_control_scale: ", _debug_view_control_scale);
 	_update_shader();
 }
 
 void Terrain3DMaterial::set_show_colormap(const bool p_enabled) {
 	SET_IF_DIFF(_debug_view_colormap, p_enabled);
-	LOG(INFO, "Enable show_colormap: ", p_enabled);
+	LOG(INFO, "Enable show_colormap: ", _debug_view_colormap);
 	_update_shader();
 }
 
 void Terrain3DMaterial::set_show_roughmap(const bool p_enabled) {
 	SET_IF_DIFF(_debug_view_roughmap, p_enabled);
-	LOG(INFO, "Enable show_roughmap: ", p_enabled);
+	LOG(INFO, "Enable show_roughmap: ", _debug_view_roughmap);
+	_update_shader();
+}
+
+void Terrain3DMaterial::set_show_displacement_buffer(const bool p_enabled) {
+	SET_IF_DIFF(_debug_view_displacement_buffer, p_enabled);
+	LOG(INFO, "Enable show_displacement_buffer: ", _debug_view_displacement_buffer);
 	_update_shader();
 }
 
 void Terrain3DMaterial::set_show_texture_albedo(const bool p_enabled) {
 	SET_IF_DIFF(_pbr_view_tex_albedo, p_enabled);
-	LOG(INFO, "Enable show_texture_albedo: ", p_enabled);
+	LOG(INFO, "Enable show_texture_albedo: ", _pbr_view_tex_albedo);
 	_update_shader();
 }
 
 void Terrain3DMaterial::set_show_texture_height(const bool p_enabled) {
 	SET_IF_DIFF(_pbr_view_tex_height, p_enabled);
-	LOG(INFO, "Enable show_texture_height: ", p_enabled);
+	LOG(INFO, "Enable show_texture_height: ", _pbr_view_tex_height);
 	_update_shader();
 }
 
 void Terrain3DMaterial::set_show_texture_normal(const bool p_enabled) {
 	SET_IF_DIFF(_pbr_view_tex_normal, p_enabled);
-	LOG(INFO, "Enable show_texture_normal: ", p_enabled);
+	LOG(INFO, "Enable show_texture_normal: ", _pbr_view_tex_normal);
 	_update_shader();
 }
 
 void Terrain3DMaterial::set_show_texture_rough(const bool p_enabled) {
 	SET_IF_DIFF(_pbr_view_tex_rough, p_enabled);
-	LOG(INFO, "Enable show_texture_rough: ", p_enabled);
-	_update_shader();
-}
-void Terrain3DMaterial::set_show_displacement_buffer(const bool p_enabled) {
-	LOG(INFO, "Enable show_texture_rough: ", p_enabled);
-	_debug_view_displacement_buffer = p_enabled;
+	LOG(INFO, "Enable show_texture_rough: ", _pbr_view_tex_rough);
 	_update_shader();
 }
 
 void Terrain3DMaterial::set_show_texture_ao(const bool p_enabled) {
 	SET_IF_DIFF(_pbr_view_tex_ao, p_enabled);
-	LOG(INFO, "Enable show_texture_ao: ", p_enabled);
+	LOG(INFO, "Enable show_texture_ao: ", _pbr_view_tex_ao);
 	_update_shader();
 }
 
@@ -1301,6 +1379,11 @@ void Terrain3DMaterial::_bind_methods() {
 	BIND_ENUM_CONSTANT(NONE);
 	BIND_ENUM_CONSTANT(FLAT);
 	BIND_ENUM_CONSTANT(NOISE);
+	BIND_ENUM_CONSTANT(MAX_REGIONS_64);
+	BIND_ENUM_CONSTANT(MAX_REGIONS_128);
+	BIND_ENUM_CONSTANT(MAX_REGIONS_256);
+	BIND_ENUM_CONSTANT(MAX_REGIONS_512);
+	BIND_ENUM_CONSTANT(MAX_REGIONS_1024);
 	BIND_ENUM_CONSTANT(LINEAR_ANISOTROPIC);
 	BIND_ENUM_CONSTANT(LINEAR);
 	BIND_ENUM_CONSTANT(NEAREST_ANISOTROPIC);
@@ -1335,6 +1418,8 @@ void Terrain3DMaterial::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("get_macro_variation_enabled"), &Terrain3DMaterial::get_macro_variation_enabled);
 	ClassDB::bind_method(D_METHOD("set_projection_enabled", "enabled"), &Terrain3DMaterial::set_projection_enabled);
 	ClassDB::bind_method(D_METHOD("get_projection_enabled"), &Terrain3DMaterial::get_projection_enabled);
+	ClassDB::bind_method(D_METHOD("set_max_regions", "count"), &Terrain3DMaterial::set_max_regions);
+	ClassDB::bind_method(D_METHOD("get_max_regions"), &Terrain3DMaterial::get_max_regions);
 
 	ClassDB::bind_method(D_METHOD("set_shader_override_enabled", "enabled"), &Terrain3DMaterial::set_shader_override_enabled);
 	ClassDB::bind_method(D_METHOD("is_shader_override_enabled"), &Terrain3DMaterial::is_shader_override_enabled);
@@ -1353,7 +1438,7 @@ void Terrain3DMaterial::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("set_shader_param", "name", "value"), &Terrain3DMaterial::set_shader_param);
 	ClassDB::bind_method(D_METHOD("get_shader_param", "name"), &Terrain3DMaterial::get_shader_param);
 
-	// PBR output
+	// PBR Material Output
 	ClassDB::bind_method(D_METHOD("set_output_albedo_enabled", "enabled"), &Terrain3DMaterial::set_output_albedo_enabled);
 	ClassDB::bind_method(D_METHOD("get_output_albedo_enabled"), &Terrain3DMaterial::get_output_albedo_enabled);
 	ClassDB::bind_method(D_METHOD("set_output_roughness_enabled", "enabled"), &Terrain3DMaterial::set_output_roughness_enabled);
@@ -1400,20 +1485,20 @@ void Terrain3DMaterial::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("get_show_colormap"), &Terrain3DMaterial::get_show_colormap);
 	ClassDB::bind_method(D_METHOD("set_show_roughmap", "enabled"), &Terrain3DMaterial::set_show_roughmap);
 	ClassDB::bind_method(D_METHOD("get_show_roughmap"), &Terrain3DMaterial::get_show_roughmap);
+	ClassDB::bind_method(D_METHOD("set_show_displacement_buffer", "enabled"), &Terrain3DMaterial::set_show_displacement_buffer);
+	ClassDB::bind_method(D_METHOD("get_show_displacement_buffer"), &Terrain3DMaterial::get_show_displacement_buffer);
 
-	// PBR Views
+	// PBR Debug Views
 	ClassDB::bind_method(D_METHOD("set_show_texture_albedo", "enabled"), &Terrain3DMaterial::set_show_texture_albedo);
 	ClassDB::bind_method(D_METHOD("get_show_texture_albedo"), &Terrain3DMaterial::get_show_texture_albedo);
 	ClassDB::bind_method(D_METHOD("set_show_texture_height", "enabled"), &Terrain3DMaterial::set_show_texture_height);
 	ClassDB::bind_method(D_METHOD("get_show_texture_height"), &Terrain3DMaterial::get_show_texture_height);
 	ClassDB::bind_method(D_METHOD("set_show_texture_normal", "enabled"), &Terrain3DMaterial::set_show_texture_normal);
 	ClassDB::bind_method(D_METHOD("get_show_texture_normal"), &Terrain3DMaterial::get_show_texture_normal);
-	ClassDB::bind_method(D_METHOD("set_show_texture_ao", "enabled"), &Terrain3DMaterial::set_show_texture_ao);
-	ClassDB::bind_method(D_METHOD("get_show_texture_ao"), &Terrain3DMaterial::get_show_texture_ao);
 	ClassDB::bind_method(D_METHOD("set_show_texture_rough", "enabled"), &Terrain3DMaterial::set_show_texture_rough);
 	ClassDB::bind_method(D_METHOD("get_show_texture_rough"), &Terrain3DMaterial::get_show_texture_rough);
-	ClassDB::bind_method(D_METHOD("set_show_displacement_buffer", "enabled"), &Terrain3DMaterial::set_show_displacement_buffer);
-	ClassDB::bind_method(D_METHOD("get_show_displacement_buffer"), &Terrain3DMaterial::get_show_displacement_buffer);
+	ClassDB::bind_method(D_METHOD("set_show_texture_ao", "enabled"), &Terrain3DMaterial::set_show_texture_ao);
+	ClassDB::bind_method(D_METHOD("get_show_texture_ao"), &Terrain3DMaterial::get_show_texture_ao);
 
 	ClassDB::bind_method(D_METHOD("save", "path"), &Terrain3DMaterial::save, DEFVAL(""));
 
@@ -1424,6 +1509,7 @@ void Terrain3DMaterial::_bind_methods() {
 	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "dual_scaling_enabled"), "set_dual_scaling_enabled", "get_dual_scaling_enabled");
 	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "macro_variation_enabled"), "set_macro_variation_enabled", "get_macro_variation_enabled");
 	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "projection_enabled"), "set_projection_enabled", "get_projection_enabled");
+	ADD_PROPERTY(PropertyInfo(Variant::INT, "max_regions", PROPERTY_HINT_ENUM, "64:64,128:128,256:256,512:512,1024:1024"), "set_max_regions", "get_max_regions");
 
 	ADD_GROUP("PBR Output", "output_");
 	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "output_albedo"), "set_output_albedo_enabled", "get_output_albedo_enabled");
@@ -1444,12 +1530,14 @@ void Terrain3DMaterial::_bind_methods() {
 	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "show_contours", PROPERTY_HINT_NONE, "", PROPERTY_USAGE_NO_EDITOR), "set_show_contours", "get_show_contours");
 	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "show_navigation", PROPERTY_HINT_NONE, "", PROPERTY_USAGE_NO_EDITOR), "set_show_navigation", "get_show_navigation");
 
-	// Hidden in Material, aliased in Terrain3D
+	// Below here properties are hidden in Material, aliased in Terrain3D
+
 	// Displacement settings
 	ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "displacement_scale", PROPERTY_HINT_NONE, "", PROPERTY_USAGE_NO_EDITOR), "set_displacement_scale", "get_displacement_scale");
 	ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "displacement_sharpness", PROPERTY_HINT_NONE, "", PROPERTY_USAGE_NO_EDITOR), "set_displacement_sharpness", "get_displacement_sharpness");
 	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "buffer_shader_override_enabled", PROPERTY_HINT_NONE, "", PROPERTY_USAGE_NO_EDITOR), "set_buffer_shader_override_enabled", "is_buffer_shader_override_enabled");
 	ADD_PROPERTY(PropertyInfo(Variant::OBJECT, "buffer_shader_override", PROPERTY_HINT_NONE, "", PROPERTY_USAGE_NO_EDITOR), "set_buffer_shader_override", "get_buffer_shader_override");
+
 	//ADD_GROUP("Debug Views", "show_");
 	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "show_checkered", PROPERTY_HINT_NONE, "", PROPERTY_USAGE_NO_EDITOR), "set_show_checkered", "get_show_checkered");
 	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "show_grey", PROPERTY_HINT_NONE, "", PROPERTY_USAGE_NO_EDITOR), "set_show_grey", "get_show_grey");
@@ -1462,13 +1550,12 @@ void Terrain3DMaterial::_bind_methods() {
 	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "show_control_scale", PROPERTY_HINT_NONE, "", PROPERTY_USAGE_NO_EDITOR), "set_show_control_scale", "get_show_control_scale");
 	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "show_colormap", PROPERTY_HINT_NONE, "", PROPERTY_USAGE_NO_EDITOR), "set_show_colormap", "get_show_colormap");
 	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "show_roughmap", PROPERTY_HINT_NONE, "", PROPERTY_USAGE_NO_EDITOR), "set_show_roughmap", "get_show_roughmap");
+	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "show_displacement_buffer", PROPERTY_HINT_NONE, "", PROPERTY_USAGE_NO_EDITOR), "set_show_displacement_buffer", "get_show_displacement_buffer");
 
-	// Hidden in Material, aliased in Terrain3D
 	//ADD_SUBGROUP("PBR Views", "show_");
 	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "show_texture_albedo", PROPERTY_HINT_NONE, "", PROPERTY_USAGE_NO_EDITOR), "set_show_texture_albedo", "get_show_texture_albedo");
 	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "show_texture_height", PROPERTY_HINT_NONE, "", PROPERTY_USAGE_NO_EDITOR), "set_show_texture_height", "get_show_texture_height");
 	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "show_texture_normal", PROPERTY_HINT_NONE, "", PROPERTY_USAGE_NO_EDITOR), "set_show_texture_normal", "get_show_texture_normal");
-	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "show_texture_ao", PROPERTY_HINT_NONE, "", PROPERTY_USAGE_NO_EDITOR), "set_show_texture_ao", "get_show_texture_ao");
 	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "show_texture_rough", PROPERTY_HINT_NONE, "", PROPERTY_USAGE_NO_EDITOR), "set_show_texture_rough", "get_show_texture_rough");
-	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "show_displacement_buffer", PROPERTY_HINT_NONE, "", PROPERTY_USAGE_NO_EDITOR), "set_show_displacement_buffer", "get_show_displacement_buffer");
+	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "show_texture_ao", PROPERTY_HINT_NONE, "", PROPERTY_USAGE_NO_EDITOR), "set_show_texture_ao", "get_show_texture_ao");
 }

--- a/src/terrain_3d_material.h
+++ b/src/terrain_3d_material.h
@@ -28,6 +28,14 @@ public: // Constants
 		NEAREST,
 	};
 
+	enum RegionMaximum {
+		MAX_REGIONS_64 = 64,
+		MAX_REGIONS_128 = 128,
+		MAX_REGIONS_256 = 256,
+		MAX_REGIONS_512 = 512,
+		MAX_REGIONS_1024 = 1024,
+	};
+
 	enum UpdateFlags {
 		UNIFORMS_ONLY = 0,
 		TEXTURE_ARRAYS = 1 << 0,
@@ -62,6 +70,7 @@ private:
 	bool _auto_shader_enabled = false;
 	bool _macro_variation_enabled = false;
 	bool _projection_enabled = false;
+	RegionMaximum _max_regions = MAX_REGIONS_1024;
 
 	// PBR Outputs
 	bool _output_albedo_enabled = true;
@@ -144,6 +153,8 @@ public:
 	bool get_macro_variation_enabled() const { return _macro_variation_enabled; }
 	void set_projection_enabled(const bool p_enabled);
 	bool get_projection_enabled() const { return _projection_enabled; }
+	void set_max_regions(const RegionMaximum p_max);
+	RegionMaximum get_max_regions() const { return _max_regions; }
 
 	void set_shader_override_enabled(const bool p_enabled);
 	bool is_shader_override_enabled() const { return _shader_override_enabled; }
@@ -158,7 +169,7 @@ public:
 	void set_shader_param(const StringName &p_name, const Variant &p_value);
 	Variant get_shader_param(const StringName &p_name) const;
 
-	// PBR outputs
+	// PBR Material Output
 	void set_output_albedo_enabled(const bool p_enabled);
 	bool get_output_albedo_enabled() const { return _output_albedo_enabled; }
 	void set_output_roughness_enabled(const bool p_enabled);
@@ -182,7 +193,7 @@ public:
 	void set_show_navigation(const bool p_enabled);
 	bool get_show_navigation() const { return _show_navigation; }
 
-	// Debug views
+	// Debug Views
 	void set_show_checkered(const bool p_enabled);
 	bool get_show_checkered() const { return _debug_view_checkered; }
 	void set_show_grey(const bool p_enabled);
@@ -208,7 +219,7 @@ public:
 	void set_show_displacement_buffer(const bool p_enabled);
 	bool get_show_displacement_buffer() const { return _debug_view_displacement_buffer; }
 
-	// PBR Views
+	// PBR Debug Views
 	void set_show_texture_albedo(const bool p_enabled);
 	bool get_show_texture_albedo() const { return _pbr_view_tex_albedo; }
 	void set_show_texture_height(const bool p_enabled);
@@ -233,6 +244,7 @@ protected:
 };
 
 VARIANT_ENUM_CAST(Terrain3DMaterial::WorldBackground);
+VARIANT_ENUM_CAST(Terrain3DMaterial::RegionMaximum);
 VARIANT_ENUM_CAST(Terrain3DMaterial::TextureFiltering);
 VARIANT_ENUM_CAST(Terrain3DMaterial::UpdateFlags);
 


### PR DESCRIPTION
Fixes #623 
Fixes #668

* Adds an option to the material to limit the number of regions that are rendered. It changes the size of `_region_locations[N]` from 64-1024. It doesn't save vram. It reduces the uniform buffer consumption for mobile games and web on mobiles. Set to the minimum number of regions you need (e.g. 64-256).

* Pads the _region_locations[] array we sent to the shader. We've been sending only the number of region locations we have. So before when we had 3 regions, we sent an vec2_array[3] to the uniform _region_locations[1024], and now we send vec2_array[1024] with the padded values of 0,0. I heard it's supposed to be padded, so now we do. Perhaps that's an issue on some older systems.
