### PR TITLE
Quality of Life Features

### DIFF
--- a/project/addons/terrain_3d/src/asset_dock.gd
+++ b/project/addons/terrain_3d/src/asset_dock.gd
@@ -22,6 +22,7 @@ var box: BoxContainer
 var buttons: BoxContainer
 var textures_btn: Button
 var meshes_btn: Button
+var import_pairs_btn: Button
 var asset_container: ScrollContainer
 var confirm_dialog: ConfirmationDialog
 var _confirmed: bool = false
@@ -102,6 +103,14 @@ func initialize(p_plugin: EditorPlugin) -> void:
 
 	meshes_btn.add_theme_font_size_override("font_size", int(16. * EditorInterface.get_editor_scale()))
 	textures_btn.add_theme_font_size_override("font_size", int(16. * EditorInterface.get_editor_scale()))
+
+	import_pairs_btn = Button.new()
+	import_pairs_btn.text = "Import Pairs..."
+	import_pairs_btn.tooltip_text = "Bulk import albedo + normal texture pairs"
+	import_pairs_btn.owner = null
+	import_pairs_btn.visible = current_list == texture_list
+	import_pairs_btn.pressed.connect(_on_import_pairs_pressed)
+	buttons.add_child(import_pairs_btn, true)
 
 	search_box.text_changed.connect(_on_search_text_changed)
 	search_button.pressed.connect(_on_search_button_pressed)
@@ -268,6 +277,7 @@ func _on_textures_pressed() -> void:
 	mesh_list.visible = false
 	textures_btn.set_pressed_no_signal(true)
 	meshes_btn.set_pressed_no_signal(false)
+	import_pairs_btn.visible = true
 	texture_list.update_asset_list()
 	if plugin.is_terrain_valid():
 		EditorInterface.edit_node(plugin.terrain)
@@ -286,11 +296,22 @@ func _on_meshes_pressed() -> void:
 	texture_list.visible = false
 	meshes_btn.set_pressed_no_signal(true)
 	textures_btn.set_pressed_no_signal(false)
+	import_pairs_btn.visible = false
 	mesh_list.update_asset_list()
 	if plugin.is_terrain_valid():
 		EditorInterface.edit_node(plugin.terrain)
 	save_editor_settings()
 	_updating_list = false
+
+
+func _on_import_pairs_pressed() -> void:
+	if plugin.debug:
+		print("Terrain3DAssetDock: _on_import_pairs_pressed")
+	plugin.select_terrain()
+	var dialog := Terrain3DTexturePairImportDialog.new()
+	dialog.plugin = plugin
+	add_child(dialog)
+	dialog.popup_centered()
 
 
 func _on_tool_changed(p_tool: Terrain3DEditor.Tool, p_operation: Terrain3DEditor.Operation) -> void:
@@ -434,6 +455,7 @@ class ListContainer extends Container:
 		entry.clicked.connect(clicked_id.bind(entries.size()))
 		entry.inspected.connect(_on_resource_inspected)
 		entry.changed.connect(_on_resource_changed.bind(res_id))
+		entry.changed_multi.connect(_on_resources_added.bind(res_id))
 		entry.type = type
 		add_child(entry, true)
 		entries.push_back(entry)
@@ -523,15 +545,63 @@ class ListContainer extends Container:
 			await get_tree().process_frame
 
 		if plugin.is_terrain_valid():
+			var method: StringName = &"set_texture_asset" if type == Terrain3DAssets.TYPE_TEXTURE else &"set_mesh_asset"
+			var old_resource: Resource
 			if type == Terrain3DAssets.TYPE_TEXTURE:
-				plugin.terrain.assets.set_texture_asset(p_id, p_resource)
+				if p_id < plugin.terrain.assets.get_texture_count():
+					old_resource = plugin.terrain.assets.get_texture_asset(p_id)
 			else:
-				plugin.terrain.assets.set_mesh_asset(p_id, p_resource)
+				if p_id < plugin.terrain.assets.get_mesh_count():
+					old_resource = plugin.terrain.assets.get_mesh_asset(p_id)
+
+			if old_resource != p_resource:
+				var noun: String = "Texture" if type == Terrain3DAssets.TYPE_TEXTURE else "Mesh"
+				var action_name: String
+				if not p_resource:
+					action_name = "Remove Terrain3D " + noun
+				elif not old_resource:
+					action_name = "Add Terrain3D " + noun
+				else:
+					action_name = "Change Terrain3D " + noun
+				plugin.create_undo_action(action_name)
+				plugin.add_do_method(Callable(plugin.terrain.assets, method).bind(p_id, p_resource))
+				plugin.add_undo_method(Callable(plugin.terrain.assets, method).bind(p_id, old_resource))
+				plugin.commit_action(true)
 
 			# If removing an entry, clear inspector
 			if not p_resource:
-				EditorInterface.inspect_object(null)			
+				EditorInterface.inspect_object(null)
 		_clearing_resource = false
+
+
+	func _on_resources_added(p_resources: Array, p_start_id: int) -> void:
+		add_assets_bulk(p_resources, p_start_id)
+
+
+	## Adds multiple new assets in a single combined undo/redo action.
+	## p_start_id = -1 appends after the current last asset.
+	func add_assets_bulk(p_resources: Array, p_start_id: int = -1) -> void:
+		if p_resources.is_empty():
+			return
+		if not plugin.is_terrain_valid():
+			plugin.select_terrain()
+			await get_tree().process_frame
+		if not plugin.is_terrain_valid():
+			return
+		var max_count: int = Terrain3DAssets.MAX_MESHES if type == Terrain3DAssets.TYPE_MESH else Terrain3DAssets.MAX_TEXTURES
+		var noun: String = "Mesh" if type == Terrain3DAssets.TYPE_MESH else "Texture"
+		var method: StringName = &"set_mesh_asset" if type == Terrain3DAssets.TYPE_MESH else &"set_texture_asset"
+		var start_id: int = p_start_id
+		if start_id < 0:
+			start_id = plugin.terrain.assets.get_mesh_count() if type == Terrain3DAssets.TYPE_MESH else plugin.terrain.assets.get_texture_count()
+		plugin.create_undo_action("Add Terrain3D %ss" % noun)
+		for i in p_resources.size():
+			var id: int = start_id + i
+			if id >= max_count:
+				break
+			plugin.add_do_method(Callable(plugin.terrain.assets, method).bind(id, p_resources[i]))
+			plugin.add_undo_method(Callable(plugin.terrain.assets, method).bind(id, null))
+		plugin.commit_action(true)
 
 
 	func set_entry_width(value: float) -> void:
@@ -584,6 +654,7 @@ class ListEntry extends MarginContainer:
 	signal hovered()
 	signal clicked()
 	signal changed(resource: Resource)
+	signal changed_multi(resources: Array)
 	signal inspected(resource: Resource)
 	
 	var resource: Resource
@@ -851,20 +922,64 @@ class ListEntry extends MarginContainer:
 	func _can_drop_data(p_at_position: Vector2, p_data: Variant) -> bool:
 		drop_data = false
 		if typeof(p_data) == TYPE_DICTIONARY:
-			if p_data.files.size() == 1:
-				queue_redraw()
+			var file_count: int = p_data.files.size()
+			if file_count == 1:
 				drop_data = true
+			elif file_count > 1 and not resource:
+				# Multiple assets can only be dropped on the empty "add new" tile
+				drop_data = true
+			if drop_data:
+				queue_redraw()
 		return drop_data
 
-		
+
 	func _drop_data(p_at_position: Vector2, p_data: Variant) -> void:
 		if typeof(p_data) == TYPE_DICTIONARY:
+			if p_data.files.size() > 1 and not resource:
+				var new_assets: Array = []
+				if type == Terrain3DAssets.TYPE_MESH:
+					for file in p_data.files:
+						var dropped_res: Resource = load(file)
+						if dropped_res is PackedScene:
+							var ma := Terrain3DMeshAsset.new()
+							ma.set_scene_file(dropped_res)
+							new_assets.push_back(ma)
+						elif dropped_res is Terrain3DMeshAsset:
+							new_assets.push_back(dropped_res)
+				else:
+					for file in p_data.files:
+						var dropped_res: Resource = load(file)
+						# Multiple dropped textures are assumed to be albedo maps
+						if dropped_res is Texture2D:
+							var ta := Terrain3DTextureAsset.new()
+							ta.set_albedo_texture(dropped_res)
+							var normal_path: String = Terrain3DTexturePairMatcher.find_normal_sibling(file)
+							if normal_path != "":
+								var normal_res: Resource = load(normal_path)
+								if normal_res is Texture2D:
+									ta.set_normal_texture(normal_res)
+							new_assets.push_back(ta)
+						elif dropped_res is Terrain3DTextureAsset:
+							new_assets.push_back(dropped_res)
+				if new_assets.is_empty():
+					return
+				resource = new_assets[0]
+				set_edited_resource(resource, true)
+				emit_signal("changed_multi", new_assets)
+				emit_signal("clicked")
+				emit_signal("inspected", resource)
+				return
 			var res: Resource = load(p_data.files[0])
 			if res is Texture2D and type == Terrain3DAssets.TYPE_TEXTURE:
 				var ta := Terrain3DTextureAsset.new()
 				if resource is Terrain3DTextureAsset:
 					ta.id = resource.id
 				ta.set_albedo_texture(res)
+				var normal_path: String = Terrain3DTexturePairMatcher.find_normal_sibling(p_data.files[0])
+				if normal_path != "":
+					var normal_res: Resource = load(normal_path)
+					if normal_res is Texture2D:
+						ta.set_normal_texture(normal_res)
 				set_edited_resource(ta, false)
 				resource = ta
 			elif res is Terrain3DTextureAsset and type == Terrain3DAssets.TYPE_TEXTURE:

--- a/project/addons/terrain_3d/src/asset_dock_45.gd
+++ b/project/addons/terrain_3d/src/asset_dock_45.gd
@@ -28,6 +28,7 @@ var box: BoxContainer
 var buttons: BoxContainer
 var textures_btn: Button
 var meshes_btn: Button
+var import_pairs_btn: Button
 var asset_container: ScrollContainer
 var confirm_dialog: ConfirmationDialog
 var _confirmed: bool = false
@@ -111,6 +112,14 @@ func initialize(p_plugin: EditorPlugin) -> void:
 
 	meshes_btn.add_theme_font_size_override("font_size", 16 * EditorInterface.get_editor_scale())
 	textures_btn.add_theme_font_size_override("font_size", 16 * EditorInterface.get_editor_scale())
+
+	import_pairs_btn = Button.new()
+	import_pairs_btn.text = "Import Pairs..."
+	import_pairs_btn.tooltip_text = "Bulk import albedo + normal texture pairs"
+	import_pairs_btn.owner = null
+	import_pairs_btn.visible = current_list == texture_list
+	import_pairs_btn.pressed.connect(_on_import_pairs_pressed)
+	buttons.add_child(import_pairs_btn, true)
 
 	_initialized = true
 	update_dock()
@@ -319,6 +328,7 @@ func _on_textures_pressed() -> void:
 	mesh_list.visible = false
 	textures_btn.set_pressed_no_signal(true)
 	meshes_btn.set_pressed_no_signal(false)
+	import_pairs_btn.visible = true
 	texture_list.update_asset_list()
 	if plugin.is_terrain_valid():
 		EditorInterface.edit_node(plugin.terrain)
@@ -337,11 +347,22 @@ func _on_meshes_pressed() -> void:
 	texture_list.visible = false
 	meshes_btn.set_pressed_no_signal(true)
 	textures_btn.set_pressed_no_signal(false)
+	import_pairs_btn.visible = false
 	mesh_list.update_asset_list()
 	if plugin.is_terrain_valid():
 		EditorInterface.edit_node(plugin.terrain)
 	save_editor_settings()
 	_updating_list = false
+
+
+func _on_import_pairs_pressed() -> void:
+	if plugin.debug:
+		print("Terrain3DAssetDock: _on_import_pairs_pressed")
+	plugin.select_terrain()
+	var dialog := Terrain3DTexturePairImportDialog.new()
+	dialog.plugin = plugin
+	add_child(dialog)
+	dialog.popup_centered()
 
 
 func _on_tool_changed(p_tool: Terrain3DEditor.Tool, p_operation: Terrain3DEditor.Operation) -> void:
@@ -580,6 +601,7 @@ class ListContainer extends Container:
 		entry.clicked.connect(clicked_id.bind(entries.size()))
 		entry.inspected.connect(_on_resource_inspected)
 		entry.changed.connect(_on_resource_changed.bind(res_id))
+		entry.changed_multi.connect(_on_resources_added.bind(res_id))
 		entry.type = type
 		add_child(entry, true)
 		entries.push_back(entry)
@@ -669,15 +691,63 @@ class ListContainer extends Container:
 			await get_tree().process_frame
 
 		if plugin.is_terrain_valid():
+			var method: StringName = &"set_texture_asset" if type == Terrain3DAssets.TYPE_TEXTURE else &"set_mesh_asset"
+			var old_resource: Resource
 			if type == Terrain3DAssets.TYPE_TEXTURE:
-				plugin.terrain.assets.set_texture_asset(p_id, p_resource)
+				if p_id < plugin.terrain.assets.get_texture_count():
+					old_resource = plugin.terrain.assets.get_texture_asset(p_id)
 			else:
-				plugin.terrain.assets.set_mesh_asset(p_id, p_resource)
+				if p_id < plugin.terrain.assets.get_mesh_count():
+					old_resource = plugin.terrain.assets.get_mesh_asset(p_id)
+
+			if old_resource != p_resource:
+				var noun: String = "Texture" if type == Terrain3DAssets.TYPE_TEXTURE else "Mesh"
+				var action_name: String
+				if not p_resource:
+					action_name = "Remove Terrain3D " + noun
+				elif not old_resource:
+					action_name = "Add Terrain3D " + noun
+				else:
+					action_name = "Change Terrain3D " + noun
+				plugin.create_undo_action(action_name)
+				plugin.add_do_method(Callable(plugin.terrain.assets, method).bind(p_id, p_resource))
+				plugin.add_undo_method(Callable(plugin.terrain.assets, method).bind(p_id, old_resource))
+				plugin.commit_action(true)
 
 			# If removing an entry, clear inspector
 			if not p_resource:
-				EditorInterface.inspect_object(null)			
+				EditorInterface.inspect_object(null)
 		_clearing_resource = false
+
+
+	func _on_resources_added(p_resources: Array, p_start_id: int) -> void:
+		add_assets_bulk(p_resources, p_start_id)
+
+
+	## Adds multiple new assets in a single combined undo/redo action.
+	## p_start_id = -1 appends after the current last asset.
+	func add_assets_bulk(p_resources: Array, p_start_id: int = -1) -> void:
+		if p_resources.is_empty():
+			return
+		if not plugin.is_terrain_valid():
+			plugin.select_terrain()
+			await get_tree().process_frame
+		if not plugin.is_terrain_valid():
+			return
+		var max_count: int = Terrain3DAssets.MAX_MESHES if type == Terrain3DAssets.TYPE_MESH else Terrain3DAssets.MAX_TEXTURES
+		var noun: String = "Mesh" if type == Terrain3DAssets.TYPE_MESH else "Texture"
+		var method: StringName = &"set_mesh_asset" if type == Terrain3DAssets.TYPE_MESH else &"set_texture_asset"
+		var start_id: int = p_start_id
+		if start_id < 0:
+			start_id = plugin.terrain.assets.get_mesh_count() if type == Terrain3DAssets.TYPE_MESH else plugin.terrain.assets.get_texture_count()
+		plugin.create_undo_action("Add Terrain3D %ss" % noun)
+		for i in p_resources.size():
+			var id: int = start_id + i
+			if id >= max_count:
+				break
+			plugin.add_do_method(Callable(plugin.terrain.assets, method).bind(id, p_resources[i]))
+			plugin.add_undo_method(Callable(plugin.terrain.assets, method).bind(id, null))
+		plugin.commit_action(true)
 
 
 	func set_entry_width(value: float) -> void:
@@ -729,6 +799,7 @@ class ListEntry extends MarginContainer:
 	signal hovered()
 	signal clicked()
 	signal changed(resource: Resource)
+	signal changed_multi(resources: Array)
 	signal inspected(resource: Resource)
 	
 	var resource: Resource
@@ -996,20 +1067,64 @@ class ListEntry extends MarginContainer:
 	func _can_drop_data(p_at_position: Vector2, p_data: Variant) -> bool:
 		drop_data = false
 		if typeof(p_data) == TYPE_DICTIONARY:
-			if p_data.files.size() == 1:
-				queue_redraw()
+			var file_count: int = p_data.files.size()
+			if file_count == 1:
 				drop_data = true
+			elif file_count > 1 and not resource:
+				# Multiple assets can only be dropped on the empty "add new" tile
+				drop_data = true
+			if drop_data:
+				queue_redraw()
 		return drop_data
 
-		
+
 	func _drop_data(p_at_position: Vector2, p_data: Variant) -> void:
 		if typeof(p_data) == TYPE_DICTIONARY:
+			if p_data.files.size() > 1 and not resource:
+				var new_assets: Array = []
+				if type == Terrain3DAssets.TYPE_MESH:
+					for file in p_data.files:
+						var dropped_res: Resource = load(file)
+						if dropped_res is PackedScene:
+							var ma := Terrain3DMeshAsset.new()
+							ma.set_scene_file(dropped_res)
+							new_assets.push_back(ma)
+						elif dropped_res is Terrain3DMeshAsset:
+							new_assets.push_back(dropped_res)
+				else:
+					for file in p_data.files:
+						var dropped_res: Resource = load(file)
+						# Multiple dropped textures are assumed to be albedo maps
+						if dropped_res is Texture2D:
+							var ta := Terrain3DTextureAsset.new()
+							ta.set_albedo_texture(dropped_res)
+							var normal_path: String = Terrain3DTexturePairMatcher.find_normal_sibling(file)
+							if normal_path != "":
+								var normal_res: Resource = load(normal_path)
+								if normal_res is Texture2D:
+									ta.set_normal_texture(normal_res)
+							new_assets.push_back(ta)
+						elif dropped_res is Terrain3DTextureAsset:
+							new_assets.push_back(dropped_res)
+				if new_assets.is_empty():
+					return
+				resource = new_assets[0]
+				set_edited_resource(resource, true)
+				emit_signal("changed_multi", new_assets)
+				emit_signal("clicked")
+				emit_signal("inspected", resource)
+				return
 			var res: Resource = load(p_data.files[0])
 			if res is Texture2D and type == Terrain3DAssets.TYPE_TEXTURE:
 				var ta := Terrain3DTextureAsset.new()
 				if resource is Terrain3DTextureAsset:
 					ta.id = resource.id
 				ta.set_albedo_texture(res)
+				var normal_path: String = Terrain3DTexturePairMatcher.find_normal_sibling(p_data.files[0])
+				if normal_path != "":
+					var normal_res: Resource = load(normal_path)
+					if normal_res is Texture2D:
+						ta.set_normal_texture(normal_res)
 				set_edited_resource(ta, false)
 				resource = ta
 			elif res is Terrain3DTextureAsset and type == Terrain3DAssets.TYPE_TEXTURE:

--- a/project/addons/terrain_3d/src/texture_pair_import_dialog.gd
+++ b/project/addons/terrain_3d/src/texture_pair_import_dialog.gd
@@ -1,0 +1,252 @@
+# Copyright © 2023-2026 Cory Petkovsek, Roope Palmroos, and Contributors.
+# Bulk albedo/normal texture pair import dialog for Terrain3D
+@tool
+extends ConfirmationDialog
+class_name Terrain3DTexturePairImportDialog
+
+var plugin: EditorPlugin
+
+var _pending_albedo_files: PackedStringArray = []
+var _pending_normal_files: PackedStringArray = []
+var _rows: Array[Dictionary] = []
+var _rows_box: VBoxContainer
+var _open_file_dialog: EditorFileDialog
+var _edit_row_index: int = -1
+var _edit_row_side: String = ""
+
+
+func _init() -> void:
+	title = "Import Texture Pairs"
+	min_size = Vector2i(560, 420)
+	# Non-modal: let the user drag files in from the FileSystem dock while this is open
+	exclusive = false
+	transient = false
+	always_on_top = true
+	confirmed.connect(_on_import)
+	canceled.connect(queue_free)
+	close_requested.connect(queue_free)
+	_build_ui()
+
+
+func _build_ui() -> void:
+	var vbox := VBoxContainer.new()
+	vbox.size_flags_horizontal = Control.SIZE_EXPAND_FILL
+	vbox.size_flags_vertical = Control.SIZE_EXPAND_FILL
+	add_child(vbox)
+
+	var columns := HBoxContainer.new()
+	columns.add_theme_constant_override("separation", 12)
+	vbox.add_child(columns)
+	columns.add_child(_build_column("Albedo", _on_albedo_dropped))
+	columns.add_child(_build_column("Normal", _on_normal_dropped))
+
+	var scroll := ScrollContainer.new()
+	scroll.custom_minimum_size = Vector2(0, 220)
+	scroll.size_flags_vertical = Control.SIZE_EXPAND_FILL
+	vbox.add_child(scroll)
+	_rows_box = VBoxContainer.new()
+	_rows_box.size_flags_horizontal = Control.SIZE_EXPAND_FILL
+	scroll.add_child(_rows_box)
+
+	var row_actions := HBoxContainer.new()
+	vbox.add_child(row_actions)
+	var add_row_btn := Button.new()
+	add_row_btn.text = "+ Add Row"
+	add_row_btn.size_flags_horizontal = Control.SIZE_EXPAND_FILL
+	add_row_btn.pressed.connect(_on_add_row_pressed)
+	row_actions.add_child(add_row_btn)
+	var clear_btn := Button.new()
+	clear_btn.text = "Clear List"
+	clear_btn.tooltip_text = "Remove all rows"
+	clear_btn.size_flags_horizontal = Control.SIZE_EXPAND_FILL
+	clear_btn.pressed.connect(_on_clear_pressed)
+	row_actions.add_child(clear_btn)
+
+	var image_filters: PackedStringArray = []
+	for ext in Terrain3DTexturePairMatcher.IMAGE_EXTENSIONS:
+		image_filters.append("*." + ext)
+
+	_open_file_dialog = EditorFileDialog.new()
+	_open_file_dialog.set_filters(image_filters)
+	_open_file_dialog.set_file_mode(EditorFileDialog.FILE_MODE_OPEN_FILE)
+	_open_file_dialog.access = EditorFileDialog.ACCESS_FILESYSTEM
+	_open_file_dialog.file_selected.connect(_on_file_picked)
+	add_child(_open_file_dialog)
+
+	get_ok_button().text = "Import"
+	get_ok_button().disabled = true
+
+
+func _build_column(p_title: String, p_dropped_callback: Callable) -> VBoxContainer:
+	var col := VBoxContainer.new()
+	col.size_flags_horizontal = Control.SIZE_EXPAND_FILL
+	var label := Label.new()
+	label.text = p_title
+	label.horizontal_alignment = HORIZONTAL_ALIGNMENT_CENTER
+	col.add_child(label)
+	var drop_zone := DropZone.new()
+	drop_zone.text = "Drop %s images here" % p_title
+	drop_zone.custom_minimum_size = Vector2(0, 60)
+	drop_zone.files_dropped.connect(p_dropped_callback)
+	col.add_child(drop_zone)
+	return col
+
+
+func _on_albedo_dropped(p_files: PackedStringArray) -> void:
+	for file in p_files:
+		if not _pending_albedo_files.has(file):
+			_pending_albedo_files.append(file)
+	_rebuild_rows()
+
+
+func _on_normal_dropped(p_files: PackedStringArray) -> void:
+	for file in p_files:
+		if not _pending_normal_files.has(file):
+			_pending_normal_files.append(file)
+	_rebuild_rows()
+
+
+func _rebuild_rows() -> void:
+	_rows = Terrain3DTexturePairMatcher.pair_lists(_pending_albedo_files, _pending_normal_files)
+	_refresh_rows_ui()
+
+
+func _refresh_rows_ui() -> void:
+	for child in _rows_box.get_children():
+		child.queue_free()
+	for i in _rows.size():
+		_rows_box.add_child(_build_row(i))
+	get_ok_button().disabled = not _has_valid_row()
+
+
+func _has_valid_row() -> bool:
+	for row in _rows:
+		if row.albedo != "":
+			return true
+	return false
+
+
+func _build_row(p_index: int) -> HBoxContainer:
+	var row: Dictionary = _rows[p_index]
+	var hbox := HBoxContainer.new()
+	hbox.size_flags_horizontal = Control.SIZE_EXPAND_FILL
+
+	var albedo_label := Label.new()
+	albedo_label.text = row.albedo.get_file() if row.albedo != "" else "(choose albedo)"
+	albedo_label.size_flags_horizontal = Control.SIZE_EXPAND_FILL
+	albedo_label.clip_text = true
+	if row.albedo == "":
+		albedo_label.modulate = Color(1., 1., 1., .5)
+	hbox.add_child(albedo_label)
+
+	var albedo_change := Button.new()
+	albedo_change.text = "Change"
+	albedo_change.pressed.connect(_on_change_pressed.bind(p_index, "albedo"))
+	hbox.add_child(albedo_change)
+
+	var arrow := Label.new()
+	arrow.text = "  →  "
+	hbox.add_child(arrow)
+
+	var normal_label := Label.new()
+	normal_label.text = row.normal.get_file() if row.normal != "" else "(none)"
+	normal_label.size_flags_horizontal = Control.SIZE_EXPAND_FILL
+	normal_label.clip_text = true
+	if row.normal == "":
+		normal_label.modulate = Color(1., 1., 1., .5)
+	hbox.add_child(normal_label)
+
+	var normal_change := Button.new()
+	normal_change.text = "Change"
+	normal_change.pressed.connect(_on_change_pressed.bind(p_index, "normal"))
+	hbox.add_child(normal_change)
+
+	var remove_btn := Button.new()
+	remove_btn.text = "x"
+	remove_btn.tooltip_text = "Remove row"
+	remove_btn.pressed.connect(_on_remove_row.bind(p_index))
+	hbox.add_child(remove_btn)
+
+	return hbox
+
+
+func _on_add_row_pressed() -> void:
+	_rows.push_back({ "albedo": "", "normal": "" })
+	_refresh_rows_ui()
+
+
+func _on_clear_pressed() -> void:
+	_pending_albedo_files.clear()
+	_pending_normal_files.clear()
+	_rows.clear()
+	_refresh_rows_ui()
+
+
+func _on_change_pressed(p_index: int, p_side: String) -> void:
+	_edit_row_index = p_index
+	_edit_row_side = p_side
+	_open_file_dialog.popup_centered()
+
+
+func _on_file_picked(p_path: String) -> void:
+	if _edit_row_index >= 0 and _edit_row_index < _rows.size():
+		_rows[_edit_row_index][_edit_row_side] = p_path
+		if _edit_row_side == "albedo" and not _pending_albedo_files.has(p_path):
+			_pending_albedo_files.append(p_path)
+		elif _edit_row_side == "normal" and not _pending_normal_files.has(p_path):
+			_pending_normal_files.append(p_path)
+	_edit_row_index = -1
+	_edit_row_side = ""
+	_refresh_rows_ui()
+
+
+func _on_remove_row(p_index: int) -> void:
+	if p_index >= 0 and p_index < _rows.size():
+		_rows.remove_at(p_index)
+		_refresh_rows_ui()
+
+
+func _on_import() -> void:
+	var new_assets: Array[Terrain3DTextureAsset] = []
+	for row in _rows:
+		if row.albedo == "":
+			continue
+		var albedo_res: Resource = load(row.albedo)
+		if not (albedo_res is Texture2D):
+			continue
+		var ta := Terrain3DTextureAsset.new()
+		ta.set_albedo_texture(albedo_res)
+		if row.normal != "":
+			var normal_res: Resource = load(row.normal)
+			if normal_res is Texture2D:
+				ta.set_normal_texture(normal_res)
+		new_assets.push_back(ta)
+	if not new_assets.is_empty() and plugin and plugin.asset_dock:
+		plugin.asset_dock.texture_list.add_assets_bulk(new_assets)
+	queue_free()
+
+
+##############################################################
+## class DropZone
+##############################################################
+
+
+class DropZone extends Button:
+	signal files_dropped(files: PackedStringArray)
+
+
+	func _can_drop_data(p_at_position: Vector2, p_data: Variant) -> bool:
+		if typeof(p_data) == TYPE_DICTIONARY and p_data.has("files"):
+			for file in p_data.files:
+				if Terrain3DTexturePairMatcher.IMAGE_EXTENSIONS.has(file.get_extension().to_lower()):
+					return true
+		return false
+
+
+	func _drop_data(p_at_position: Vector2, p_data: Variant) -> void:
+		var files: PackedStringArray = []
+		for file in p_data.files:
+			if Terrain3DTexturePairMatcher.IMAGE_EXTENSIONS.has(file.get_extension().to_lower()):
+				files.append(file)
+		if not files.is_empty():
+			files_dropped.emit(files)

--- a/project/addons/terrain_3d/src/texture_pair_import_dialog.gd.uid
+++ b/project/addons/terrain_3d/src/texture_pair_import_dialog.gd.uid
@@ -1,0 +1,1 @@
+uid://0uu5qvlc7sym

--- a/project/addons/terrain_3d/src/texture_pair_matcher.gd
+++ b/project/addons/terrain_3d/src/texture_pair_matcher.gd
@@ -1,0 +1,103 @@
+# Copyright © 2023-2026 Cory Petkovsek, Roope Palmroos, and Contributors.
+# Matches albedo texture files to their normal map sibling by filename convention
+extends RefCounted
+class_name Terrain3DTexturePairMatcher
+
+# Role tokens are matched as whole underscore-delimited segments, wherever they occur in the
+# filename -- e.g. both "rock_albedo.png" (role at the end) and "rock_packed_albedo_height.png"
+# (role in the middle, followed by extra channel info) are recognized.
+const ALBEDO_KEYWORDS: PackedStringArray = [
+	"albedo", "basecolor", "diffuse", "diff", "color", "col",
+]
+const NORMAL_KEYWORDS: PackedStringArray = [ "normal", "nrm", "norm", "n", "nml" ]
+
+# Matches the extensions accepted by channel_packer_dragdrop.gd
+const IMAGE_EXTENSIONS: PackedStringArray = [
+	"png", "bmp", "exr", "hdr", "jpg", "jpeg", "tga", "svg", "webp", "ktx", "dds",
+]
+
+
+# Splits a filename stem into lowercase underscore-delimited segments, normalizing the
+# two-segment "base_color" spelling to the single token "basecolor" first.
+static func _segments(p_stem: String) -> PackedStringArray:
+	var normalized: String = p_stem.to_lower().replace("base_color", "basecolor")
+	return normalized.split("_")
+
+
+# Returns the index of the first segment matching a keyword in p_keywords, or -1.
+static func _find_role_index(p_segments: PackedStringArray, p_keywords: PackedStringArray) -> int:
+	for i in p_segments.size():
+		if p_keywords.has(p_segments[i]):
+			return i
+	return -1
+
+
+# Returns true if any segment of p_path's filename matches a keyword in p_keywords.
+static func _has_role(p_path: String, p_keywords: PackedStringArray) -> bool:
+	return _find_role_index(_segments(p_path.get_file().get_basename()), p_keywords) != -1
+
+
+# Returns a directory+prefix key with the role token and everything after it stripped, so that
+# "dir/rock_packed_albedo_height" and "dir/rock_packed_normal_roughness" both normalize to
+# "dir/rock_packed". Files with no recognized role token return their full stem unchanged.
+static func _base_key(p_path: String) -> String:
+	var dir: String = p_path.get_base_dir()
+	var segments: PackedStringArray = _segments(p_path.get_file().get_basename())
+	var role_index: int = _find_role_index(segments, ALBEDO_KEYWORDS)
+	if role_index == -1:
+		role_index = _find_role_index(segments, NORMAL_KEYWORDS)
+	if role_index == -1:
+		return dir.path_join("_".join(segments))
+	return dir.path_join("_".join(segments.slice(0, role_index)))
+
+
+# Given an absolute/res:// path to an albedo image, looks in the same directory for a sibling
+# file that shares its base key and carries a normal-map role token. Returns the sibling path,
+# or "" if none is found.
+static func find_normal_sibling(p_albedo_path: String) -> String:
+	var dir_path: String = p_albedo_path.get_base_dir()
+	var dir: DirAccess = DirAccess.open(dir_path)
+	if not dir:
+		return ""
+
+	var target_key: String = _base_key(p_albedo_path)
+	dir.list_dir_begin()
+	var file_name: String = dir.get_next()
+	while file_name != "":
+		if not dir.current_is_dir() and IMAGE_EXTENSIONS.has(file_name.get_extension().to_lower()):
+			var candidate_path: String = dir_path.path_join(file_name)
+			if candidate_path != p_albedo_path \
+					and _base_key(candidate_path) == target_key \
+					and _has_role(candidate_path, NORMAL_KEYWORDS):
+				dir.list_dir_end()
+				return candidate_path
+		file_name = dir.get_next()
+	dir.list_dir_end()
+	return ""
+
+
+# Given the albedo-column and normal-column file lists from the pair import dialog, pairs them
+# up by matching base key. Unlike find_normal_sibling(), the column a file was dropped into is
+# always authoritative for its role -- filenames are only used to decide which albedo/normal go
+# together, never to reclassify a file dropped into the "wrong" column.
+# Returns Array[Dictionary], each {"albedo": String, "normal": String} (either may be "").
+static func pair_lists(p_albedo_files: PackedStringArray, p_normal_files: PackedStringArray) -> Array[Dictionary]:
+	var normal_by_key: Dictionary = {} # base_key -> normal file path
+	for file in p_normal_files:
+		normal_by_key[_base_key(file)] = file
+
+	var pairs: Array[Dictionary] = []
+	var consumed_keys: Dictionary = {}
+	for file in p_albedo_files:
+		var key: String = _base_key(file)
+		var normal_path: String = ""
+		if normal_by_key.has(key):
+			normal_path = normal_by_key[key]
+			consumed_keys[key] = true
+		pairs.push_back({ "albedo": file, "normal": normal_path })
+
+	for file in p_normal_files:
+		if not consumed_keys.has(_base_key(file)):
+			pairs.push_back({ "albedo": "", "normal": file })
+
+	return pairs

--- a/project/addons/terrain_3d/src/texture_pair_matcher.gd.uid
+++ b/project/addons/terrain_3d/src/texture_pair_matcher.gd.uid
@@ -1,0 +1,1 @@
+uid://bbscclssmmyhs


### PR DESCRIPTION
## Summary
- Add texture pair import dialog and matcher for bulk importing albedo/normal textures
- Users can now drag-and-drop multiple files into the textures and meshes panels
- Added editor's own Undo/Redo (history) registration for user changes in these two areas

## Test plan
- [ ] Manually verify drag-and-drop import of multiple albedo/normal texture pairs in the editor
- [ ] Verify Undo/Redo works for texture and mesh dock changes