### PR TITLE
Move region blend code to Terrain3DData::get_height()

### DIFF
--- a/doc/api/class_terrain3d.rst
+++ b/doc/api/class_terrain3d.rst
@@ -1759,7 +1759,7 @@ Possible return values:
 
 
 
-Also see :ref:`get_raycast_result()<class_Terrain3D_method_get_raycast_result>` and :ref:`Terrain3DData.get_height()<class_Terrain3DData_method_get_height>` for alternative functions.
+Also see :ref:`get_raycast_result()<class_Terrain3D_method_get_raycast_result>` and :ref:`Terrain3DData.get_surface_height()<class_Terrain3DData_method_get_surface_height>` for alternative functions.
 
 .. rst-class:: classref-item-separator
 
@@ -1791,7 +1791,7 @@ Collision_mask has the physics layers the query will detect as a bitmask. By def
 
 See `PhysicsDirectSpaceState3D.intersect_ray <https://docs.godotengine.org/en/stable/classes/class_physicsdirectspacestate3d.html#class-physicsdirectspacestate3d-method-intersect-ray>`__ for how to interpret the resulting dictionary.
 
-Also see :ref:`get_intersection()<class_Terrain3D_method_get_intersection>` and :ref:`Terrain3DData.get_height()<class_Terrain3DData_method_get_height>` for alternative functions.
+Also see :ref:`get_intersection()<class_Terrain3D_method_get_intersection>` and :ref:`Terrain3DData.get_surface_height()<class_Terrain3DData_method_get_surface_height>` for alternative functions.
 
 .. rst-class:: classref-item-separator
 

--- a/doc/api/class_terrain3ddata.rst
+++ b/doc/api/class_terrain3ddata.rst
@@ -122,6 +122,8 @@ Methods
    +----------------------------------------------------------------------------+------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
    | ``float``                                                                  | :ref:`get_roughness<class_Terrain3DData_method_get_roughness>`\ (\ global_position\: ``Vector3``\ ) |const|                                                                                                                  |
    +----------------------------------------------------------------------------+------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
+   | ``float``                                                                  | :ref:`get_surface_height<class_Terrain3DData_method_get_surface_height>`\ (\ global_position\: ``Vector3``\ ) |const|                                                                                                        |
+   +----------------------------------------------------------------------------+------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
    | ``Vector3``                                                                | :ref:`get_texture_id<class_Terrain3DData_method_get_texture_id>`\ (\ global_position\: ``Vector3``\ ) |const|                                                                                                                |
    +----------------------------------------------------------------------------+------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
    | ``bool``                                                                   | :ref:`has_region<class_Terrain3DData_method_has_region>`\ (\ region_location\: ``Vector2i``\ ) |const|                                                                                                                       |
@@ -709,11 +711,7 @@ Returns ``NAN`` if the position is outside of defined regions.
 
 ``float`` **get_height**\ (\ global_position\: ``Vector3``\ ) |const| :ref:`🔗<class_Terrain3DData_method_get_height>`
 
-Returns the height at the requested position. If the position is close to a vertex, the pixel height on the heightmap is returned. Otherwise the value is interpolated from the 4 vertices surrounding the position.
-
-Returns ``NAN`` if the requested position is a hole or outside of defined regions.
-
-Also see :ref:`Terrain3D.get_raycast_result()<class_Terrain3D_method_get_raycast_result>` and :ref:`Terrain3D.get_intersection()<class_Terrain3D_method_get_intersection>` for alternative functions
+Returns the height value on the heightmap at the specified position. Though this returns the data in the region, this is may not be the apparent ground level. See :ref:`get_surface_height()<class_Terrain3DData_method_get_surface_height>`.
 
 .. rst-class:: classref-item-separator
 
@@ -781,7 +779,7 @@ Returns the position of a terrain vertex at a certain LOD. If the position is ou
 
 ``Vector3`` **get_normal**\ (\ global_position\: ``Vector3``\ ) |const| :ref:`🔗<class_Terrain3DData_method_get_normal>`
 
-Returns the terrain normal at the specified position. This function uses :ref:`get_height()<class_Terrain3DData_method_get_height>`.
+Returns the terrain normal at the specified position. This function calls :ref:`get_surface_height()<class_Terrain3DData_method_get_surface_height>` 3 times.
 
 Returns ``Vector3(NAN, NAN, NAN)`` if the requested position is a hole or outside of defined regions.
 
@@ -795,7 +793,7 @@ Returns ``Vector3(NAN, NAN, NAN)`` if the requested position is a hole or outsid
 
 ``Color`` **get_pixel**\ (\ map_type\: :ref:`MapType<enum_Terrain3DRegion_MapType>`, global_position\: ``Vector3``\ ) |const| :ref:`🔗<class_Terrain3DData_method_get_pixel>`
 
-Returns the pixel for the map type associated with the specified position.
+Returns the pixel for the map type associated with the specified position. Global position is descaled and floored to find the vertex grid coordinates.
 
 Returns ``Color(NAN, NAN, NAN, NAN)`` if the position is outside of defined regions.
 
@@ -942,6 +940,22 @@ Returns all regions in a dictionary indexed by region location. Some regions may
 Returns the roughness modifier (wetness) on the color map alpha channel associated with the specified position.
 
 Returns ``Color(NAN, NAN, NAN, NAN)`` if the position is outside of defined regions.
+
+.. rst-class:: classref-item-separator
+
+----
+
+.. _class_Terrain3DData_method_get_surface_height:
+
+.. rst-class:: classref-method
+
+``float`` **get_surface_height**\ (\ global_position\: ``Vector3``\ ) |const| :ref:`🔗<class_Terrain3DData_method_get_surface_height>`
+
+Returns the rendered height at the requested global position. This method starts with the raw height in the region data returned by :ref:`get_height()<class_Terrain3DData_method_get_height>`. It then mixes in the ``ground_level`` and ``region_blend`` values from the material if they exist. Next, if global_position is very close to a vertex the value is returned. Otherwise, this is repeated 3 more times and the final height value is interpolated. Thus it's 4x faster to snap your vertex to :ref:`Terrain3D.vertex_spacing<class_Terrain3D_property_vertex_spacing>` before calling it. This function is used for collision, navigation baking, and instancer placement.
+
+Returns ``NAN`` if the requested position is a hole or outside of defined regions.
+
+Also see :ref:`Terrain3D.get_raycast_result()<class_Terrain3D_method_get_raycast_result>` and :ref:`Terrain3D.get_intersection()<class_Terrain3D_method_get_intersection>` for alternative functions.
 
 .. rst-class:: classref-item-separator
 
@@ -1291,9 +1305,7 @@ See :ref:`set_pixel()<class_Terrain3DData_method_set_pixel>` for important infor
 
 |void| **set_height**\ (\ global_position\: ``Vector3``, height\: ``float``\ ) :ref:`🔗<class_Terrain3DData_method_set_height>`
 
-Sets the height value on the heightmap pixel associated with the specified position. See :ref:`set_pixel()<class_Terrain3DData_method_set_pixel>` for important information.
-
-Unlike :ref:`get_height()<class_Terrain3DData_method_get_height>`, which interpolates between vertices, this function does not and will set the pixel at floored coordinates.
+Sets the height value on the heightmap at the specified position. See :ref:`set_pixel()<class_Terrain3DData_method_set_pixel>` for important information. Also see :ref:`get_height()<class_Terrain3DData_method_get_height>`.
 
 .. rst-class:: classref-item-separator
 
@@ -1305,7 +1317,7 @@ Unlike :ref:`get_height()<class_Terrain3DData_method_get_height>`, which interpo
 
 |void| **set_pixel**\ (\ map_type\: :ref:`MapType<enum_Terrain3DRegion_MapType>`, global_position\: ``Vector3``, pixel\: ``Color``\ ) :ref:`🔗<class_Terrain3DData_method_set_pixel>`
 
-Sets the pixel for the map type associated with the specified position. This method is fine for setting a few pixels, but if you wish to modify thousands of pixels quickly, you should get the region and use :ref:`Terrain3DRegion.get_map()<class_Terrain3DRegion_method_get_map>`, then edit the images directly.
+Sets the pixel for the map type associated with the specified position. Global position is descaled and floored to find the vertex grid coordinates. This method is fine for setting a few pixels, but if you wish to modify thousands of pixels quickly, you should get the region and use :ref:`Terrain3DRegion.get_map()<class_Terrain3DRegion_method_get_map>`, then edit the images directly.
 
 After setting pixels you need to call :ref:`update_maps()<class_Terrain3DData_method_update_maps>`. You may also need to regenerate collision if you don't have dynamic collision enabled.
 

--- a/doc/doc_classes/Terrain3D.xml
+++ b/doc/doc_classes/Terrain3D.xml
@@ -82,7 +82,7 @@
 				- If there is no intersection, eg. the ray points towards the sky, it returns the maximum double float value [code skip-lint]Vector3(3.402823466e+38F,...)[/code]. You can check this case with this code: [code skip-lint]if point.z &gt; 3.4e38:[/code]
 				- On error, it returns [code skip-lint]Vector3(NAN, NAN, NAN)[/code] and prints a message to the console.
 
-				Also see [method get_raycast_result] and [method Terrain3DData.get_height] for alternative functions.
+				Also see [method get_raycast_result] and [method Terrain3DData.get_surface_height] for alternative functions.
 			</description>
 		</method>
 		<method name="get_plugin" qualifiers="const">
@@ -102,7 +102,7 @@
 				Direction is added to src_pos and includes magnitude. So to run a raycast from (100, 100, 100) to the ground 100m below, direction would be (0, -110, 0) with margin.
 				Collision_mask has the physics layers the query will detect as a bitmask. By default, all collision layers are detected.
 				See [url=https://docs.godotengine.org/en/stable/classes/class_physicsdirectspacestate3d.html#class-physicsdirectspacestate3d-method-intersect-ray]PhysicsDirectSpaceState3D.intersect_ray[/url] for how to interpret the resulting dictionary.
-				Also see [method get_intersection] and [method Terrain3DData.get_height] for alternative functions.
+				Also see [method get_intersection] and [method Terrain3DData.get_surface_height] for alternative functions.
 			</description>
 		</method>
 		<method name="set_camera">

--- a/doc/doc_classes/Terrain3DData.xml
+++ b/doc/doc_classes/Terrain3DData.xml
@@ -176,9 +176,7 @@
 			<return type="float" />
 			<param index="0" name="global_position" type="Vector3" />
 			<description>
-				Returns the height at the requested position. If the position is close to a vertex, the pixel height on the heightmap is returned. Otherwise the value is interpolated from the 4 vertices surrounding the position.
-				Returns [code skip-lint]NAN[/code] if the requested position is a hole or outside of defined regions.
-				Also see [method Terrain3D.get_raycast_result] and [method Terrain3D.get_intersection] for alternative functions
+				Returns the height value on the heightmap at the specified position. Though this returns the data in the region, this is may not be the apparent ground level. See [method get_surface_height].
 			</description>
 		</method>
 		<method name="get_height_maps_rid" qualifiers="const">
@@ -217,7 +215,7 @@
 			<return type="Vector3" />
 			<param index="0" name="global_position" type="Vector3" />
 			<description>
-				Returns the terrain normal at the specified position. This function uses [method get_height].
+				Returns the terrain normal at the specified position. This function calls [method get_surface_height] 3 times.
 				Returns [code skip-lint]Vector3(NAN, NAN, NAN)[/code] if the requested position is a hole or outside of defined regions.
 			</description>
 		</method>
@@ -226,7 +224,7 @@
 			<param index="0" name="map_type" type="int" enum="Terrain3DRegion.MapType" />
 			<param index="1" name="global_position" type="Vector3" />
 			<description>
-				Returns the pixel for the map type associated with the specified position.
+				Returns the pixel for the map type associated with the specified position. Global position is descaled and floored to find the vertex grid coordinates.
 				Returns [code skip-lint]Color(NAN, NAN, NAN, NAN)[/code] if the position is outside of defined regions.
 			</description>
 		</method>
@@ -309,6 +307,15 @@
 			<description>
 				Returns the roughness modifier (wetness) on the color map alpha channel associated with the specified position.
 				Returns [code skip-lint]Color(NAN, NAN, NAN, NAN)[/code] if the position is outside of defined regions.
+			</description>
+		</method>
+		<method name="get_surface_height" qualifiers="const">
+			<return type="float" />
+			<param index="0" name="global_position" type="Vector3" />
+			<description>
+				Returns the rendered height at the requested global position. This method starts with the raw height in the region data returned by [method get_height]. It then mixes in the [code skip-lint]ground_level[/code] and [code skip-lint]region_blend[/code] values from the material if they exist. Next, if global_position is very close to a vertex the value is returned. Otherwise, this is repeated 3 more times and the final height value is interpolated. Thus it's 4x faster to snap your vertex to [member Terrain3D.vertex_spacing] before calling it. This function is used for collision, navigation baking, and instancer placement.
+				Returns [code skip-lint]NAN[/code] if the requested position is a hole or outside of defined regions.
+				Also see [method Terrain3D.get_raycast_result] and [method Terrain3D.get_intersection] for alternative functions.
 			</description>
 		</method>
 		<method name="get_texture_id" qualifiers="const">
@@ -533,8 +540,7 @@
 			<param index="0" name="global_position" type="Vector3" />
 			<param index="1" name="height" type="float" />
 			<description>
-				Sets the height value on the heightmap pixel associated with the specified position. See [method set_pixel] for important information.
-				Unlike [method get_height], which interpolates between vertices, this function does not and will set the pixel at floored coordinates.
+				Sets the height value on the heightmap at the specified position. See [method set_pixel] for important information. Also see [method get_height].
 			</description>
 		</method>
 		<method name="set_pixel">
@@ -543,7 +549,7 @@
 			<param index="1" name="global_position" type="Vector3" />
 			<param index="2" name="pixel" type="Color" />
 			<description>
-				Sets the pixel for the map type associated with the specified position. This method is fine for setting a few pixels, but if you wish to modify thousands of pixels quickly, you should get the region and use [method Terrain3DRegion.get_map], then edit the images directly.
+				Sets the pixel for the map type associated with the specified position. Global position is descaled and floored to find the vertex grid coordinates. This method is fine for setting a few pixels, but if you wish to modify thousands of pixels quickly, you should get the region and use [method Terrain3DRegion.get_map], then edit the images directly.
 				After setting pixels you need to call [method update_maps]. You may also need to regenerate collision if you don't have dynamic collision enabled.
 			</description>
 		</method>

--- a/doc/docs/games.md
+++ b/doc/docs/games.md
@@ -21,7 +21,7 @@ Terrain3D is being used in the following games. To add yours, submit all the lin
 | [Unaccessible](https://store.steampowered.com/app/3419670/Unaccessible/) | [Rembot Games](https://x.com/RembotGames) | 3rd person wheelchair platformer
 | [sunder](https://codeberg.org/sunder/sunder) | [anyreso](https://mastodon.gamedev.place/@anyreso) | A fast-paced free software shooter
 | [Crusator](https://store.steampowered.com/app/4052830/Crusator/) | [Crusator](https://x.com/CrusatorGame) | Twin-stick shooter
-
+| [Empyrean Defense](https://store.steampowered.com/app/3575690/Empyrean_Defense/) | [Nighthawk Studios](https://nighthawk-studios.com/games/) | Modern warfare tower defense game
 
 ## Demos
 

--- a/doc/docs/texture_prep.md
+++ b/doc/docs/texture_prep.md
@@ -4,7 +4,7 @@
 Terrain3D supports up to 32 texture sets using albedo, height, normal, and roughness textures, each set are channel packed into 2 files. This page describes everything you need to know to prepare your texture files. Continue on to [Texture Painting](texture_painting.md) to learn how to use them.
 
 **Table of Contents**
-* [Texture Requirements](#texture-requirements)
+* [Texture Requirements](#texture-format-requirements)
 * [Texture Content](#texture-content)
 * [Channel Pack Textures in Terrain3D](#channel-pack-textures-in-terrain3d)
 * [Channel Pack Textures with Gimp](#channel-pack-textures-with-gimp)
@@ -12,28 +12,31 @@ Terrain3D supports up to 32 texture sets using albedo, height, normal, and rough
 * [Frequently Asked Questions](#faq)
 
 
-## Texture Requirements
+## Texture Format Requirements
 
-### Texture Files
+### Texture Packing
 
-Typically "a texture" say rock comes as a pack of individual texture files: albedo/diffuse/base color, height, normal, smoothness/roughness, ambient occlusion (AO). For maximum efficiency we provide the option of packing these 5 separate files into 2.
+Typically "a texture" comes as a pack of individual texture map files: albedo/diffuse/base color, height/displacement, normal, smoothness/roughness, ambient occlusion (AO). For maximum efficiency we provide the option of packing these 5 separate files into 2 files, which we call a texture set.
 
-Terrain3D is designed for texture sets that are channel packed as follows:
+Terrain3D is designed for texture sets that are channel-packed as follows:
 
 | Name | Format |
 | - | - |
 | albedo_texture | RGB: Albedo, A: Height
-| normal_texture| RGB: Normal map ([OpenGL](#normal-map-format)), RGB: AO, A: Roughness
+| normal_texture| RGB: Normal map ([OpenGL](#normal-map-format)), RGB: [AO](#ambient-occlusion), A: [Roughness](#roughness-vs-smoothness)
 
-The terrain can work without the height, normal, ao, or roughness maps. But then you won't have height blending, roughness, or the other features. That may be fine for a low-poly or stylized terrain, but not for a realistic one.
+The terrain can work without height, normal, AO, or roughness textures, but then you won't have height blending, roughness, or other features. This may be fine for a low-poly or stylized terrain, but a realistic terrain should use all of the textures you have available.
 
-Textures can be channel packed using the `Pack Textures...` option in the Terrain3D menu at the top of the viewport (recommended), or in [Gimp](https://www.gimp.org/). Photoshop or [Krita](https://krita.org/) are possible, but working with alpha channels can be a bit challenging.
+Textures can be channel packed using the `Pack Textures...` option in the Terrain3D menu at the top of the viewport (recommended), or with professional texture authoring tools. [Gimp](https://www.gimp.org/), Photoshop, or [Krita](https://krita.org/) are possible, but working with alpha channels or baking AO can be challenging.
+
 
 ### Texture Sizes
 
-All albedo textures must be the same size, and all normal textures must be the same size. Each type gets combined into separate Texture2DArrays, so their sizes of the two arrays can differ.
+All albedo textures must be the same size, and all normal textures must be the same size. Each type gets combined into separate Texture2DArrays, so the texture sizes of the two arrays can differ.
 
-Double click any texture file and the inspector will show you the size. The demo textures are 1024x1024.
+Double-clicking a texture file in the FileSystem panel will display it in the Inspector and show the currently imported format, size, mipmaps and VRAM consumption. Settings may be adjustable on the Godot Import tab.
+
+The demo textures are 1024x1024.
 
 For GPU efficiency, it is recommended that all of your textures have dimensions that are a power of 2 (128, 256, 512, 1024, 2048, 4096, 8192), but this isn't required.
 
@@ -41,20 +44,20 @@ For GPU efficiency, it is recommended that all of your textures have dimensions 
 
 All albedo textures must be the same format, and all normal textures must be the same format. Albedo and Normals are combined into separate Texture2DArrays, so the two can have different formats.
 
-Double-clicking a texture in the FileSystem panel will display it in the Inspector with the current converted format of the file, size, and mipmaps. Settings may be adjustable on the Godot Import tab.
+Double-clicking a texture file in the FileSystem panel will display it in the Inspector and show the currently imported format, size, mipmaps and VRAM consumption. Settings may be adjustable on the Godot Import tab.
+
+The demo textures are PNG imported as HQ, which are converted to BPTC.
 
 | Type | Supports | Format |
 | - | - | - |
-| **PNG** | Desktop, Mobile | RGBA, converts to DXT5 or BPTC (HQ). In Godot you must go to the Import tab and select: `Mode: VRAM Compressed`, `Normal Map: Disabled`, `Mipmaps Generate: On`, optionally check `High Quality`, then reimport each file. 
-| **DDS** | Desktop | BC3 / DXT5, linear (intel plugin), Color + alpha, mipmaps generated. These files are used directly by Godot and are not converted, so there are no import settings.|
+| **PNG** | Desktop, Mobile | RGBA, converts to DXT5 or BPTC (HQ). In Godot, go to the Import tab and select: `Mode: VRAM Compressed`, `Normal Map: Disabled`, `Mipmaps Generate: On`, optionally check `High Quality`, then reimport each file. 
+| **DDS** | Desktop | BC3 / DXT5, linear (intel plugin), Color + alpha, mipmaps generated. These files are used directly by Godot and are not converted, so there are no import settings.
 | **Others** | | Other [Godot supported formats](https://docs.godotengine.org/en/stable/tutorials/assets_pipeline/importing_images.html#supported-image-formats) like KTX, TGA, JPG, WEBP should work as long as you match similar settings to PNG.
 | **EXR** | | While EXRs can work, they store color data as 16/32-bit float, not 8-bit integer. Don't use them for terrain textures unless you know what you're doing.
 
-To get the highest quality compression on desktop, use either:
-* Use PNG with the high quality option in Godot (BC6/BPTC). Pack with our channnel packer and mark HQ. Godot does not currently support importing anything higher than BC3/DXT5 in DDS files.
-* DDS (BC3/DXT5) made in Gimp are recommended over using the default PNG settings, which produces poor quality BC3/DXT5 files. When creating DDS files in Gimp you have a lot more conversion options, such as different mipmaps filtering algorithms which can be helpful to remove artifacts in reflections (eg try Mitchell). 
+The best recommendation right now for mobile or desktop is to pack textures with our channel packer, save as PNG, and set VRAM compressed, mipmaps, and HQ in the Godot import settings.
 
-The demo textures are PNG imported as HQ which are converted to BPTC.
+Notes on DDS files: Godot does not currently support importing anything higher than BC3/DXT5 in DDS files. If you use PNG with HQ set, Godot will convert it to BC6/BPTC. The standard PNG import converts to BC3/DXT5, however the compression algorithm isn't great. DDS (BC3/DXT5) files made in Gimp are much higher quality than the standard non-HQ PNG settings. When creating DDS files in Gimp you have a lot more conversion options, such as different mipmaps filtering algorithms which can be helpful to remove artifacts in reflections (eg try Mitchell). However packing in Gimp means no AO maps.
 
 You can create DDS files by:
   * Exporting directly from Gimp
@@ -63,11 +66,12 @@ You can create DDS files by:
 
 You can create KTX files with [Khronos' KTX tools](https://github.com/KhronosGroup/KTX-Software/releases).
 
+
 ## Texture Content
 
 ### Seamless Textures
 
-Make sure you have seamless textures that can be repeated without an obvious seam.
+Make sure your textures are seamless and can be repeated without an obvious seam.
 
 ### Height Textures
 
@@ -77,7 +81,7 @@ If creating your own height textures, aim for a central point of grey (0.5) with
 
 Normal maps come in two formats: DirectX with -Y, and OpenGL with +Y. Both formats should be normalized.
 
-DirectX can be converted to OpenGL and vice versa by inverting the green channel in a photo editing app, or within our texture packing tool.
+DirectX can be converted to OpenGL and vice versa by inverting the green channel in a photo editing app, or in our texture packing tool.
 
 They can often be identified visually by whether bumps appear to stick out (OpenGL) or appear pushed in (DirectX). The sphere and pyramid on the left in the image below are the clearest examples. 
 
@@ -85,7 +89,7 @@ They can often be identified visually by whether bumps appear to stick out (Open
 :target: ../_images/tex_normalmap.png
 ```
 
-Natural textures like rock or grass can be very difficult to tell. However if you get assets made for a certain engine like Unreal or Unity, you can generally assume their format and convert as needed. On occasion artists get it wrong though, so if the lighting looks off on your object, try inverting the normal map.
+Natural textures like rock or grass can be very difficult to tell. However if you get assets made for a certain engine like Unreal or Unity, you can generally assume their format and convert as needed. On occasion artists get it wrong though, so if the lighting looks off on your texture, try inverting the normal map.
 
 | Software | DirectX | OpenGL |
 |----------|---------|--------|
@@ -111,11 +115,11 @@ You can tell which is which just by looking at distinctive textures and thinking
 
 ### Ambient Occlusion
 
-Our built in texture packing tool allows you to easily combine AO texture maps into your normal texture set. This is done by a clever technique of expecting your normal map is normalized, then scaling the vector by the AO value.
+Our built in texture packing tool allows you to easily combine AO texture maps into your normal texture set using a clever technique. We expect the normals on your normal map to be normalized (typical), which means the magnitude of the normal vector can be scaled by the AO value.
 
-AO maps are not required for any texture. You can even mix and match on different textures, unlike with sizes or formats. If you haven't included an AO texture, AO will be approximated from the normal map.
+AO maps are not required for any texture. You can even mix and match AO or no AO on different textures, unlike with sizes or formats. If you haven't included an AO texture, AO will be approximated from the normal map.
 
-If you wish to apply AO to your textures manually or in another tool, ensure your normal map is normalized, then pack AO with: `unpacked_normal_vector * (sqrt(ao) * 0.5 + 0.5)`.
+If you wish to apply AO to your textures manually or in another tool, ensure your normal map is normalized, then bake in AO with: `unpacked_normal_vector * (sqrt(ao) * 0.5 + 0.5)`.
 
 
 ## Channel Pack Textures in Terrain3D
@@ -143,7 +147,7 @@ Make sure to reimport both files. Double click each file in the filesystem and e
 
 ## Channel Pack Textures with Gimp
 
-> Note: AO packing normals manually is complex and not reccomended. The formula used is: `unpacked_normal_vector * (sqrt(ao) * 0.5 + 0.5)`
+> Note: Packing AO into a normal map is optional and we currently don't have a process for Gimp. Use our channel packer to include AO maps.
 
 1. Open your RGB Albedo and greyscale Height files (or Normal and Roughness).
 
@@ -203,23 +207,23 @@ There are numerous websites where you can download high quality, royalty free te
 
 ### Why do we have to channel pack textures? Why is this so difficult?
 
-You don't have to. You can use just the albedo map, or also the normal map, without the others. However if you want a realistic terrain with height blending and roughness, you need all of the maps. You could have 5 different texture maps in memory, or pack that down to 2 maps and save precious VRAM.
+You don't have to pack your textures. You can use just the albedo map, or also just the normal map, without height, roughness, or AO. However if you want a realistic terrain with height blending and other features, you need all of the maps.
 
-Channel packing is a very common task done by professional game developers. Every pro asset pack you've used has channel packed textures. When you download texture packs from websites, they provide individual textures so you can pack them how you want. They are not intended to be used individually!
+Channel packing is a very common task done by professional game developers using every engine. Performing this process once, allows us to store the data for 5 raw texture maps in the space of only 2 textures, saving precious VRAM. Every pro asset pack you've used has channel packed textures for this reason. When you download texture packs from websites, they provide individual textures so you can pack them how you want. They are not intended to be used individually!
 
-We offer a built in `Pack Textures` tool, found in the Terrain3D menu at the top of the viewport that facilitates the texture creation process within Godot. Packing can be done in 30 seconds.
+We offer a built in `Pack Textures` tool, found in the Terrain3D menu at the top of the viewport that facilitates the texture creation process without leaving Godot. Packing a texture set can be done in 30 seconds.
 
 Finally, we provide easy, 5-step instructions for packing textures with Gimp, which takes less than 2 minutes once you're familiar with the process. 
 
-If we want high performance games, we need to optimize our games for graphics hardware. A shader can retrieve four channels RGBA from a texture at once. Albedo and normal textures only have RGB. Thus, reading Alpha is free, and a waste if not used. So, we put height / roughness in the Alpha channel.
+If we want high performance games, we need to optimize our games for graphics hardware. A shader can retrieve four RGBA channels from a texture at once. Albedo and Normal textures only use RGB. Thus, reading Alpha is free, and a waste if not used. So, we put height / roughness in the Alpha channel.
 
-We could have the software let you specify individual maps and we pack textures for you at startup, however that would mean processing up to 160 images every time any scene with Terrain3D loads, both in the editor and running games. Exported games may not even work since Godot's image compression libraries only exist in the editor. The most reasonable path is for gamedevs to learn a simple process that they'll use for their entire career and use it to set up terrain textures one time.
+We could have the software let you specify individual maps and we pack textures for you at startup, however that would mean processing up to 160 images every time any scene with Terrain3D loads, both in the editor and running games. Exported games may not even work since Godot's image compression libraries only exist in the editor. The most reasonable path is for gamedevs to learn a simple concept that they'll use for their entire career across all engines, and process their terrain textures one time.
 
 ### What about Emissive, Metal, and other texture maps?
 
 Most terrain textures like grass, rock, and dirt do not need these. 
 
-Occasional textures do need additional texture maps. Lava rock might need emissive, or rock with gold veins might need metallic, or some unique texture might need both. These are most likely only 1-2 textures out of the possible 32, so setting up these additional options for all textures is a waste of memory. You can add a [custom shader](tips_technical.md#add-a-custom-texture-map) to add the individual texture map.
+Occasional textures do need additional texture maps. Lava rock might need emissive, or rock with gold veins might need metallic, or some unique texture might need both. These are most likely only 1-2 textures out of the possible 32, so setting up these additional options for all textures is a waste of memory. However, you can [customize the shader](tips_technical.md#add-a-custom-texture-map) to add an individual texture map.
 
 ### Why not use Standard Godot materials?
 
@@ -227,12 +231,11 @@ All materials in Godot are just shaders. The standard shader is both overly comp
 
 ### What about displacement?
 
-Godot doesn't support texture displacement via tessellation or geometry shaders in the renderer. However, we provide the option of subdividing the terrain mesh, to allow textures to displace verteices. For further details see [Displacement](displacement.md).
+Godot doesn't support texture displacement via tessellation or geometry shaders in the renderer. However, we provide the option of subdividing the terrain mesh, to allow textures to displace vertices. For further details see [Displacement](displacement.md).
 
 Effects like depth parallax or occlusion mapping etc require many samples in fragment, which can be prohibitivley expensive when applied to already complex terrain shaders. There are [alternatives](https://github.com/TokisanGames/Terrain3D/issues/175) that might prove useful in the future.
 
 ### What about...
 
-We provide a base texture with the most commonly needed terrain options. Then we provide the option for a custom shader so you can explore `what about` on your own. Any of the options in the Godot StandardMaterial can be converted to a shader, and then you can insert that code into a custom shader. You could experiment with Godot's standard depth parallax technique, or any of the alternatives above. Or anything else you can imagine, like a sinewave that ripples the vertices outward for a VFX ground ripple effect, or ripples on a puddle ground texture.
-
+We provide a base shader with the most commonly needed terrain options. Then we provide the option for a custom shader so you can explore `what about` on your own. Any of the options in the Godot StandardMaterial can be converted to a shader, and then you can insert that code into a custom shader. You could experiment with Godot's standard depth parallax technique, any of the alternatives above, or anything else you can imagine such as a sinewave that ripples the vertices outward for a VFX ground ripple effect, or ripples on a puddle ground texture.
 

--- a/doc/docs/user_interface.md
+++ b/doc/docs/user_interface.md
@@ -36,7 +36,7 @@ After selecting the Terrain3D node, the Terrain3D menu appears at the top of the
 The Live Info Panel can be enabled from the Terrain3D menu. When active, it displays real‑time information about the terrain under your mouse cursor, at the center of your brush, including:
 
 * X, Z mouse position on the terrain
-* Height
+* Height (surface)
 * Slope angle
 * Texture data, such as:
   * Base texture index
@@ -48,7 +48,11 @@ The Live Info Panel can be enabled from the Terrain3D menu. When active, it disp
 :target: ../_images/ui_live_info_panel.png
 ```
 
+Notes:
+
 When the Region Tool is selected, the panel shows only the current region coordinates, and an approximate mouse position. Change to any other tool, and set brush size to zero for the most accurate information.
+
+Height may show two values, the first is the actual sculpted height stored in the region. The second, if it appears is the value from `Terrain3DData.get_surface_height()`. This is the rendered height used by collision, navigation, and instancer placement. It is modified by the `ground_level` and `region_blend` uniforms from the material and interpolates adjacent vertices.
 
 ---
 

--- a/project/addons/terrain_3d/csharp/Terrain3DData.cs
+++ b/project/addons/terrain_3d/csharp/Terrain3DData.cs
@@ -66,6 +66,12 @@ public partial class Terrain3DData : GodotObject
 		Minimum = 1,
 	}
 
+	public enum ExportMode
+	{
+		Slices = 0,
+		Regions = 1,
+	}
+
 	public new class GDExtensionSignalName : GodotObject.SignalName
 	{
 		/// <summary>
@@ -430,13 +436,17 @@ public partial class Terrain3DData : GodotObject
 		/// </summary>
 		public new static readonly StringName GetHeight = "get_height";
 		/// <summary>
-		/// Cached name for the 'set_color' member.
+		/// Cached name for the 'get_surface_height' member.
 		/// </summary>
-		public new static readonly StringName SetColor = "set_color";
+		public new static readonly StringName GetSurfaceHeight = "get_surface_height";
 		/// <summary>
-		/// Cached name for the 'get_color' member.
+		/// Cached name for the 'get_normal' member.
 		/// </summary>
-		public new static readonly StringName GetColor = "get_color";
+		public new static readonly StringName GetNormal = "get_normal";
+		/// <summary>
+		/// Cached name for the 'is_in_slope' member.
+		/// </summary>
+		public new static readonly StringName IsInSlope = "is_in_slope";
 		/// <summary>
 		/// Cached name for the 'set_control' member.
 		/// </summary>
@@ -445,14 +455,6 @@ public partial class Terrain3DData : GodotObject
 		/// Cached name for the 'get_control' member.
 		/// </summary>
 		public new static readonly StringName GetControl = "get_control";
-		/// <summary>
-		/// Cached name for the 'set_roughness' member.
-		/// </summary>
-		public new static readonly StringName SetRoughness = "set_roughness";
-		/// <summary>
-		/// Cached name for the 'get_roughness' member.
-		/// </summary>
-		public new static readonly StringName GetRoughness = "get_roughness";
 		/// <summary>
 		/// Cached name for the 'set_control_base_id' member.
 		/// </summary>
@@ -477,6 +479,10 @@ public partial class Terrain3DData : GodotObject
 		/// Cached name for the 'get_control_blend' member.
 		/// </summary>
 		public new static readonly StringName GetControlBlend = "get_control_blend";
+		/// <summary>
+		/// Cached name for the 'get_texture_id' member.
+		/// </summary>
+		public new static readonly StringName GetTextureId = "get_texture_id";
 		/// <summary>
 		/// Cached name for the 'set_control_angle' member.
 		/// </summary>
@@ -518,17 +524,21 @@ public partial class Terrain3DData : GodotObject
 		/// </summary>
 		public new static readonly StringName GetControlAuto = "get_control_auto";
 		/// <summary>
-		/// Cached name for the 'get_normal' member.
+		/// Cached name for the 'set_color' member.
 		/// </summary>
-		public new static readonly StringName GetNormal = "get_normal";
+		public new static readonly StringName SetColor = "set_color";
 		/// <summary>
-		/// Cached name for the 'is_in_slope' member.
+		/// Cached name for the 'get_color' member.
 		/// </summary>
-		public new static readonly StringName IsInSlope = "is_in_slope";
+		public new static readonly StringName GetColor = "get_color";
 		/// <summary>
-		/// Cached name for the 'get_texture_id' member.
+		/// Cached name for the 'set_roughness' member.
 		/// </summary>
-		public new static readonly StringName GetTextureId = "get_texture_id";
+		public new static readonly StringName SetRoughness = "set_roughness";
+		/// <summary>
+		/// Cached name for the 'get_roughness' member.
+		/// </summary>
+		public new static readonly StringName GetRoughness = "get_roughness";
 		/// <summary>
 		/// Cached name for the 'get_mesh_vertex' member.
 		/// </summary>
@@ -670,23 +680,20 @@ public partial class Terrain3DData : GodotObject
 	public new double GetHeight(Vector3 globalPosition) => 
 		Call(GDExtensionMethodName.GetHeight, [globalPosition]).As<double>();
 
-	public new void SetColor(Vector3 globalPosition, Color color) => 
-		Call(GDExtensionMethodName.SetColor, [globalPosition, color]);
+	public new double GetSurfaceHeight(Vector3 globalPosition) => 
+		Call(GDExtensionMethodName.GetSurfaceHeight, [globalPosition]).As<double>();
 
-	public new Color GetColor(Vector3 globalPosition) => 
-		Call(GDExtensionMethodName.GetColor, [globalPosition]).As<Color>();
+	public new Vector3 GetNormal(Vector3 globalPosition) => 
+		Call(GDExtensionMethodName.GetNormal, [globalPosition]).As<Vector3>();
+
+	public new bool IsInSlope(Vector3 globalPosition, Vector2 slopeRange, Vector3 normal = default) => 
+		Call(GDExtensionMethodName.IsInSlope, [globalPosition, slopeRange, normal]).As<bool>();
 
 	public new void SetControl(Vector3 globalPosition, long control) => 
 		Call(GDExtensionMethodName.SetControl, [globalPosition, control]);
 
 	public new long GetControl(Vector3 globalPosition) => 
 		Call(GDExtensionMethodName.GetControl, [globalPosition]).As<long>();
-
-	public new void SetRoughness(Vector3 globalPosition, double roughness) => 
-		Call(GDExtensionMethodName.SetRoughness, [globalPosition, roughness]);
-
-	public new double GetRoughness(Vector3 globalPosition) => 
-		Call(GDExtensionMethodName.GetRoughness, [globalPosition]).As<double>();
 
 	public new void SetControlBaseId(Vector3 globalPosition, long textureId) => 
 		Call(GDExtensionMethodName.SetControlBaseId, [globalPosition, textureId]);
@@ -705,6 +712,9 @@ public partial class Terrain3DData : GodotObject
 
 	public new double GetControlBlend(Vector3 globalPosition) => 
 		Call(GDExtensionMethodName.GetControlBlend, [globalPosition]).As<double>();
+
+	public new Vector3 GetTextureId(Vector3 globalPosition) => 
+		Call(GDExtensionMethodName.GetTextureId, [globalPosition]).As<Vector3>();
 
 	public new void SetControlAngle(Vector3 globalPosition, double degrees) => 
 		Call(GDExtensionMethodName.SetControlAngle, [globalPosition, degrees]);
@@ -736,14 +746,17 @@ public partial class Terrain3DData : GodotObject
 	public new bool GetControlAuto(Vector3 globalPosition) => 
 		Call(GDExtensionMethodName.GetControlAuto, [globalPosition]).As<bool>();
 
-	public new Vector3 GetNormal(Vector3 globalPosition) => 
-		Call(GDExtensionMethodName.GetNormal, [globalPosition]).As<Vector3>();
+	public new void SetColor(Vector3 globalPosition, Color color) => 
+		Call(GDExtensionMethodName.SetColor, [globalPosition, color]);
 
-	public new bool IsInSlope(Vector3 globalPosition, Vector2 slopeRange, Vector3 normal = default) => 
-		Call(GDExtensionMethodName.IsInSlope, [globalPosition, slopeRange, normal]).As<bool>();
+	public new Color GetColor(Vector3 globalPosition) => 
+		Call(GDExtensionMethodName.GetColor, [globalPosition]).As<Color>();
 
-	public new Vector3 GetTextureId(Vector3 globalPosition) => 
-		Call(GDExtensionMethodName.GetTextureId, [globalPosition]).As<Vector3>();
+	public new void SetRoughness(Vector3 globalPosition, double roughness) => 
+		Call(GDExtensionMethodName.SetRoughness, [globalPosition, roughness]);
+
+	public new double GetRoughness(Vector3 globalPosition) => 
+		Call(GDExtensionMethodName.GetRoughness, [globalPosition]).As<double>();
 
 	public new Vector3 GetMeshVertex(long lod, Terrain3DData.HeightFilter filter, Vector3 globalPosition) => 
 		Call(GDExtensionMethodName.GetMeshVertex, [lod, Variant.From(filter), globalPosition]).As<Vector3>();
@@ -757,11 +770,11 @@ public partial class Terrain3DData : GodotObject
 	public new void ImportImages(Godot.Collections.Array images, Vector3 globalPosition = default, double offset = 0, double scale = 1) => 
 		Call(GDExtensionMethodName.ImportImages, [images, globalPosition, offset, scale]);
 
-	public new Error ExportImage(string fileName, Terrain3DRegion.MapType mapType) => 
-		Call(GDExtensionMethodName.ExportImage, [fileName, Variant.From(mapType)]).As<Error>();
+	public new Error ExportImage(string fileName, Terrain3DRegion.MapType mapType = Terrain3DRegion.MapType.Height, Terrain3DData.ExportMode mode = Terrain3DData.ExportMode.Slices) => 
+		Call(GDExtensionMethodName.ExportImage, [fileName, Variant.From(mapType), Variant.From(mode)]).As<Error>();
 
-	public new Image LayeredToImage(Terrain3DRegion.MapType mapType) => 
-		Call(GDExtensionMethodName.LayeredToImage, [Variant.From(mapType)]).As<Image>();
+	public new Image LayeredToImage(Terrain3DRegion.MapType mapType, Rect2I bounds = default) => 
+		Call(GDExtensionMethodName.LayeredToImage, [Variant.From(mapType), bounds]).As<Image>();
 
 	public new void Dump(bool verbose = false) => 
 		Call(GDExtensionMethodName.Dump, [verbose]);
@@ -777,5 +790,17 @@ public static int SafeAsInt32(this Terrain3DData.HeightFilter enumValue, int def
 Convert.ToInt32(enumValue);
 
 public static int SafeAsInt32(this Terrain3DData.HeightFilter? enumValue, int defaultValue = 0) =>
+enumValue.HasValue ? Convert.ToInt32(enumValue.Value) : defaultValue;
+}
+
+file static class ExportModeExtensions
+{
+public static int SafeAsInt32(this Terrain3DData.ExportMode enumValue) =>
+Convert.ToInt32(enumValue);
+
+public static int SafeAsInt32(this Terrain3DData.ExportMode enumValue, int defaultValue) =>
+Convert.ToInt32(enumValue);
+
+public static int SafeAsInt32(this Terrain3DData.ExportMode? enumValue, int defaultValue = 0) =>
 enumValue.HasValue ? Convert.ToInt32(enumValue.Value) : defaultValue;
 }

--- a/project/addons/terrain_3d/csharp/Terrain3DMaterial.cs
+++ b/project/addons/terrain_3d/csharp/Terrain3DMaterial.cs
@@ -67,6 +67,15 @@ public partial class Terrain3DMaterial : Resource
 		Noise = 2,
 	}
 
+	public enum RegionMaximum
+	{
+		MaxRegions64 = 64,
+		MaxRegions128 = 128,
+		MaxRegions256 = 256,
+		MaxRegions512 = 512,
+		MaxRegions1024 = 1024,
+	}
+
 	public enum TextureFilteringEnum
 	{
 		LinearAnisotropic = 0,
@@ -114,6 +123,10 @@ public partial class Terrain3DMaterial : Resource
 		/// Cached name for the 'projection_enabled' member.
 		/// </summary>
 		public new static readonly StringName ProjectionEnabled = "projection_enabled";
+		/// <summary>
+		/// Cached name for the 'max_regions' member.
+		/// </summary>
+		public new static readonly StringName MaxRegions = "max_regions";
 		/// <summary>
 		/// Cached name for the 'output_albedo' member.
 		/// </summary>
@@ -223,6 +236,10 @@ public partial class Terrain3DMaterial : Resource
 		/// </summary>
 		public new static readonly StringName ShowRoughmap = "show_roughmap";
 		/// <summary>
+		/// Cached name for the 'show_displacement_buffer' member.
+		/// </summary>
+		public new static readonly StringName ShowDisplacementBuffer = "show_displacement_buffer";
+		/// <summary>
 		/// Cached name for the 'show_texture_albedo' member.
 		/// </summary>
 		public new static readonly StringName ShowTextureAlbedo = "show_texture_albedo";
@@ -235,17 +252,13 @@ public partial class Terrain3DMaterial : Resource
 		/// </summary>
 		public new static readonly StringName ShowTextureNormal = "show_texture_normal";
 		/// <summary>
-		/// Cached name for the 'show_texture_ao' member.
-		/// </summary>
-		public new static readonly StringName ShowTextureAo = "show_texture_ao";
-		/// <summary>
 		/// Cached name for the 'show_texture_rough' member.
 		/// </summary>
 		public new static readonly StringName ShowTextureRough = "show_texture_rough";
 		/// <summary>
-		/// Cached name for the 'show_displacement_buffer' member.
+		/// Cached name for the 'show_texture_ao' member.
 		/// </summary>
-		public new static readonly StringName ShowDisplacementBuffer = "show_displacement_buffer";
+		public new static readonly StringName ShowTextureAo = "show_texture_ao";
 	}
 
 	public new Terrain3DMaterial.WorldBackgroundEnum WorldBackground
@@ -282,6 +295,12 @@ public partial class Terrain3DMaterial : Resource
 	{
 		get => Get(GDExtensionPropertyName.ProjectionEnabled).As<bool>();
 		set => Set(GDExtensionPropertyName.ProjectionEnabled, value);
+	}
+
+	public new Terrain3DMaterial.RegionMaximum MaxRegions
+	{
+		get => Get(GDExtensionPropertyName.MaxRegions).As<Terrain3DMaterial.RegionMaximum>();
+		set => Set(GDExtensionPropertyName.MaxRegions, Variant.From(value));
 	}
 
 	public new bool OutputAlbedo
@@ -446,6 +465,12 @@ public partial class Terrain3DMaterial : Resource
 		set => Set(GDExtensionPropertyName.ShowRoughmap, value);
 	}
 
+	public new bool ShowDisplacementBuffer
+	{
+		get => Get(GDExtensionPropertyName.ShowDisplacementBuffer).As<bool>();
+		set => Set(GDExtensionPropertyName.ShowDisplacementBuffer, value);
+	}
+
 	public new bool ShowTextureAlbedo
 	{
 		get => Get(GDExtensionPropertyName.ShowTextureAlbedo).As<bool>();
@@ -464,22 +489,16 @@ public partial class Terrain3DMaterial : Resource
 		set => Set(GDExtensionPropertyName.ShowTextureNormal, value);
 	}
 
-	public new bool ShowTextureAo
-	{
-		get => Get(GDExtensionPropertyName.ShowTextureAo).As<bool>();
-		set => Set(GDExtensionPropertyName.ShowTextureAo, value);
-	}
-
 	public new bool ShowTextureRough
 	{
 		get => Get(GDExtensionPropertyName.ShowTextureRough).As<bool>();
 		set => Set(GDExtensionPropertyName.ShowTextureRough, value);
 	}
 
-	public new bool ShowDisplacementBuffer
+	public new bool ShowTextureAo
 	{
-		get => Get(GDExtensionPropertyName.ShowDisplacementBuffer).As<bool>();
-		set => Set(GDExtensionPropertyName.ShowDisplacementBuffer, value);
+		get => Get(GDExtensionPropertyName.ShowTextureAo).As<bool>();
+		set => Set(GDExtensionPropertyName.ShowTextureAo, value);
 	}
 
 	public new class GDExtensionMethodName : Resource.MethodName
@@ -553,6 +572,18 @@ public static int SafeAsInt32(this Terrain3DMaterial.WorldBackgroundEnum enumVal
 Convert.ToInt32(enumValue);
 
 public static int SafeAsInt32(this Terrain3DMaterial.WorldBackgroundEnum? enumValue, int defaultValue = 0) =>
+enumValue.HasValue ? Convert.ToInt32(enumValue.Value) : defaultValue;
+}
+
+file static class RegionMaximumExtensions
+{
+public static int SafeAsInt32(this Terrain3DMaterial.RegionMaximum enumValue) =>
+Convert.ToInt32(enumValue);
+
+public static int SafeAsInt32(this Terrain3DMaterial.RegionMaximum enumValue, int defaultValue) =>
+Convert.ToInt32(enumValue);
+
+public static int SafeAsInt32(this Terrain3DMaterial.RegionMaximum? enumValue, int defaultValue = 0) =>
 enumValue.HasValue ? Convert.ToInt32(enumValue.Value) : defaultValue;
 }
 

--- a/project/addons/terrain_3d/extras/3rd_party/project_on_terrain3d.gd
+++ b/project/addons/terrain_3d/extras/3rd_party/project_on_terrain3d.gd
@@ -94,7 +94,7 @@
 		#var t: Transform3D = transforms.list[i]
 		#
 		#var location: Vector3 = (gt * t).origin
-		#var height: float = _terrain.data.get_height(location)		
+		#var height: float = _terrain.data.get_surface_height(location)
 		#if is_nan(height):
 			#continue
 		#

--- a/project/addons/terrain_3d/extras/particle_example/terrain_3D_particles.gd
+++ b/project/addons/terrain_3d/extras/particle_example/terrain_3D_particles.gd
@@ -220,8 +220,9 @@ func _update_process_parameters() -> void:
 		var process_rid: RID = process_material.get_rid()
 		if terrain and process_rid.is_valid():
 			RenderingServer.material_set_param(process_rid, "_background_mode", terrain.material.world_background)
-			if terrain.material.world_background > 0:
+			if "ground_level" in terrain.material:
 				RenderingServer.material_set_param(process_rid, "ground_level", terrain.material.ground_level)
+			if "region_blend" in terrain.material:
 				RenderingServer.material_set_param(process_rid, "region_blend", terrain.material.region_blend)
 			RenderingServer.material_set_param(process_rid, "_vertex_spacing", terrain.vertex_spacing)
 			RenderingServer.material_set_param(process_rid, "_vertex_density", 1.0 / terrain.vertex_spacing)

--- a/project/addons/terrain_3d/src/live_info_panel.gd
+++ b/project/addons/terrain_3d/src/live_info_panel.gd
@@ -33,7 +33,8 @@ func update(cursor_position: Vector3) -> void:
 		lbl_text += "Slope: -\n"
 		lbl_text += "Texture: -"
 	else:
-		lbl_text += "Height: %0.2f\n" % plugin.terrain.data.get_height(cursor_position)
+		var heights := Vector2(plugin.terrain.data.get_height(cursor_position), plugin.terrain.data.get_surface_height(cursor_position))
+		lbl_text += "Height: %0.2f" % heights.x + ( " (%.2f)\n" % heights.y if abs(heights.x - heights.y) > .1 else "\n" )
 		lbl_text += "Slope: %0.1f°\n" % slope
 		var texture_id: Vector3 = plugin.terrain.data.get_texture_id(cursor_position)
 		var auto: String = "Auto" if plugin.terrain.data.get_control_auto(cursor_position) else "-"

--- a/project/addons/terrain_3d/src/tool_settings.gd
+++ b/project/addons/terrain_3d/src/tool_settings.gd
@@ -165,8 +165,8 @@ func _ready() -> void:
 	collision_list = create_submenu(main_list, "Collision", Layout.VERTICAL)
 	add_setting({ "name":"on_collision", "label":"On Collision", "type":SettingType.CHECKBOX, "list":collision_list,
 							"default":true })
-	add_setting({ "name":"raycast_height", "label":"Raycast Height", "type":SettingType.SLIDER, 
-							"list":collision_list, "default":10, "unit":"m", "range":Vector3(0, 200, .25) })
+	add_setting({ "name":"raycast_height", "label":"Raycast Height", "type":SettingType.SLIDER, "list":collision_list,
+							"default":10, "unit":"m", "range":Vector3(0, 200, .25), "flags":ALLOW_LARGER })
 
 	if DisplayServer.is_touchscreen_available():
 		add_setting({ "name":"invert", "label":"Invert", "type":SettingType.CHECKBOX, "list":main_list, "default":false, "flags":ADD_SEPARATOR })

--- a/project/addons/terrain_3d/tools/importer.gd
+++ b/project/addons/terrain_3d/tools/importer.gd
@@ -16,7 +16,7 @@ func reset_settings() -> void:
 	destination_directory = ""
 	import_position = Vector2i.ZERO
 	height_offset = 0.0
-	import_scale = 1.0
+	height_scale = 1.0
 	r16_range = Vector2(0, 1)
 	r16_size = Vector2i(1024, 1024)
 	material = null
@@ -47,7 +47,7 @@ func update_heights() -> void:
 ## The top left (-X, -Y) corner position of where to place the imported data. Positions are descaled and ignore the vertex_spacing setting.
 @export var import_position: Vector2i = Vector2i(0, 0) : set = set_import_position
 ## This scales the height of imported values.
-@export var import_scale: float = 1.0
+@export var height_scale: float = 1.0
 ## This vertically offsets the height of imported values.
 @export var height_offset: float = 0.0
 ## The lowest and highest height values of the imported image. Only use for r16 files.
@@ -71,13 +71,22 @@ func set_r16_size(p_value: Vector2i) -> void:
 
 
 func start_import() -> void:
-	print("Terrain3DImporter: Importing files:\n\t%s\n\t%s\n\t%s" % [ height_file_name, control_file_name, color_file_name])
+	print("Terrain3DImporter: Importing files:")
+	var output_names: String = ""
+	for str: String in [ height_file_name, control_file_name, color_file_name]:
+		if not str.is_empty():
+			output_names += "\t" + str + "\n" 
+	print(output_names)
 
 	var imported_images: Array[Image]
 	imported_images.resize(Terrain3DRegion.TYPE_MAX)
 	var min_max := Vector2(0, 1)
 	var img: Image
 	if height_file_name:
+		if height_file_name.get_extension() == "png":
+			push_warning("Terrain3DImporter: 16-bit height map PNGs aren't supported by Godot. All PNGs are read as 8-bit.")
+		if  height_file_name.get_extension() in [ "png", "jpg" ]:
+			push_warning("Terrain3DImporter: 8-bit height map detected. Heights will be terraced. Use a 16-bit data source and file type for smooth heights.")			
 		img = Terrain3DUtil.load_image(height_file_name, ResourceLoader.CACHE_MODE_IGNORE, r16_range, r16_size)
 		min_max = Terrain3DUtil.get_min_max(img)
 		imported_images[Terrain3DRegion.TYPE_HEIGHT] = img
@@ -91,7 +100,7 @@ func start_import() -> void:
 			material.show_checkered = false
 			material.show_colormap = true
 	var pos := Vector3(import_position.x * vertex_spacing, 0, import_position.y * vertex_spacing)
-	data.import_images(imported_images, pos, height_offset, import_scale)
+	data.import_images(imported_images, pos, height_offset, height_scale)
 	print("Terrain3DImporter: Import finished")
 
 

--- a/project/addons/terrain_3d/utils/terrain_3d_objects.gd
+++ b/project/addons/terrain_3d/utils/terrain_3d_objects.gd
@@ -60,7 +60,7 @@ func _get_terrain_height(p_global_position: Vector3) -> float:
 	var terrain: Terrain3D = get_terrain()
 	if not terrain or not terrain.data:
 		return 0.0
-	var height: float = terrain.data.get_height(p_global_position)
+	var height: float = terrain.data.get_surface_height(p_global_position)
 	if is_nan(height):
 		return 0.0
 	return height

--- a/project/demo/src/Enemy.gd
+++ b/project/demo/src/Enemy.gd
@@ -47,7 +47,7 @@ func _physics_process(p_delta: float) -> void:
 
 	# Ensure enemy doesn't fall through terrain when collision absent
 	if get_parent().terrain:
-		var height: float = get_parent().terrain.data.get_height(global_position)
+		var height: float = get_parent().terrain.data.get_surface_height(global_position)
 		if not is_nan(height):
 			global_position.y = maxf(global_position.y, height)
 

--- a/src/terrain_3d.cpp
+++ b/src/terrain_3d.cpp
@@ -387,15 +387,20 @@ void Terrain3D::_generate_triangles(PackedVector3Array &p_vertices, PackedVector
 			}
 		}
 	} else {
-		// Bake within an AABB, e.g. runtime navigation baker
-		int32_t z_start = (int32_t)Math::ceil(p_global_aabb.position.z / _vertex_spacing);
-		int32_t z_end = (int32_t)Math::floor(p_global_aabb.get_end().z / _vertex_spacing) + 1;
-		int32_t x_start = (int32_t)Math::ceil(p_global_aabb.position.x / _vertex_spacing);
-		int32_t x_end = (int32_t)Math::floor(p_global_aabb.get_end().x / _vertex_spacing) + 1;
+		// Bake within an AABB
+		const real_t vs = _vertex_spacing;
+		const int32_t start_x = int32_t(Math::ceil(p_global_aabb.position.x / vs));
+		const int32_t start_z = int32_t(Math::ceil(p_global_aabb.position.z / vs));
+		const int32_t end_x = int32_t(Math::floor(p_global_aabb.get_end().x / vs)) + 1;
+		const int32_t end_z = int32_t(Math::floor(p_global_aabb.get_end().z / vs)) + 1;
 
-		for (int32_t z = z_start; z < z_end; ++z) {
-			for (int32_t x = x_start; x < x_end; ++x) {
-				real_t height = _data->get_height(Vector3(x, 0.f, z));
+		for (int32_t z = start_z; z < end_z; ++z) {
+			for (int32_t x = start_x; x < end_x; ++x) {
+				const real_t height = _data->get_modified_height(Vector2i(x, z));
+				if (std::isnan(height)) {
+					continue;
+				}
+
 				if (height >= p_global_aabb.position.y && height <= p_global_aabb.get_end().y) {
 					_generate_triangle_pair(p_vertices, p_uvs, p_lod, p_filter, p_require_nav, x, z);
 				}
@@ -415,55 +420,69 @@ void Terrain3D::_generate_triangles(PackedVector3Array &p_vertices, PackedVector
 void Terrain3D::_generate_triangle_pair(PackedVector3Array &p_vertices, PackedVector2Array *p_uvs,
 		const int32_t p_lod, const Terrain3DData::HeightFilter p_filter, const bool p_require_nav,
 		const int32_t x, const int32_t z) const {
-	int32_t step = 1 << CLAMP(p_lod, 0, 8);
-	Vector3 xz = Vector3(x, 0.0f, z) * _vertex_spacing;
-	Vector3 xsz = Vector3(x + step, 0.0f, z) * _vertex_spacing;
-	Vector3 xzs = Vector3(x, 0.0f, z + step) * _vertex_spacing;
-	Vector3 xszs = Vector3(x + step, 0.0f, z + step) * _vertex_spacing;
-	Vector3 v1 = _data->get_mesh_vertex(p_lod, p_filter, xz);
-	bool nan1 = std::isnan(v1.y);
-	if (nan1) {
+	const int32_t step = 1 << CLAMP(p_lod, 0, 8);
+	const Vector2i v1g(x, z);
+	const Vector2i v2g(x + step, z);
+	const Vector2i v3g(x, z + step);
+	const Vector2i v4g(x + step, z + step);
+	real_t h1 = _data->get_mesh_vertex_height(p_lod, p_filter, v1g);
+	if (std::isnan(h1)) {
 		return;
 	}
-	Vector3 v2 = _data->get_mesh_vertex(p_lod, p_filter, xsz);
-	Vector3 v3 = _data->get_mesh_vertex(p_lod, p_filter, xzs);
-	Vector3 v4 = _data->get_mesh_vertex(p_lod, p_filter, xszs);
-	bool nan2 = std::isnan(v2.y);
-	bool nan3 = std::isnan(v3.y);
-	bool nan4 = std::isnan(v4.y);
+	real_t h2 = _data->get_mesh_vertex_height(p_lod, p_filter, v2g);
+	real_t h3 = _data->get_mesh_vertex_height(p_lod, p_filter, v3g);
+	real_t h4 = _data->get_mesh_vertex_height(p_lod, p_filter, v4g);
+	bool nan2 = std::isnan(h2);
+	bool nan3 = std::isnan(h3);
+	bool nan4 = std::isnan(h4);
 	// If on the region edge, duplicate the edge pixels
 	// Check #2 upper right
 	if (nan2) {
-		v2.y = v1.y;
+		h2 = h1;
 	}
 	// Check #3 lower left
 	if (nan3) {
-		v3.y = v1.y;
+		h3 = h1;
 	}
 	// Check #4 lower right
 	if (nan4) {
 		if (!nan2) {
-			v4.y = v2.y;
+			h4 = h2;
 		} else if (!nan3) {
-			v4.y = v3.y;
+			h4 = h3;
 		} else {
-			v4.y = v1.y;
+			h4 = h1;
 		}
 	}
-	uint32_t ctrl1 = _data->get_control(xz);
-	uint32_t ctrl2 = _data->get_control(xsz);
-	uint32_t ctrl3 = _data->get_control(xzs);
-	uint32_t ctrl4 = _data->get_control(xszs);
+
+	// Get control pixels
+	real_t val = _data->get_pixel_descaled(TYPE_CONTROL, v1g).r;
+	uint32_t ctrl1 = (std::isnan(val)) ? UINT32_MAX : as_uint(val);
+	val = _data->get_pixel_descaled(TYPE_CONTROL, v2g).r;
+	uint32_t ctrl2 = (std::isnan(val)) ? UINT32_MAX : as_uint(val);
+	val = _data->get_pixel_descaled(TYPE_CONTROL, v3g).r;
+	uint32_t ctrl3 = (std::isnan(val)) ? UINT32_MAX : as_uint(val);
+	val = _data->get_pixel_descaled(TYPE_CONTROL, v4g).r;
+	uint32_t ctrl4 = (std::isnan(val)) ? UINT32_MAX : as_uint(val);
+
 	// Holes are only where the control map is valid and the bit is set
 	bool hole1 = ctrl1 != UINT32_MAX && is_hole(ctrl1);
 	bool hole2 = ctrl2 != UINT32_MAX && is_hole(ctrl2);
 	bool hole3 = ctrl3 != UINT32_MAX && is_hole(ctrl3);
 	bool hole4 = ctrl4 != UINT32_MAX && is_hole(ctrl4);
+
 	// Navigation is where the control map is valid and the bit is set, or it's the region edge and nav1 is set
-	bool nav1 = ctrl1 != UINT32_MAX && is_nav(ctrl1);
-	bool nav2 = ctrl2 != UINT32_MAX && is_nav(ctrl2) || nan2 && nav1;
-	bool nav3 = ctrl3 != UINT32_MAX && is_nav(ctrl3) || nan3 && nav1;
-	bool nav4 = ctrl4 != UINT32_MAX && is_nav(ctrl4) || nan4 && nav1;
+	bool nav1 = (ctrl1 != UINT32_MAX && is_nav(ctrl1));
+	bool nav2 = (ctrl2 != UINT32_MAX && is_nav(ctrl2)) || (nan2 && nav1);
+	bool nav3 = (ctrl3 != UINT32_MAX && is_nav(ctrl3)) || (nan3 && nav1);
+	bool nav4 = (ctrl4 != UINT32_MAX && is_nav(ctrl4)) || (nan4 && nav1);
+
+	const real_t vs = _vertex_spacing;
+	Vector3 v1(v1g.x * vs, h1, v1g.y * vs);
+	Vector3 v2(v2g.x * vs, h2, v2g.y * vs);
+	Vector3 v3(v3g.x * vs, h3, v3g.y * vs);
+	Vector3 v4(v4g.x * vs, h4, v4g.y * vs);
+
 	//Bottom 143 triangle
 	if (!(hole1 || hole4 || hole3) && (!p_require_nav || (nav1 && nav4 && nav3))) {
 		p_vertices.push_back(v1);
@@ -630,7 +649,7 @@ void Terrain3D::update_region_labels() {
 			label->set_visibility_range_fade_mode(GeometryInstance3D::VISIBILITY_RANGE_FADE_SELF);
 			_label_parent->add_child(label, true);
 			Vector3 pos = Vector3(real_t(region_loc.x) + .5f, 0.f, real_t(region_loc.y) + .5f) * _region_size * _vertex_spacing;
-			real_t height = _data->get_height(pos);
+			real_t height = _data->get_surface_height(pos);
 			pos.y = (std::isnan(height)) ? 0.f : height;
 			label->set_position(pos);
 		}
@@ -941,7 +960,7 @@ Vector3 Terrain3D::get_intersection(const Vector3 &p_src_pos, const Vector3 &p_d
 	Vector3 direction = p_direction.normalized();
 	// If looking straight down in a region, use get_height
 	if (direction.y < -.99999f) {
-		real_t height = _data->get_height(p_src_pos);
+		real_t height = _data->get_surface_height(p_src_pos);
 		if (std ::isfinite(height)) {
 			return Vector3(p_src_pos.x, height, p_src_pos.z);
 		}
@@ -950,14 +969,14 @@ Vector3 Terrain3D::get_intersection(const Vector3 &p_src_pos, const Vector3 &p_d
 	// Raymarching mode
 	if (!p_gpu_mode) {
 		// Must start above terrain if in a region
-		real_t height = _data->get_height(p_src_pos);
+		real_t height = _data->get_surface_height(p_src_pos);
 		if (height > p_src_pos.y) { // False if Nan
 			return V3_MAX;
 		}
 		// Raymarch down the ray in small increments until we find the terrain height
 		Vector3 point = p_src_pos;
 		for (int i = 0; i < 4000; i++) {
-			height = _data->get_height(point);
+			height = _data->get_surface_height(point);
 			if (point.y - height <= 0.f) { // Nan comparison is false, which continues loop
 				return point;
 			}

--- a/src/terrain_3d_collision.cpp
+++ b/src/terrain_3d_collision.cpp
@@ -23,84 +23,19 @@ Dictionary Terrain3DCollision::_get_shape_data(const Vector2i &p_position, const
 	IS_DATA_INIT_MESG("Terrain not initialized", Dictionary());
 	const Terrain3DData *data = _terrain->get_data();
 
-	const Ref<Terrain3DMaterial> material = _terrain->get_material();
-	if (!material.is_valid()) {
+	// Get region_loc of top left corner of descaled and grid snapped collision shape position
+	Vector2i region_loc = V2I_DIVIDE_FLOOR(p_position, _terrain->get_region_size());
+	const Terrain3DRegion *region = data->get_region_ptr(region_loc);
+	if (!region || region->is_deleted()) {
+		LOG(EXTREME, "Region not found at: ", region_loc, ". Returning blank");
 		return Dictionary();
 	}
-	const Terrain3DMaterial::WorldBackground bg_mode = material->get_world_background();
-	const bool is_bg_flat_or_noise = bg_mode == Terrain3DMaterial::WorldBackground::FLAT || bg_mode == Terrain3DMaterial::WorldBackground::NOISE;
-	const real_t ground_level = material->get("ground_level");
-	const real_t region_blend = material->get("region_blend");
-	const int region_map_size = Terrain3DData::REGION_MAP_SIZE;
-	const PackedInt32Array region_map = data->get_region_map();
-	const int region_size = _terrain->get_region_size();
-	const real_t region_texel_size = 1.f / real_t(region_size);
-
-	auto check_region = [&](const Vector2 &uv2) -> real_t {
-		Vector2i pos = Vector2i(Math::floor(uv2.x), Math::floor(uv2.y)) + Vector2i(region_map_size / 2, region_map_size / 2);
-		int layer_index = 0;
-		if ((uint32_t)(pos.x | pos.y) < (uint32_t)region_map_size) {
-			int v = region_map[pos.y * region_map_size + pos.x];
-			layer_index = Math::clamp(v - 1, -1, 0) + 1;
-		}
-		return real_t(layer_index);
-	};
-
-	auto get_region_blend = [&](Vector2 uv2) -> real_t {
-		// Floating point bias (must match shader)
-		uv2 -= Vector2(0.5011f, 0.5011f);
-
-		real_t a = check_region(uv2 + Vector2(0.0f, 1.0f));
-		real_t b = check_region(uv2 + Vector2(1.0f, 1.0f));
-		real_t c = check_region(uv2 + Vector2(1.0f, 0.0f));
-		real_t d = check_region(uv2 + Vector2(0.0f, 0.0f));
-
-		real_t blend_factor = 2.0f + 126.0f * (1.0f - region_blend);
-		Vector2 f = Vector2(uv2.x - Math::floor(uv2.x), uv2.y - Math::floor(uv2.y));
-		f.x = Math::clamp(f.x, real_t(1e-8f), real_t(1.0f - 1e-8f));
-		f.y = Math::clamp(f.y, real_t(1e-8f), real_t(1.0f - 1e-8f));
-		Vector2 w = Vector2(1.f / (1.f + Math::exp(blend_factor * Math::log((1.f - f.x) / f.x))),
-				1.f / (1.f + Math::exp(blend_factor * Math::log((1.f - f.y) / f.y))));
-		real_t blend = Math::lerp(Math::lerp(d, c, w.x), Math::lerp(a, b, w.x), w.y);
-
-		return (1.f - blend) * 2.f;
-	};
 
 	int hshape_size = p_size + 1; // Calculate last vertex at end
 	PackedRealArray map_data = PackedRealArray();
 	map_data.resize(hshape_size * hshape_size);
 	real_t min_height = FLT_MAX;
 	real_t max_height = -FLT_MAX;
-
-	Ref<Image> map, map_x, map_z, map_xz; // height maps
-	Ref<Image> cmap, cmap_x, cmap_z, cmap_xz; // control maps w/ holes
-
-	// Get region_loc of top left corner of descaled and grid snapped collision shape position
-	Vector2i region_loc = V2I_DIVIDE_FLOOR(p_position, region_size);
-	const Terrain3DRegion *region = data->get_region_ptr(region_loc);
-	if (!region || region->is_deleted()) {
-		LOG(EXTREME, "Region not found at: ", region_loc, ". Returning blank");
-		return Dictionary();
-	}
-	map = region->get_map(TYPE_HEIGHT);
-	cmap = region->get_map(TYPE_CONTROL);
-
-	// Get +X, +Z adjacent regions in case we run over
-	region = data->get_region_ptr(region_loc + Vector2i(1, 0));
-	if (region && !region->is_deleted()) {
-		map_x = region->get_map(TYPE_HEIGHT);
-		cmap_x = region->get_map(TYPE_CONTROL);
-	}
-	region = data->get_region_ptr(region_loc + Vector2i(0, 1));
-	if (region && !region->is_deleted()) {
-		map_z = region->get_map(TYPE_HEIGHT);
-		cmap_z = region->get_map(TYPE_CONTROL);
-	}
-	region = data->get_region_ptr(region_loc + Vector2i(1, 1));
-	if (region && !region->is_deleted()) {
-		map_xz = region->get_map(TYPE_HEIGHT);
-		cmap_xz = region->get_map(TYPE_CONTROL);
-	}
 
 	for (int z = 0; z < hshape_size; z++) {
 		for (int x = 0; x < hshape_size; x++) {
@@ -112,27 +47,7 @@ Dictionary Terrain3DCollision::_get_shape_data(const Vector2i &p_position, const
 			int index = hshape_size - 1 - z + x * hshape_size;
 
 			Vector2i shape_pos = p_position + Vector2i(x, z);
-			Vector2i shape_region_loc = V2I_DIVIDE_FLOOR(shape_pos, region_size);
-			int img_x = Math::posmod(shape_pos.x, region_size);
-			bool next_x = shape_region_loc.x > region_loc.x;
-			int img_y = Math::posmod(shape_pos.y, region_size);
-			bool next_z = shape_region_loc.y > region_loc.y;
-
-			// Set heights on local map, or adjacent maps if on the last row/col
-			real_t height = NAN;
-			if (!next_x && !next_z && map.is_valid()) {
-				height = is_hole(cmap->get_pixel(img_x, img_y).r) ? NAN : map->get_pixel(img_x, img_y).r;
-			} else if (next_x && !next_z && map_x.is_valid()) {
-				height = is_hole(cmap_x->get_pixel(img_x, img_y).r) ? NAN : map_x->get_pixel(img_x, img_y).r;
-			} else if (!next_x && next_z && map_z.is_valid()) {
-				height = is_hole(cmap_z->get_pixel(img_x, img_y).r) ? NAN : map_z->get_pixel(img_x, img_y).r;
-			} else if (next_x && next_z && map_xz.is_valid()) {
-				height = is_hole(cmap_xz->get_pixel(img_x, img_y).r) ? NAN : map_xz->get_pixel(img_x, img_y).r;
-			}
-			if (!std::isnan(height) && is_bg_flat_or_noise) {
-				Vector2 uv2 = Vector2(shape_pos) * region_texel_size;
-				height = Math::lerp(height, ground_level, smoothstep(0.f, 1.f, get_region_blend(uv2)));
-			}
+			real_t height = data->get_height(Vector3(shape_pos.x, 0., shape_pos.y) * _terrain->get_vertex_spacing());
 			map_data[index] = height;
 			if (!std::isnan(height)) {
 				min_height = MIN(min_height, height);

--- a/src/terrain_3d_collision.cpp
+++ b/src/terrain_3d_collision.cpp
@@ -45,9 +45,7 @@ Dictionary Terrain3DCollision::_get_shape_data(const Vector2i &p_position, const
 			// int index = z * hshape_size + x;
 			// Array Index Rotated Y=-90 - must rotate shape Y=+90 (xform below)
 			int index = hshape_size - 1 - z + x * hshape_size;
-
-			Vector2i shape_pos = p_position + Vector2i(x, z);
-			real_t height = data->get_height(Vector3(shape_pos.x, 0., shape_pos.y) * _terrain->get_vertex_spacing());
+			real_t height = data->get_modified_height(p_position + Vector2i(x, z));
 			map_data[index] = height;
 			if (!std::isnan(height)) {
 				min_height = MIN(min_height, height);

--- a/src/terrain_3d_data.cpp
+++ b/src/terrain_3d_data.cpp
@@ -43,6 +43,45 @@ void Terrain3DData::_copy_paste_dfr(const Terrain3DRegion *p_src_region, const R
 	_terrain->get_instancer()->copy_paste_dfr(p_src_region, p_src_rect, p_dst_region);
 }
 
+Error Terrain3DData::_save_export_image(const MapType p_map_type, const Ref<Image> &p_img, const String &p_path,
+		const String &p_ext) const {
+	if (p_map_type == TYPE_HEIGHT && (p_ext == "r16" || p_ext == "raw")) {
+		Ref<FileAccess> file = FileAccess::open(p_path, FileAccess::WRITE);
+		if (file.is_null()) {
+			return ERR_CANT_OPEN;
+		}
+		Vector2 minmax = _master_height_range;
+		if (minmax.x >= minmax.y) {
+			// Global height range wasn't calculated, fall back to range for this image
+			minmax = Util::get_min_max(p_img);
+			LOG(MESG, "  Height range (per image fallback): ", vformat("%.2f", minmax.x), " to ", vformat("%.2f", minmax.y));
+		} else {
+			LOG(MESG, "  Height range (global scale): ", vformat("%.2f", minmax.x), " to ", vformat("%.2f", minmax.y));
+		}
+		float range = minmax.y - minmax.x;
+		real_t hscale = 65535.0 / (range != 0.f ? range : 1.f);
+		for (int y = 0; y < p_img->get_height(); y++) {
+			for (int x = 0; x < p_img->get_width(); x++) {
+				int h = int((p_img->get_pixel(x, y).r - minmax.x) * hscale);
+				h = CLAMP(h, 0, 65535);
+				file->store_16(h);
+			}
+		}
+		return file->get_error();
+	} else if (p_ext == "exr") {
+		return p_img->save_exr(p_path, (p_map_type == TYPE_HEIGHT));
+	} else if (p_ext == "png") {
+		return p_img->save_png(p_path);
+	} else if (p_ext == "jpg") {
+		return p_img->save_jpg(p_path);
+	} else if (p_ext == "webp") {
+		return p_img->save_webp(p_path);
+	} else if (p_ext == "res" || p_ext == "tres") {
+		return ResourceSaver::get_singleton()->save(p_img, p_path, ResourceSaver::FLAG_COMPRESS);
+	}
+	return ERR_FILE_UNRECOGNIZED;
+}
+
 ///////////////////////////
 // Public Functions
 ///////////////////////////
@@ -655,6 +694,7 @@ real_t Terrain3DData::get_height(const Vector3 &p_global_position) const {
 	if (is_hole(get_control(p_global_position))) {
 		return NAN;
 	}
+	real_t height = NAN;
 	Vector3 pos = p_global_position;
 	const real_t &step = _vertex_spacing;
 	pos.y = 0.f;
@@ -662,7 +702,7 @@ real_t Terrain3DData::get_height(const Vector3 &p_global_position) const {
 	Vector3 pos_round = pos.snapped(Vector3(step, 0.f, step));
 	// If requested position is close to a vertex, return its height
 	if ((pos - pos_round).length_squared() < 0.0001f) {
-		return get_pixel(TYPE_HEIGHT, pos).r;
+		height = get_pixel(TYPE_HEIGHT, pos).r;
 	} else {
 		// Otherwise, bilinearly interpolate 4 surrounding vertices
 		Vector3 pos00 = Vector3(floor(pos.x / step) * step, 0.f, floor(pos.z / step) * step);
@@ -673,8 +713,47 @@ real_t Terrain3DData::get_height(const Vector3 &p_global_position) const {
 		real_t ht10 = get_pixel(TYPE_HEIGHT, pos10).r;
 		Vector3 pos11 = pos00 + Vector3(step, 0.f, step);
 		real_t ht11 = get_pixel(TYPE_HEIGHT, pos11).r;
-		return bilerp(ht00, ht01, ht10, ht11, pos00, pos11, pos);
+		height = bilerp(ht00, ht01, ht10, ht11, pos00, pos11, pos);
 	}
+
+	if (!std::isnan(height) && _terrain->get_material()->get_world_background() != Terrain3DMaterial::WorldBackground::NONE) {
+		height = Math::lerp(height, _terrain->get_material()->get("ground_level"), smoothstep(0.f, 1.f, get_region_blend(pos)));
+	}
+	return height;
+}
+
+real_t Terrain3DData::get_region_blend(const Vector3 &p_global_position) const {
+	auto check_region = [&](const Vector2 &uv2) -> real_t {
+		Vector2i pos = Vector2i(Math::floor(uv2.x), Math::floor(uv2.y)) + Vector2i(REGION_MAP_SIZE / 2, REGION_MAP_SIZE / 2);
+		int layer_index = 0;
+		if ((uint32_t)(pos.x | pos.y) < (uint32_t)REGION_MAP_SIZE) {
+			int v = _region_map[pos.y * REGION_MAP_SIZE + pos.x];
+			layer_index = Math::clamp(v - 1, -1, 0) + 1;
+		}
+		return real_t(layer_index);
+	};
+
+	const real_t region_blend = _terrain->get_material()->get("region_blend");
+	const real_t region_texel_size = 1.f / real_t(_region_size);
+	Vector2 uv2 = Vector2(floor(p_global_position.x / _vertex_spacing), floor(p_global_position.z / _vertex_spacing)) * region_texel_size;
+	//Vector2 uv2 = Vector2(floor(p_global_position.x / _vertex_spacing) * _vertex_spacing, floor(p_global_position.z / _vertex_spacing) * _vertex_spacing);
+	// Floating point bias (must match shader)
+	uv2 -= Vector2(0.5011f, 0.5011f);
+
+	real_t a = check_region(uv2 + Vector2(0.0f, 1.0f));
+	real_t b = check_region(uv2 + Vector2(1.0f, 1.0f));
+	real_t c = check_region(uv2 + Vector2(1.0f, 0.0f));
+	real_t d = check_region(uv2 + Vector2(0.0f, 0.0f));
+
+	real_t blend_factor = 2.0f + 126.0f * (1.0f - region_blend);
+	Vector2 f = Vector2(uv2.x - Math::floor(uv2.x), uv2.y - Math::floor(uv2.y));
+	f.x = Math::clamp(f.x, real_t(1e-8f), real_t(1.0f - 1e-8f));
+	f.y = Math::clamp(f.y, real_t(1e-8f), real_t(1.0f - 1e-8f));
+	Vector2 w = Vector2(1.f / (1.f + Math::exp(blend_factor * Math::log((1.f - f.x) / f.x))),
+			1.f / (1.f + Math::exp(blend_factor * Math::log((1.f - f.y) / f.y))));
+	real_t blend = Math::lerp(Math::lerp(d, c, w.x), Math::lerp(a, b, w.x), w.y);
+
+	return (1.f - blend) * 2.f;
 }
 
 Vector3 Terrain3DData::get_normal(const Vector3 &p_global_position) const {
@@ -1119,7 +1198,7 @@ Error Terrain3DData::export_image(const String &p_file_name, const MapType p_map
 			LOG(MESG, "  Position: ", Vector2(region_loc * _region_size) * _vertex_spacing);
 			LOG(MESG, "  Image Size: ", img->get_size(), " px");
 
-			Error err = _save_export_image(img, path, ext, p_map_type);
+			Error err = _save_export_image(p_map_type, img, path, ext);
 			if (err != OK) {
 				last_error = err;
 			} else {
@@ -1152,7 +1231,7 @@ Error Terrain3DData::export_image(const String &p_file_name, const MapType p_map
 				LOG(MESG, "  Position: ", Vector2(slice_origin) * _vertex_spacing);
 				LOG(MESG, "  Image Size: ", img->get_size(), "px");
 
-				Error err = _save_export_image(img, path, ext, p_map_type);
+				Error err = _save_export_image(p_map_type, img, path, ext);
 				if (err != OK) {
 					last_error = err;
 				} else {
@@ -1164,45 +1243,6 @@ Error Terrain3DData::export_image(const String &p_file_name, const MapType p_map
 
 	LOG(MESG, "=== Export complete: ", files_exported, " file(s) ===");
 	return last_error;
-}
-
-Error Terrain3DData::_save_export_image(const Ref<Image> &p_img, const String &p_path,
-		const String &p_ext, const MapType p_map_type) const {
-	if (p_map_type == TYPE_HEIGHT && (p_ext == "r16" || p_ext == "raw")) {
-		Ref<FileAccess> file = FileAccess::open(p_path, FileAccess::WRITE);
-		if (file.is_null()) {
-			return ERR_CANT_OPEN;
-		}
-		Vector2 minmax = _master_height_range;
-		if (minmax.x >= minmax.y) {
-			// Global height range wasn't calculated, fall back to range for this image
-			minmax = Util::get_min_max(p_img);
-			LOG(MESG, "  Height range (per image fallback): ", vformat("%.2f", minmax.x), " to ", vformat("%.2f", minmax.y));
-		} else {
-			LOG(MESG, "  Height range (global scale): ", vformat("%.2f", minmax.x), " to ", vformat("%.2f", minmax.y));
-		}
-		float range = minmax.y - minmax.x;
-		real_t hscale = 65535.0 / (range != 0.f ? range : 1.f);
-		for (int y = 0; y < p_img->get_height(); y++) {
-			for (int x = 0; x < p_img->get_width(); x++) {
-				int h = int((p_img->get_pixel(x, y).r - minmax.x) * hscale);
-				h = CLAMP(h, 0, 65535);
-				file->store_16(h);
-			}
-		}
-		return file->get_error();
-	} else if (p_ext == "exr") {
-		return p_img->save_exr(p_path, (p_map_type == TYPE_HEIGHT));
-	} else if (p_ext == "png") {
-		return p_img->save_png(p_path);
-	} else if (p_ext == "jpg") {
-		return p_img->save_jpg(p_path);
-	} else if (p_ext == "webp") {
-		return p_img->save_webp(p_path);
-	} else if (p_ext == "res" || p_ext == "tres") {
-		return ResourceSaver::get_singleton()->save(p_img, p_path, ResourceSaver::FLAG_COMPRESS);
-	}
-	return ERR_FILE_UNRECOGNIZED;
 }
 
 Ref<Image> Terrain3DData::layered_to_image(const MapType p_map_type, const Rect2i &p_bounds) const {
@@ -1354,21 +1394,23 @@ void Terrain3DData::_bind_methods() {
 
 	ClassDB::bind_method(D_METHOD("set_pixel", "map_type", "global_position", "pixel"), &Terrain3DData::set_pixel);
 	ClassDB::bind_method(D_METHOD("get_pixel", "map_type", "global_position"), &Terrain3DData::get_pixel);
+
+	// Height Map
 	ClassDB::bind_method(D_METHOD("set_height", "global_position", "height"), &Terrain3DData::set_height);
 	ClassDB::bind_method(D_METHOD("get_height", "global_position"), &Terrain3DData::get_height);
-	ClassDB::bind_method(D_METHOD("set_color", "global_position", "color"), &Terrain3DData::set_color);
-	ClassDB::bind_method(D_METHOD("get_color", "global_position"), &Terrain3DData::get_color);
+	ClassDB::bind_method(D_METHOD("get_normal", "global_position"), &Terrain3DData::get_normal);
+	ClassDB::bind_method(D_METHOD("is_in_slope", "global_position", "slope_range", "normal"), &Terrain3DData::is_in_slope, DEFVAL(V3_ZERO));
+
+	// Control Map
 	ClassDB::bind_method(D_METHOD("set_control", "global_position", "control"), &Terrain3DData::set_control);
 	ClassDB::bind_method(D_METHOD("get_control", "global_position"), &Terrain3DData::get_control);
-	ClassDB::bind_method(D_METHOD("set_roughness", "global_position", "roughness"), &Terrain3DData::set_roughness);
-	ClassDB::bind_method(D_METHOD("get_roughness", "global_position"), &Terrain3DData::get_roughness);
-
 	ClassDB::bind_method(D_METHOD("set_control_base_id", "global_position", "texture_id"), &Terrain3DData::set_control_base_id);
 	ClassDB::bind_method(D_METHOD("get_control_base_id", "global_position"), &Terrain3DData::get_control_base_id);
 	ClassDB::bind_method(D_METHOD("set_control_overlay_id", "global_position", "texture_id"), &Terrain3DData::set_control_overlay_id);
 	ClassDB::bind_method(D_METHOD("get_control_overlay_id", "global_position"), &Terrain3DData::get_control_overlay_id);
 	ClassDB::bind_method(D_METHOD("set_control_blend", "global_position", "blend_value"), &Terrain3DData::set_control_blend);
 	ClassDB::bind_method(D_METHOD("get_control_blend", "global_position"), &Terrain3DData::get_control_blend);
+	ClassDB::bind_method(D_METHOD("get_texture_id", "global_position"), &Terrain3DData::get_texture_id);
 	ClassDB::bind_method(D_METHOD("set_control_angle", "global_position", "degrees"), &Terrain3DData::set_control_angle);
 	ClassDB::bind_method(D_METHOD("get_control_angle", "global_position"), &Terrain3DData::get_control_angle);
 	ClassDB::bind_method(D_METHOD("set_control_scale", "global_position", "percentage_modifier"), &Terrain3DData::set_control_scale);
@@ -1380,9 +1422,12 @@ void Terrain3DData::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("set_control_auto", "global_position", "enable"), &Terrain3DData::set_control_auto);
 	ClassDB::bind_method(D_METHOD("get_control_auto", "global_position"), &Terrain3DData::get_control_auto);
 
-	ClassDB::bind_method(D_METHOD("get_normal", "global_position"), &Terrain3DData::get_normal);
-	ClassDB::bind_method(D_METHOD("is_in_slope", "global_position", "slope_range", "normal"), &Terrain3DData::is_in_slope, DEFVAL(V3_ZERO));
-	ClassDB::bind_method(D_METHOD("get_texture_id", "global_position"), &Terrain3DData::get_texture_id);
+	// Color Map
+	ClassDB::bind_method(D_METHOD("set_color", "global_position", "color"), &Terrain3DData::set_color);
+	ClassDB::bind_method(D_METHOD("get_color", "global_position"), &Terrain3DData::get_color);
+	ClassDB::bind_method(D_METHOD("set_roughness", "global_position", "roughness"), &Terrain3DData::set_roughness);
+	ClassDB::bind_method(D_METHOD("get_roughness", "global_position"), &Terrain3DData::get_roughness);
+
 	ClassDB::bind_method(D_METHOD("get_mesh_vertex", "lod", "filter", "global_position"), &Terrain3DData::get_mesh_vertex);
 
 	ClassDB::bind_method(D_METHOD("get_height_range"), &Terrain3DData::get_height_range);

--- a/src/terrain_3d_data.cpp
+++ b/src/terrain_3d_data.cpp
@@ -59,7 +59,7 @@ Error Terrain3DData::_save_export_image(const MapType p_map_type, const Ref<Imag
 			LOG(MESG, "  Height range (global scale): ", vformat("%.2f", minmax.x), " to ", vformat("%.2f", minmax.y));
 		}
 		float range = minmax.y - minmax.x;
-		real_t hscale = 65535.0 / (range != 0.f ? range : 1.f);
+		real_t hscale = 65535.f / (range != 0.f ? range : 1.f);
 		for (int y = 0; y < p_img->get_height(); y++) {
 			for (int x = 0; x < p_img->get_width(); x++) {
 				int h = int((p_img->get_pixel(x, y).r - minmax.x) * hscale);
@@ -644,101 +644,109 @@ void Terrain3DData::set_pixel(const MapType p_map_type, const Vector3 &p_global_
 		LOG(ERROR, "Specified map type out of range");
 		return;
 	}
-	Vector2i region_loc = get_region_location(p_global_position);
+	Vector2i vgrid = world_to_vgrid(p_global_position);
+	Vector2i region_loc = V2I_DIVIDE_FLOOR(vgrid, _region_size);
 	Terrain3DRegion *region = get_region_ptr(region_loc);
-	if (!region) {
+	if (!region || region->is_deleted()) {
 		LOG(ERROR, "No active region found at: ", p_global_position);
 		return;
 	}
-	if (region->is_deleted()) {
-		LOG(ERROR, "No active region found at: ", p_global_position);
-		return;
-	}
-	Vector2i global_offset = region_loc * _region_size;
-	Vector3 descaled_pos = p_global_position / _vertex_spacing;
-	Vector2i img_pos = Vector2i(descaled_pos.x - global_offset.x, descaled_pos.z - global_offset.y);
-	img_pos = img_pos.clamp(V2I_ZERO, V2I(_region_size - 1));
 	Image *map = region->get_map_ptr(p_map_type);
 	if (map) {
+		// Local pixel in the region is always [0, region_size)
+		Vector2i img_pos(Math::posmod(vgrid.x, _region_size), Math::posmod(vgrid.y, _region_size));
 		map->set_pixelv(img_pos, p_pixel);
 		region->set_modified(true);
 	}
 }
 
-Color Terrain3DData::get_pixel(const MapType p_map_type, const Vector3 &p_global_position) const {
+// Expects descaled, snapped/floored, global position - vertex grid
+Color Terrain3DData::get_pixel_descaled(const MapType p_map_type, const Vector2i &p_vgrid) const {
 	if (p_map_type < 0 || p_map_type >= TYPE_MAX) {
 		LOG(ERROR, "Specified map type out of range");
 		return COLOR_NAN;
 	}
-	Vector2i region_loc = get_region_location(p_global_position);
+	Vector2i region_loc = V2I_DIVIDE_FLOOR(p_vgrid, _region_size);
 	const Terrain3DRegion *region = get_region_ptr(region_loc);
-	if (!region) {
+	if (!region || region->is_deleted()) {
 		return COLOR_NAN;
 	}
-	if (region->is_deleted()) {
-		return COLOR_NAN;
-	}
-	Vector2i global_offset = region_loc * _region_size;
-	Vector3 descaled_pos = p_global_position / _vertex_spacing;
-	Vector2i img_pos = Vector2i(descaled_pos.x - global_offset.x, descaled_pos.z - global_offset.y);
-	img_pos = img_pos.clamp(V2I_ZERO, V2I(_region_size - 1));
 	Image *map = region->get_map_ptr(p_map_type);
 	if (map) {
+		// Local pixel in the region is always [0, region_size)
+		Vector2i img_pos(Math::posmod(p_vgrid.x, _region_size), Math::posmod(p_vgrid.y, _region_size));
 		return map->get_pixelv(img_pos);
 	} else {
 		return COLOR_NAN;
 	}
 }
 
-real_t Terrain3DData::get_height(const Vector3 &p_global_position) const {
-	if (is_hole(get_control(p_global_position))) {
-		return NAN;
-	}
-	real_t height = NAN;
+real_t Terrain3DData::get_surface_height(const Vector3 &p_global_position) const {
 	Vector3 pos = p_global_position;
 	const real_t &step = _vertex_spacing;
 	pos.y = 0.f;
-	// Round to nearest vertex
+	// Compare position to nearest vertex, and if close don't interpolate
 	Vector3 pos_round = pos.snapped(Vector3(step, 0.f, step));
-	// If requested position is close to a vertex, return its height
 	if ((pos - pos_round).length_squared() < 0.0001f) {
-		height = get_pixel(TYPE_HEIGHT, pos).r;
+		return get_modified_height(world_to_vgrid(pos_round));
 	} else {
 		// Otherwise, bilinearly interpolate 4 surrounding vertices
-		Vector3 pos00 = Vector3(floor(pos.x / step) * step, 0.f, floor(pos.z / step) * step);
-		real_t ht00 = get_pixel(TYPE_HEIGHT, pos00).r;
-		Vector3 pos01 = pos00 + Vector3(0.f, 0.f, step);
-		real_t ht01 = get_pixel(TYPE_HEIGHT, pos01).r;
-		Vector3 pos10 = pos00 + Vector3(step, 0.f, 0.f);
-		real_t ht10 = get_pixel(TYPE_HEIGHT, pos10).r;
-		Vector3 pos11 = pos00 + Vector3(step, 0.f, step);
-		real_t ht11 = get_pixel(TYPE_HEIGHT, pos11).r;
-		height = bilerp(ht00, ht01, ht10, ht11, pos00, pos11, pos);
+		Vector2i v00 = world_to_vgrid(pos);
+		real_t ht00 = get_modified_height(v00);
+		Vector2i v01 = v00 + Vector2i(0, 1);
+		real_t ht01 = get_modified_height(v01);
+		Vector2i v10 = v00 + Vector2i(1, 0);
+		real_t ht10 = get_modified_height(v10);
+		Vector2i v11 = v00 + Vector2i(1, 1);
+		real_t ht11 = get_modified_height(v11);
+		return bilerp(ht00, ht01, ht10, ht11, Vector2(v00), Vector2(v11), v3v2(pos / step));
 	}
+}
 
-	if (!std::isnan(height) && _terrain->get_material()->get_world_background() != Terrain3DMaterial::WorldBackground::NONE) {
-		height = Math::lerp(height, _terrain->get_material()->get("ground_level"), smoothstep(0.f, 1.f, get_region_blend(pos)));
+// Expects descaled, snapped/floored global position - vertex grid
+// Returns height modified by world background region blend, ground level
+real_t Terrain3DData::get_modified_height(const Vector2i &p_vgrid) const {
+	real_t control = get_pixel_descaled(TYPE_CONTROL, p_vgrid).r;
+	if (is_hole(control)) {
+		return NAN;
+	}
+	real_t height = get_pixel_descaled(TYPE_HEIGHT, p_vgrid).r;
+	const Ref<Terrain3DMaterial> material = _terrain->get_material();
+	if (material.is_valid()) {
+		const Terrain3DMaterial::WorldBackground bg_mode = material->get_world_background();
+		if (bg_mode == Terrain3DMaterial::WorldBackground::FLAT || bg_mode == Terrain3DMaterial::WorldBackground::NOISE) {
+			Variant var_gl = material->get("ground_level");
+			Variant var_rb = material->get("region_blend");
+			if (var_gl.get_type() == Variant::NIL || var_rb.get_type() == Variant::NIL) {
+				return height;
+			}
+			const real_t ground_level = var_gl;
+			const real_t region_texel_size = 1.f / real_t(_region_size);
+			Vector2 uv2 = Vector2(p_vgrid) * region_texel_size;
+			height = Math::lerp(height, ground_level, smoothstep(0.f, 1.f, get_region_blend(uv2)));
+		}
 	}
 	return height;
 }
 
-real_t Terrain3DData::get_region_blend(const Vector3 &p_global_position) const {
+real_t Terrain3DData::get_region_blend(const Vector2 &p_uv2) const {
+	const Ref<Terrain3DMaterial> material = _terrain->get_material();
+	if (!material.is_valid()) {
+		return 0.f;
+	}
+	Variant var_rb = material->get("region_blend");
+	if (var_rb.get_type() == Variant::NIL) {
+		return 0.f;
+	}
+	const real_t region_blend = var_rb;
+
 	auto check_region = [&](const Vector2 &uv2) -> real_t {
-		Vector2i pos = Vector2i(Math::floor(uv2.x), Math::floor(uv2.y)) + Vector2i(REGION_MAP_SIZE / 2, REGION_MAP_SIZE / 2);
-		int layer_index = 0;
-		if ((uint32_t)(pos.x | pos.y) < (uint32_t)REGION_MAP_SIZE) {
-			int v = _region_map[pos.y * REGION_MAP_SIZE + pos.x];
-			layer_index = Math::clamp(v - 1, -1, 0) + 1;
-		}
-		return real_t(layer_index);
+		int idx = get_region_map_index(Vector2i(Math::floor(uv2.x), Math::floor(uv2.y)));
+		return (idx >= 0 && _region_map[idx] > 0) ? 1.f : 0.f;
 	};
 
-	const real_t region_blend = _terrain->get_material()->get("region_blend");
-	const real_t region_texel_size = 1.f / real_t(_region_size);
-	Vector2 uv2 = Vector2(floor(p_global_position.x / _vertex_spacing), floor(p_global_position.z / _vertex_spacing)) * region_texel_size;
-	//Vector2 uv2 = Vector2(floor(p_global_position.x / _vertex_spacing) * _vertex_spacing, floor(p_global_position.z / _vertex_spacing) * _vertex_spacing);
 	// Floating point bias (must match shader)
-	uv2 -= Vector2(0.5011f, 0.5011f);
+	Vector2 uv2 = p_uv2 - Vector2(0.5011f, 0.5011f);
 
 	real_t a = check_region(uv2 + Vector2(0.0f, 1.0f));
 	real_t b = check_region(uv2 + Vector2(1.0f, 1.0f));
@@ -760,10 +768,20 @@ Vector3 Terrain3DData::get_normal(const Vector3 &p_global_position) const {
 	if (get_region_idp(p_global_position) < 0 || is_hole(get_control(p_global_position))) {
 		return V3_NAN;
 	}
-	real_t height = get_height(p_global_position);
-	real_t u = height - get_height(p_global_position + Vector3(_vertex_spacing, 0.0f, 0.0f));
-	real_t v = height - get_height(p_global_position + Vector3(0.f, 0.f, _vertex_spacing));
-	Vector3 normal = Vector3(u, _vertex_spacing, v);
+	const real_t step = _vertex_spacing;
+	real_t h = get_surface_height(p_global_position);
+	if (!std::isfinite(h)) {
+		return V3_NAN;
+	}
+	real_t hx = get_surface_height(p_global_position + Vector3(step, 0.f, 0.f));
+	if (!std::isfinite(hx)) {
+		return V3_NAN;
+	}
+	real_t hz = get_surface_height(p_global_position + Vector3(0.f, 0.f, step));
+	if (!std::isfinite(hx)) {
+		return V3_NAN;
+	}
+	Vector3 normal(h - hx, step, h - hz);
 	normal.normalize();
 	return normal;
 }
@@ -781,24 +799,10 @@ bool Terrain3DData::is_in_slope(const Vector3 &p_global_position, const Vector2 
 		slope_normal.normalize();
 	} else {
 		// Else, compute terrain normal
-		if (get_region_idp(p_global_position) < 0) {
+		slope_normal = get_normal(p_global_position);
+		if (!slope_normal.is_finite()) {
 			return false;
 		}
-		// Adapted from get_height() to work with holes
-		auto get_height = [&](Vector3 pos) -> real_t {
-			real_t step = _terrain->get_vertex_spacing();
-			// Round to nearest vertex
-			Vector3 pos_round = pos.snapped(Vector3(step, 0.f, step));
-			real_t height = get_pixel(TYPE_HEIGHT, pos_round).r;
-			return std::isnan(height) ? 0.f : height;
-		};
-
-		const real_t vertex_spacing = _terrain->get_vertex_spacing();
-		const real_t height = get_height(p_global_position);
-		const real_t u = height - get_height(p_global_position + Vector3(vertex_spacing, 0.0f, 0.0f));
-		const real_t v = height - get_height(p_global_position + Vector3(0.f, 0.f, vertex_spacing));
-		slope_normal = Vector3(u, vertex_spacing, v);
-		slope_normal.normalize();
 	}
 
 	const real_t slope_angle = slope_normal.angle_to(V3_UP);
@@ -817,39 +821,33 @@ bool Terrain3DData::is_in_slope(const Vector3 &p_global_position, const Vector2 
  * value of .3-.5, otherwise it's the base texture.
  **/
 Vector3 Terrain3DData::get_texture_id(const Vector3 &p_global_position) const {
-	// Verify in a region
-	int region_id = get_region_idp(p_global_position);
-	if (region_id < 0) {
-		return V3_NAN;
-	}
+	Vector2i vgrid = world_to_vgrid(p_global_position);
 
-	// Verify not in a hole
-	float src = get_pixel(TYPE_CONTROL, p_global_position).r; // 32-bit float, not double/real
-	if (is_hole(src)) {
+	// Region + hole check
+	real_t control = get_pixel_descaled(TYPE_CONTROL, vgrid).r;
+	if (std::isnan(control) || is_hole(control)) {
 		return V3_NAN;
 	}
 
 	// If material available, autoshader enabled, and pixel set to auto
 	if (_terrain) {
-		Ref<Terrain3DMaterial> t_material = _terrain->get_material();
-		bool auto_enabled = t_material->get_auto_shader_enabled();
-		bool control_auto = is_auto(src);
-		if (auto_enabled && control_auto) {
-			real_t auto_slope = real_t(t_material->get_shader_param("auto_slope"));
-			real_t auto_height_reduction = real_t(t_material->get_shader_param("auto_height_reduction"));
-			real_t height = get_height(p_global_position);
+		Ref<Terrain3DMaterial> mat = _terrain->get_material();
+		if (mat.is_valid() && mat->get_auto_shader_enabled() && is_auto(control)) {
+			real_t auto_slope = real_t(mat->get_shader_param("auto_slope"));
+			real_t auto_height_reduction = real_t(mat->get_shader_param("auto_height_reduction"));
+			real_t height = get_modified_height(vgrid);
 			Vector3 normal = get_normal(p_global_position);
-			uint32_t base_id = t_material->get_shader_param("auto_base_texture");
-			uint32_t overlay_id = t_material->get_shader_param("auto_overlay_texture");
+			uint32_t base_id = mat->get_shader_param("auto_base_texture");
+			uint32_t overlay_id = mat->get_shader_param("auto_overlay_texture");
 			real_t blend = CLAMP((auto_slope * 2.f * (normal.y - 1.f) + 1.f) - auto_height_reduction * .01f * height, 0.f, 1.f);
 			return Vector3(real_t(base_id), real_t(overlay_id), blend);
 		}
 	}
 
 	// Else, just get textures from control map
-	uint32_t base_id = get_base(src);
-	uint32_t overlay_id = get_overlay(src);
-	real_t blend = real_t(get_blend(src)) / 255.0f;
+	uint32_t base_id = get_base(control);
+	uint32_t overlay_id = get_overlay(control);
+	real_t blend = real_t(get_blend(control)) / 255.f;
 	return Vector3(real_t(base_id), real_t(overlay_id), blend);
 }
 
@@ -864,27 +862,32 @@ Vector3 Terrain3DData::get_texture_id(const Vector3 &p_global_position) const {
  */
 Vector3 Terrain3DData::get_mesh_vertex(const int32_t p_lod, const HeightFilter p_filter, const Vector3 &p_global_position) const {
 	LOG(INFO, "Calculating vertex location");
-	int32_t step = 1 << CLAMP(p_lod, 0, 8);
-	real_t height = 0.0f;
+	Vector2i vgrid = world_to_vgrid(p_global_position);
+	real_t height = get_mesh_vertex_height(p_lod, p_filter, vgrid);
+	return Vector3(p_global_position.x, height, p_global_position.z);
+}
 
+real_t Terrain3DData::get_mesh_vertex_height(const int32_t p_lod, const HeightFilter p_filter, const Vector2i &p_vgrid) const {
+	const int32_t lod_step = 1 << CLAMP(p_lod, 0, 8);
+	real_t height = 0.f;
 	switch (p_filter) {
 		case HEIGHT_FILTER_NEAREST: {
-			if (is_hole(get_control(p_global_position))) {
-				height = NAN;
-			} else {
-				height = get_height(p_global_position);
-			}
+			height = get_modified_height(p_vgrid);
 		} break;
+
 		case HEIGHT_FILTER_MINIMUM: {
-			height = get_height(p_global_position);
-			for (int32_t dx = -step / 2; dx < step / 2; dx += 1) {
-				for (int32_t dz = -step / 2; dz < step / 2; dz += 1) {
-					Vector3 position = p_global_position + Vector3(dx, 0.f, dz) * _vertex_spacing;
-					if (is_hole(get_control(position))) {
+			height = get_modified_height(p_vgrid);
+			if (std::isnan(height)) {
+				break;
+			}
+			const int half = lod_step / 2;
+			for (int32_t dx = -half; dx < half; ++dx) {
+				for (int32_t dz = -half; dz < half; ++dz) {
+					real_t h = get_modified_height(p_vgrid + Vector2i(dx, dz));
+					if (std::isnan(h)) {
 						height = NAN;
-						break;
+						return height;
 					}
-					real_t h = get_height(position);
 					if (h < height) {
 						height = h;
 					}
@@ -892,7 +895,7 @@ Vector3 Terrain3DData::get_mesh_vertex(const int32_t p_lod, const HeightFilter p
 			}
 		} break;
 	}
-	return Vector3(p_global_position.x, height, p_global_position.z);
+	return height;
 }
 
 void Terrain3DData::add_edited_area(const AABB &p_area) {
@@ -1398,6 +1401,7 @@ void Terrain3DData::_bind_methods() {
 	// Height Map
 	ClassDB::bind_method(D_METHOD("set_height", "global_position", "height"), &Terrain3DData::set_height);
 	ClassDB::bind_method(D_METHOD("get_height", "global_position"), &Terrain3DData::get_height);
+	ClassDB::bind_method(D_METHOD("get_surface_height", "global_position"), &Terrain3DData::get_surface_height);
 	ClassDB::bind_method(D_METHOD("get_normal", "global_position"), &Terrain3DData::get_normal);
 	ClassDB::bind_method(D_METHOD("is_in_slope", "global_position", "slope_range", "normal"), &Terrain3DData::is_in_slope, DEFVAL(V3_ZERO));
 

--- a/src/terrain_3d_data.cpp
+++ b/src/terrain_3d_data.cpp
@@ -930,17 +930,17 @@ void Terrain3DData::calc_height_range(const bool p_recursive) {
  * It does NOT normalize values to 0-1. You must do that using get_min_max() and adjusting scale and offset.
  * Parameters:
  *	p_images - MapType.TYPE_MAX sized array of Images for Height, Control, Color. Images can be blank or null
- *	p_global_position - X,0,Z location on the region map. Valid range is ~ (+/-8192, +/-8192)
+ *	p_global_position - X,0,Z location on the region map. Valid range is +/-16 * region_size
  *	p_offset - Add this factor to all height values, can be negative
  *	p_scale - Scale all height values by this factor (applied after offset)
  */
 void Terrain3DData::import_images(const TypedArray<Image> &p_images, const Vector3 &p_global_position, const real_t p_offset, const real_t p_scale) {
 	IS_INIT_MESG("Data not initialized", VOID);
+	// Validate images and determine common size
 	if (p_images.size() != TYPE_MAX) {
 		LOG(ERROR, "p_images.size() is ", p_images.size(), ". It should be ", TYPE_MAX, " even if some Images are blank or null");
 		return;
 	}
-
 	Vector2i img_size = V2I_ZERO;
 	for (int i = 0; i < TYPE_MAX; i++) {
 		Ref<Image> img = p_images[i];
@@ -962,35 +962,56 @@ void Terrain3DData::import_images(const TypedArray<Image> &p_images, const Vecto
 		return;
 	}
 
-	Vector3 descaled_position = p_global_position / _vertex_spacing;
-	int max_dimension = _region_size * REGION_MAP_SIZE / 2;
-	if ((std::abs(descaled_position.x) > max_dimension) || (std::abs(descaled_position.z) > max_dimension)) {
-		LOG(ERROR, "Specify a position within +/-", Vector3(max_dimension, 0.f, max_dimension) * _vertex_spacing);
-		return;
-	}
-	if ((descaled_position.x + img_size.x > max_dimension) ||
-			(descaled_position.z + img_size.y > max_dimension)) {
-		LOG(ERROR, img_size, " image will not fit at ", p_global_position,
-				". Try ", -(img_size * _vertex_spacing) / 2.f, " to center, or increase region_size");
+	// Convert import origin to floored, descaled vertex grid
+	const Vector2i img_start = world_to_vgrid(p_global_position);
+	const Vector2i img_end = img_start + img_size - Vector2i(1, 1);
+
+	// Validate vertex-grid range for the current region_size
+	// Regions run from -HALF .. HALF-1, each covering _region_size vertices
+	const int half = REGION_MAP_SIZE / 2;
+	const int min_v = -half * _region_size;
+	const int max_v = (half * _region_size) - 1; // inclusive
+
+	if (img_start.x < min_v || img_start.y < min_v ||
+			img_end.x > max_v || img_end.y > max_v) {
+		// How large does region_size need to be for this image to fit
+		// (centred or placed at the requested position)?
+		const int required_span = MAX(img_size.x, img_size.y);
+		int min_region_size = _region_size;
+		while (min_region_size < Terrain3D::RegionSize::SIZE_2048 &&
+				required_span > min_region_size * REGION_MAP_SIZE) {
+			min_region_size <<= 1;
+		}
+
+		LOG(ERROR, "Image of size ", img_size, " at ", v3v2i(p_global_position),
+				" does not fit within max width of ", REGION_MAP_SIZE, " * region_size ", _region_size,
+				" = ", REGION_MAP_SIZE * _region_size);
+
+		if (min_region_size > _region_size) {
+			LOG(ERROR, "Increase region_size to at least ", min_region_size,
+					" and place the image so its center covers the the origin.");
+		} else {
+			LOG(ERROR, "Try a position near ",
+					-Vector3(img_size.x, 0.f, img_size.y) * _vertex_spacing * 0.5f,
+					" to center the image.");
+		}
 		return;
 	}
 
+	// Apply scale and offsets to the heightmap and filter out invalid data
 	TypedArray<Image> src_images;
 	src_images.resize(TYPE_MAX);
-
 	for (int i = 0; i < TYPE_MAX; i++) {
 		Ref<Image> img = p_images[i];
 		src_images[i] = img;
-		if (img.is_null()) {
+		if (img.is_null() || img->is_empty()) {
 			continue;
 		}
-
-		// Apply scale and offsets to the heightmap and filter out invalid data
-		if (i == TYPE_HEIGHT) {
+		if (i == TYPE_HEIGHT && (p_scale != 1.f || p_offset != 0.f)) {
 			LOG(DEBUG, "Creating new temp image to adjust scale: ", p_scale, " offset: ", p_offset);
-			Ref<Image> newimg = Image::create_empty(img->get_size().x, img->get_size().y, false, FORMAT[TYPE_HEIGHT]);
-			for (int y = 0; y < img->get_height(); y++) {
-				for (int x = 0; x < img->get_width(); x++) {
+			Ref<Image> newimg = Image::create_empty(img_size.x, img_size.y, false, FORMAT[TYPE_HEIGHT]);
+			for (int y = 0; y < img_size.y; y++) {
+				for (int x = 0; x < img_size.x; x++) {
 					Color clr = img->get_pixel(x, y);
 					if (std::isnormal(clr.r)) {
 						clr.r = (clr.r * p_scale) + p_offset;
@@ -1005,55 +1026,34 @@ void Terrain3DData::import_images(const TypedArray<Image> &p_images, const Vecto
 	}
 
 	// Calculate regions this image will span
-	int img_start_x = (int)Math::floor(descaled_position.x);
-	int img_start_z = (int)Math::floor(descaled_position.z);
-	int img_end_x = img_start_x + img_size.x - 1;
-	int img_end_z = img_start_z + img_size.y - 1;
-
-	int start_region_x = (int)Math::floor(real_t(img_start_x) / real_t(_region_size));
-	int start_region_z = (int)Math::floor(real_t(img_start_z) / real_t(_region_size));
-	int end_region_x = (int)Math::floor(real_t(img_end_x) / real_t(_region_size));
-	int end_region_z = (int)Math::floor(real_t(img_end_z) / real_t(_region_size));
-
-	// Clamp region indices to valid range
-	int half_region_map = REGION_MAP_SIZE / 2;
-	start_region_x = CLAMP(start_region_x, -half_region_map, half_region_map - 1);
-	start_region_z = CLAMP(start_region_z, -half_region_map, half_region_map - 1);
-	end_region_x = CLAMP(end_region_x, -half_region_map, half_region_map - 1);
-	end_region_z = CLAMP(end_region_z, -half_region_map, half_region_map - 1);
-
-	LOG(DEBUG, "Image spans regions (", start_region_x, ",", start_region_z, ") to (", end_region_x, ",", end_region_z, ")");
+	const Vector2i start_region = V2I_DIVIDE_FLOOR(img_start, _region_size);
+	const Vector2i end_region = V2I_DIVIDE_FLOOR(img_end, _region_size);
+	LOG(DEBUG, "Image spans regions ", start_region, " to ", end_region);
 
 	bool generate_mipmaps = false;
-	for (int rz = start_region_z; rz <= end_region_z; rz++) {
-		for (int rx = start_region_x; rx <= end_region_x; rx++) {
-			Vector2i region_loc = Vector2i(rx, rz);
+	for (int rz = start_region.y; rz <= end_region.y; rz++) {
+		for (int rx = start_region.x; rx <= end_region.x; rx++) {
+			const Vector2i region_loc = Vector2i(rx, rz);
+			const Vector2i region_origin = region_loc * _region_size;
 
-			int region_start_x = rx * _region_size;
-			int region_start_z = rz * _region_size;
-			int region_end_x = region_start_x + _region_size - 1;
-			int region_end_z = region_start_z + _region_size - 1;
-
-			int overlap_start_x = MAX(region_start_x, img_start_x);
-			int overlap_start_z = MAX(region_start_z, img_start_z);
-			int overlap_end_x = MIN(region_end_x, img_end_x);
-			int overlap_end_z = MIN(region_end_z, img_end_z);
+			// Overlap in descaled vertex space
+			const int overlap_start_x = MAX(region_origin.x, img_start.x);
+			const int overlap_start_z = MAX(region_origin.y, img_start.y);
+			const int overlap_end_x = MIN(region_origin.x + _region_size - 1, img_end.x);
+			const int overlap_end_z = MIN(region_origin.y + _region_size - 1, img_end.y);
 
 			// Skip if no overlap
 			if (overlap_end_x < overlap_start_x || overlap_end_z < overlap_start_z) {
 				continue;
 			}
 
-			int copy_width = overlap_end_x - overlap_start_x + 1;
-			int copy_height = overlap_end_z - overlap_start_z + 1;
-
-			int src_x = overlap_start_x - img_start_x;
-			int src_z = overlap_start_z - img_start_z;
-			int dst_x = overlap_start_x - region_start_x;
-			int dst_z = overlap_start_z - region_start_z;
+			const int copy_width = overlap_end_x - overlap_start_x + 1;
+			const int copy_height = overlap_end_z - overlap_start_z + 1;
+			const Vector2i src_pos(overlap_start_x - img_start.x, overlap_start_z - img_start.y);
+			const Vector2i dst_pos(overlap_start_x - region_origin.x, overlap_start_z - region_origin.y);
 
 			LOG(DEBUG, "Region ", region_loc, ": copying ", Vector2i(copy_width, copy_height),
-					" from img(", src_x, ",", src_z, ") to region(", dst_x, ",", dst_z, ")");
+					" from img", src_pos, " to region", dst_pos);
 
 			Ref<Terrain3DRegion> region = get_region(region_loc);
 			if (region.is_null()) {
@@ -1068,11 +1068,11 @@ void Terrain3DData::import_images(const TypedArray<Image> &p_images, const Vecto
 				region->set_region_size(_region_size);
 				region->set_vertex_spacing(_vertex_spacing);
 			}
+
 			for (int i = 0; i < TYPE_MAX; i++) {
 				Ref<Image> img = src_images[i];
 				if (img.is_valid() && !img->is_empty()) {
 					Ref<Image> region_map;
-
 					Ref<Image> existing_map = region->get_map(static_cast<MapType>(i));
 					if (existing_map.is_valid() && !existing_map->is_empty()) {
 						region_map.instantiate();
@@ -1083,7 +1083,7 @@ void Terrain3DData::import_images(const TypedArray<Image> &p_images, const Vecto
 					} else {
 						region_map = Util::get_filled_image(_region_sizev, COLOR[i], false, img->get_format());
 					}
-					region_map->blit_rect(img, Rect2i(src_x, src_z, copy_width, copy_height), Vector2i(dst_x, dst_z));
+					region_map->blit_rect(img, Rect2i(src_pos, Vector2i(copy_width, copy_height)), dst_pos);
 					region->set_map(static_cast<MapType>(i), region_map);
 					if (i == TYPE_COLOR) {
 						generate_mipmaps = true;
@@ -1095,6 +1095,13 @@ void Terrain3DData::import_images(const TypedArray<Image> &p_images, const Vecto
 		}
 	}
 	update_maps(TYPE_MAX, true, generate_mipmaps);
+
+	if (_master_height_range.y - _master_height_range.x < 2.f) {
+		Ref<Image> htimg = p_images[TYPE_HEIGHT];
+		if (htimg.is_valid() && !htimg->is_empty()) {
+			LOG(WARN, "No heights > 2m detected. Are you importing a normalized (0-1) heightmap? Scale it 300-500x");
+		}
+	}
 }
 
 /** Exports a specified map as one of r16/raw, exr, jpg, png, webp, res, tres

--- a/src/terrain_3d_data.h
+++ b/src/terrain_3d_data.h
@@ -81,7 +81,7 @@ private:
 	// Functions
 	void _clear();
 	void _copy_paste_dfr(const Terrain3DRegion *p_src_region, const Rect2i &p_src_rect, const Rect2i &p_dst_rect, const Terrain3DRegion *p_dst_region);
-	Error _save_export_image(const Ref<Image> &p_img, const String &p_path, const String &p_ext, const MapType p_map_type) const;
+	Error _save_export_image(const MapType p_map_type, const Ref<Image> &p_img, const String &p_path, const String &p_ext) const;
 
 public:
 	Terrain3DData() {}
@@ -143,22 +143,24 @@ public:
 
 	void set_pixel(const MapType p_map_type, const Vector3 &p_global_position, const Color &p_pixel);
 	Color get_pixel(const MapType p_map_type, const Vector3 &p_global_position) const;
+
+	// Height Map
 	void set_height(const Vector3 &p_global_position, const real_t p_height);
 	real_t get_height(const Vector3 &p_global_position) const;
-	void set_color(const Vector3 &p_global_position, const Color &p_color);
-	Color get_color(const Vector3 &p_global_position) const;
-	void set_control(const Vector3 &p_global_position, const uint32_t p_control);
-	uint32_t get_control(const Vector3 &p_global_position) const;
-	void set_roughness(const Vector3 &p_global_position, const real_t p_roughness);
-	real_t get_roughness(const Vector3 &p_global_position) const;
+	real_t get_region_blend(const Vector3 &p_global_position) const;
+	Vector3 get_normal(const Vector3 &p_global_position) const;
+	bool is_in_slope(const Vector3 &p_global_position, const Vector2 &p_slope_range, const Vector3 &p_normal = V3_ZERO) const;
 
 	// Control Map
+	void set_control(const Vector3 &p_global_position, const uint32_t p_control);
+	uint32_t get_control(const Vector3 &p_global_position) const;
 	void set_control_base_id(const Vector3 &p_global_position, const uint8_t p_base);
 	uint32_t get_control_base_id(const Vector3 &p_global_position) const;
 	void set_control_overlay_id(const Vector3 &p_global_position, const uint8_t p_overlay);
 	uint32_t get_control_overlay_id(const Vector3 &p_global_position) const;
 	void set_control_blend(const Vector3 &p_global_position, const real_t p_blend);
 	real_t get_control_blend(const Vector3 &p_global_position) const;
+	Vector3 get_texture_id(const Vector3 &p_global_position) const;
 	void set_control_angle(const Vector3 &p_global_position, const real_t p_angle);
 	real_t get_control_angle(const Vector3 &p_global_position) const;
 	void set_control_scale(const Vector3 &p_global_position, const real_t p_scale);
@@ -170,9 +172,12 @@ public:
 	void set_control_auto(const Vector3 &p_global_position, const bool p_auto);
 	bool get_control_auto(const Vector3 &p_global_position) const;
 
-	Vector3 get_normal(const Vector3 &p_global_position) const;
-	bool is_in_slope(const Vector3 &p_global_position, const Vector2 &p_slope_range, const Vector3 &p_normal = V3_ZERO) const;
-	Vector3 get_texture_id(const Vector3 &p_global_position) const;
+	// Color Map
+	void set_color(const Vector3 &p_global_position, const Color &p_color);
+	Color get_color(const Vector3 &p_global_position) const;
+	void set_roughness(const Vector3 &p_global_position, const real_t p_roughness);
+	real_t get_roughness(const Vector3 &p_global_position) const;
+
 	Vector3 get_mesh_vertex(const int32_t p_lod, const HeightFilter p_filter, const Vector3 &p_global_position) const;
 
 	void add_edited_area(const AABB &p_area);
@@ -274,18 +279,6 @@ inline void Terrain3DData::set_height(const Vector3 &p_global_position, const re
 	set_pixel(TYPE_HEIGHT, p_global_position, Color(p_height, 0.f, 0.f, 1.f));
 }
 
-inline void Terrain3DData::set_color(const Vector3 &p_global_position, const Color &p_color) {
-	Color clr = p_color;
-	clr.a = get_roughness(p_global_position);
-	set_pixel(TYPE_COLOR, p_global_position, clr);
-}
-
-inline Color Terrain3DData::get_color(const Vector3 &p_global_position) const {
-	Color clr = get_pixel(TYPE_COLOR, p_global_position);
-	clr.a = 1.0f;
-	return clr;
-}
-
 inline void Terrain3DData::set_control(const Vector3 &p_global_position, const uint32_t p_control) {
 	set_pixel(TYPE_CONTROL, p_global_position, Color(as_float(p_control), 0.f, 0.f, 1.f));
 }
@@ -336,7 +329,7 @@ inline void Terrain3DData::set_control_angle(const Vector3 &p_global_position, c
 	set_control(p_global_position, (control & ~(0xF << 10)) | enc_uv_rotation(uvrotation));
 }
 
-// returns angle in degrees
+// Returns angle in degrees
 inline real_t Terrain3DData::get_control_angle(const Vector3 &p_global_position) const {
 	uint32_t control = get_control(p_global_position);
 	real_t angle = real_t(get_uv_rotation(control)) * 22.5f;
@@ -386,6 +379,18 @@ inline void Terrain3DData::set_control_auto(const Vector3 &p_global_position, co
 inline bool Terrain3DData::get_control_auto(const Vector3 &p_global_position) const {
 	uint32_t control = get_control(p_global_position);
 	return control == UINT32_MAX ? false : is_auto(control);
+}
+
+inline void Terrain3DData::set_color(const Vector3 &p_global_position, const Color &p_color) {
+	Color clr = p_color;
+	clr.a = get_roughness(p_global_position);
+	set_pixel(TYPE_COLOR, p_global_position, clr);
+}
+
+inline Color Terrain3DData::get_color(const Vector3 &p_global_position) const {
+	Color clr = get_pixel(TYPE_COLOR, p_global_position);
+	clr.a = 1.0f;
+	return clr;
 }
 
 inline void Terrain3DData::set_roughness(const Vector3 &p_global_position, const real_t p_roughness) {

--- a/src/terrain_3d_data.h
+++ b/src/terrain_3d_data.h
@@ -101,6 +101,7 @@ public:
 	void do_for_regions(const Rect2i &p_area, const Callable &p_callback);
 	void change_region_size(int region_size);
 
+	Vector2i world_to_vgrid(const Vector3 &p_global_position) const;
 	Vector2i get_region_location(const Vector3 &p_global_position) const;
 	int get_region_id(const Vector2i &p_region_loc) const;
 	int get_region_idp(const Vector3 &p_global_position) const;
@@ -143,11 +144,14 @@ public:
 
 	void set_pixel(const MapType p_map_type, const Vector3 &p_global_position, const Color &p_pixel);
 	Color get_pixel(const MapType p_map_type, const Vector3 &p_global_position) const;
+	Color get_pixel_descaled(const MapType p_map_type, const Vector2i &p_vgrid) const;
 
 	// Height Map
 	void set_height(const Vector3 &p_global_position, const real_t p_height);
 	real_t get_height(const Vector3 &p_global_position) const;
-	real_t get_region_blend(const Vector3 &p_global_position) const;
+	real_t get_surface_height(const Vector3 &p_global_position) const;
+	real_t get_modified_height(const Vector2i &p_vgrid) const;
+	real_t get_region_blend(const Vector2 &p_uv2) const;
 	Vector3 get_normal(const Vector3 &p_global_position) const;
 	bool is_in_slope(const Vector3 &p_global_position, const Vector2 &p_slope_range, const Vector3 &p_normal = V3_ZERO) const;
 
@@ -179,6 +183,7 @@ public:
 	real_t get_roughness(const Vector3 &p_global_position) const;
 
 	Vector3 get_mesh_vertex(const int32_t p_lod, const HeightFilter p_filter, const Vector3 &p_global_position) const;
+	real_t get_mesh_vertex_height(const int32_t p_lod, const HeightFilter p_filter, const Vector2i &p_vgrid) const;
 
 	void add_edited_area(const AABB &p_area);
 	void clear_edited_area() { _edited_area = AABB(); }
@@ -222,8 +227,7 @@ inline int Terrain3DData::get_region_map_index(const Vector2i &p_region_loc) {
 
 // Returns a region location given a global position. No bounds checking nor data access.
 inline Vector2i Terrain3DData::get_region_location(const Vector3 &p_global_position) const {
-	Vector2 descaled_position = v3v2(p_global_position) / _vertex_spacing;
-	return Vector2i((descaled_position / real_t(_region_size)).floor());
+	return V2I_DIVIDE_FLOOR(world_to_vgrid(p_global_position), _region_size);
 }
 
 // Returns id of any active region. -1 if out of bounds or no region, or region id
@@ -275,8 +279,22 @@ inline Ref<Terrain3DRegion> Terrain3DData::get_regionp(const Vector3 &p_global_p
 
 // Inline Map Functions
 
+// Descale and floor global position to vertex grid
+inline Vector2i Terrain3DData::world_to_vgrid(const Vector3 &p_global_position) const {
+	return Vector2i(Math::floor(p_global_position.x / _vertex_spacing),
+			Math::floor(p_global_position.z / _vertex_spacing));
+}
+
+inline Color Terrain3DData::get_pixel(const MapType p_map_type, const Vector3 &p_global_position) const {
+	return get_pixel_descaled(p_map_type, world_to_vgrid(p_global_position));
+}
+
 inline void Terrain3DData::set_height(const Vector3 &p_global_position, const real_t p_height) {
 	set_pixel(TYPE_HEIGHT, p_global_position, Color(p_height, 0.f, 0.f, 1.f));
+}
+
+inline real_t Terrain3DData::get_height(const Vector3 &p_global_position) const {
+	return get_pixel(TYPE_HEIGHT, p_global_position).r;
 }
 
 inline void Terrain3DData::set_control(const Vector3 &p_global_position, const uint32_t p_control) {

--- a/src/terrain_3d_instancer.cpp
+++ b/src/terrain_3d_instancer.cpp
@@ -516,14 +516,14 @@ Vector2i Terrain3DInstancer::_get_cell(const Vector3 &p_global_position, const i
 Array Terrain3DInstancer::_get_usable_height(const Vector3 &p_global_position, const Vector2 &p_slope_range, const bool p_on_collision, const real_t p_raycast_start) const {
 	IS_DATA_INIT(Array());
 	const Terrain3DData *data = _terrain->get_data();
-	real_t height = data->get_height(p_global_position);
+	real_t height = data->get_surface_height(p_global_position);
 	Dictionary raycast_result;
 	bool raycast_hit = false;
 	real_t raycast_height = -FLT_MAX;
 	Vector3 raycast_normal = V3_UP;
 	// Raycast physics if using on_collision
 	if (p_on_collision) {
-		Vector3 start_pos = Vector3(p_global_position.x, height + p_raycast_start, p_global_position.z);
+		Vector3 start_pos = Vector3(p_global_position.x, (std::isnan(height) ? 0.f : height) + p_raycast_start, p_global_position.z);
 		raycast_result = _terrain->get_raycast_result(start_pos, Vector3(0.0f, -p_raycast_start - 1.0f, 0.0f), 0xFFFFFFFF, true);
 		if (raycast_result.has("position")) {
 			raycast_hit = true;

--- a/src/terrain_3d_util.cpp
+++ b/src/terrain_3d_util.cpp
@@ -507,7 +507,7 @@ void Terrain3DUtil::benchmark(Terrain3D *p_terrain) {
 	for (int i = 0; i < 3; i++) {
 		start_time = Time::get_singleton()->get_ticks_msec();
 		for (int j = 0; j < 1000000; j++) {
-			data->get_height(vec);
+			data->get_surface_height(vec);
 		}
 		LOG(MESG, "get_height() 1M interpolated: ", Time::get_singleton()->get_ticks_msec() - start_time, "ms");
 	}


### PR DESCRIPTION
Admin edit

* get_height() is now a simple wrapper for get_pixel()
* get_surface_height() adds the material region blend and ground level and interpolates among adjacent vertices
* The UI shows both on the live info panel. The first is necessary for accurate picking
* Added Terrain3DData::world_to_vgrid() as a universal global_position to descaled, floored vertex grid converter which should be used for all functions for consistency in internal use.
* added get_pixel_descaled() and get_modified_height() which take a vgrid for internal use
* Collision, instancer, nav baking, mesh baking call these various new functions
* Improved importer detection and messaging
* Instancer on_collision start height now allows larger than 200m

----------

fixes #949
fixes #999

Moved the region blending code to Terrain3DData::get_height() so that it can be shared when generating collision, or checking the height for any other purpose including instance painting.

Collision generation still passes in the exact vertex so it doesn't need interpolation.  

<img width="1092" height="794" alt="image" src="https://github.com/user-attachments/assets/8f2d2831-2968-48e5-9cf3-783f1c1f104c" />
