### PR TITLE
Fix regions silently failing to save after an interrupted brush stroke

### DIFF
--- a/src/terrain_3d_editor.cpp
+++ b/src/terrain_3d_editor.cpp
@@ -906,16 +906,14 @@ void Terrain3DEditor::set_operation(const Operation p_operation) {
 // Called on mouse click
 void Terrain3DEditor::start_operation(const Vector3 &p_global_position) {
 	IS_DATA_INIT_MESG("Terrain isn't initialized", VOID);
+	// In case mouse-up was intercepted (by a modal dialog, focus change, or a raycast miss, etc...)
+	stop_operation();
 	LOG(INFO, "Setting up undo snapshot");
 	_undo_data.clear();
 	_undo_data["region_locations"] = _terrain->get_data()->get_region_locations().duplicate();
 	_is_operating = true;
-	_original_regions = TypedArray<Terrain3DRegion>(); // New pointers instead of clear
-	_edited_regions = TypedArray<Terrain3DRegion>();
-	_added_removed_locations = TypedArray<Vector2i>();
 	// Reset counter at start to ensure first click places an instance
 	_terrain->get_instancer()->reset_density_counter();
-	_terrain->get_data()->clear_edited_area();
 	_operation_position = p_global_position;
 	_operation_movement = V3_ZERO;
 }


### PR DESCRIPTION
If a brush stroke ends without `stop_operation()` running, the affected regions are left permanently flagged as edited. This means `backup_region()` skips them, which means they are never marked modified, never written to disk, and never recorded for undo operations.

This bug will help resolve https://github.com/sci-comp/scene-builder/issues/34 in my level design asset, which is how I found this bug (it's easy to intercept Terrain3D operations when another plugin is listening for hotkeys). 