### PR TITLE
Add slope point selection hotkeys

### DIFF
--- a/project/addons/terrain_3d/src/editor_plugin.gd
+++ b/project/addons/terrain_3d/src/editor_plugin.gd
@@ -233,6 +233,7 @@ func _forward_3d_gui_input(p_viewport_camera: Camera3D, p_event: InputEvent) -> 
 				var height: float = terrain.data.get_height(mouse_global_position)
 				ui.brush_data["height"] = height
 				ui.tool_settings.set_setting("height", height)
+				return AFTER_GUI_INPUT_STOP
 				
 			# If adjusting regions
 			if editor.get_tool() == Terrain3DEditor.REGION:
@@ -334,6 +335,9 @@ func _read_input(p_event: InputEvent = null) -> AfterGUIInput:
 
 # Returns true if hotkey matches and operation triggered
 func consume_hotkey(p_event: InputEventKey) -> bool:
+	if ui.operation_builder and ui.operation_builder.try_consume_hotkey(p_event):
+		return true
+
 	# Handle repeatable keys
 	match p_event.keycode:
 		KEY_BRACKETLEFT:

--- a/project/addons/terrain_3d/src/gradient_operation_builder.gd
+++ b/project/addons/terrain_3d/src/gradient_operation_builder.gd
@@ -55,3 +55,15 @@ func apply_operation(p_editor: Terrain3DEditor, p_global_position: Vector3, p_ca
 	p_editor.stop_operation()
 	
 	_get_point_picker().clear()
+
+
+func try_consume_hotkey(p_event: InputEventKey) -> bool:
+	var picker: MultiPicker = _get_point_picker()
+	match p_event.keycode:
+		KEY_1:
+			picker.buttons[0].pressed.emit()
+		KEY_2:
+			picker.buttons[1].pressed.emit()
+		_:
+			return false
+	return true

--- a/project/addons/terrain_3d/src/multi_picker.gd
+++ b/project/addons/terrain_3d/src/multi_picker.gd
@@ -10,9 +10,9 @@ signal value_changed
 const ICON_PICKER_CHECKED: String = "res://addons/terrain_3d/icons/picker_checked.svg"
 const MAX_POINTS: int = 2
 
-
 var icon_picker: Texture2D
 var icon_picker_checked: Texture2D
+var buttons: Array[Button]
 var points: PackedVector3Array
 var picking_index: int = -1
 
@@ -29,6 +29,7 @@ func _enter_tree() -> void:
 		button.tooltip_text = "Pick point on the Terrain"
 		button.set_meta(&"point_index", i)
 		button.pressed.connect(_on_button_pressed.bind(i))
+		buttons.append(button)
 		add_child(button)
 	
 	_update_buttons()
@@ -42,9 +43,8 @@ func _on_button_pressed(button_index: int) -> void:
 
 
 func _update_buttons() -> void:
-	for child in get_children():
-		if child is Button:
-			_update_button(child)
+	for button in buttons:
+		_update_button(button)
 
 
 func _update_button(button: Button) -> void:

--- a/project/addons/terrain_3d/src/operation_builder.gd
+++ b/project/addons/terrain_3d/src/operation_builder.gd
@@ -23,3 +23,7 @@ func is_ready() -> bool:
 
 func apply_operation(editor: Terrain3DEditor, p_global_position: Vector3, p_camera_direction: float) -> void:
 	pass
+
+
+func try_consume_hotkey(p_event: InputEventKey) -> bool:
+	return false


### PR DESCRIPTION
Adds shortcuts for individual slope point selection.

When the slope tool is active, `KEY_1` selects the first gradient point for picking, `KEY_2` selects the second.

This PR introduces `OperationBuilder` input/hotkey consumption, which is hopefully a clean enough approach for scoping hotkeys to certain tools and operations.

This version currently overrides the default region grid toggle (`KEY_1`) and region label toggle (`KEY_2`) when the slope tool is selected. I just personally find `KEY_1` and `KEY_2` far too convenient to limit to debug toggles, but this is also something that can be addressed once https://github.com/TokisanGames/Terrain3D/pull/983 is merged.

https://github.com/user-attachments/assets/970d2361-bb70-4037-acd9-e6134685b343