### PR TITLE
Fix dummy texture RID leak on reinitialization

### DIFF
--- a/src/terrain_3d_material.cpp
+++ b/src/terrain_3d_material.cpp
@@ -827,7 +827,8 @@ void Terrain3DMaterial::initialize(Terrain3D *p_terrain) {
 	}
 	_shader.instantiate();
 	_buffer_shader.instantiate();
-	if (!_generated_dummy.get_rid().is_valid()) { // Create dummy texture array to avoid empty sampler2DArrays
+	// Create dummy texture array to avoid empty sampler2DArrays
+	if (!_generated_dummy.get_rid().is_valid()) {
 		Ref<Image> img = Image::create(1, 1, false, Image::FORMAT_RF);
 		TypedArray<Image> ia = { img };
 		_generated_dummy.create(ia);

--- a/src/terrain_3d_material.cpp
+++ b/src/terrain_3d_material.cpp
@@ -827,7 +827,7 @@ void Terrain3DMaterial::initialize(Terrain3D *p_terrain) {
 	}
 	_shader.instantiate();
 	_buffer_shader.instantiate();
-	{ // Create dummy texture array to avoid empty sampler2DArrays
+	if (!_generated_dummy.get_rid().is_valid()) { // Create dummy texture array to avoid empty sampler2DArrays
 		Ref<Image> img = Image::create(1, 1, false, Image::FORMAT_RF);
 		TypedArray<Image> ia = { img };
 		_generated_dummy.create(ia);


### PR DESCRIPTION
Terrain3DMaterial::initialize() can run repeatedly when assets or the data directory change at runtime. Each call recreated the dummy texture array and orphaned its previous RID. Reuse the existing valid dummy texture instead.