### PR TITLE
Add erosion brush (issue #102)

### DIFF
--- a/project/addons/terrain_3d/src/toolbar.gd
+++ b/project/addons/terrain_3d/src/toolbar.gd
@@ -44,10 +44,18 @@ func _ready() -> void:
 		"add_text":"Raise (R)", "add_op":Terrain3DEditor.ADD, "add_icon":ICON_HEIGHT_ADD,
 		"sub_text":"Lower (R)", "sub_op":Terrain3DEditor.SUBTRACT, "sub_icon":ICON_HEIGHT_SUB })
 
-	add_tool_button({ "tool":Terrain3DEditor.SCULPT, 
+	add_tool_button({ "tool":Terrain3DEditor.SCULPT,
 		"add_text":"Smooth (Shift)", "add_op":Terrain3DEditor.AVERAGE, "add_icon":ICON_HEIGHT_SMOOTH })
 
-	add_tool_button({ "tool":Terrain3DEditor.HEIGHT, 
+	# No dedicated icon or shortcut key yet -- reuses the smooth icon as a
+	# placeholder (both are neighborhood-filter height operations) and no
+	# letter is claimed since every other single-key shortcut in this file
+	# is already in use; a maintainer/community keybind + real icon are a
+	# natural follow-up, not required for the feature to work.
+	add_tool_button({ "tool":Terrain3DEditor.SCULPT,
+		"add_text":"Erode", "add_op":Terrain3DEditor.ERODE, "add_icon":ICON_HEIGHT_SMOOTH })
+
+	add_tool_button({ "tool":Terrain3DEditor.HEIGHT,
 		"add_text":"Height (H)", "add_op":Terrain3DEditor.ADD, "add_icon":ICON_HEIGHT_FLAT,
 		"sub_text":"Height (H)", "sub_op":Terrain3DEditor.SUBTRACT, "sub_icon":ICON_HEIGHT_FLAT })
 

--- a/project/addons/terrain_3d/src/ui.gd
+++ b/project/addons/terrain_3d/src/ui.gd
@@ -20,6 +20,7 @@ const COLOR_LIFT := Color(1.0, 0.6, 0.0) # Bright orange
 const COLOR_FLATTEN := Color(0.0, 0.6, 1.0) # Cyan
 const COLOR_HEIGHT := Color(0.0, 0.8, 0.8) # Brighter cyan
 const COLOR_SLOPE := Color(1.0, 1.0, 0.0) # Bright yellow
+const COLOR_ERODE := Color(0.55, 0.27, 0.07) # Saddle brown
 const COLOR_PAINT := Color(0.0, 0.5, 0.0) # Dark green
 const COLOR_SPRAY := Color(0.4, 0.8, 0.4) # Lighter green
 const COLOR_UNSPRAY := Color(0.5, 0.2, 0.5) # Neutral purple
@@ -461,6 +462,9 @@ func update_decal() -> void:
 					Terrain3DEditor.GRADIENT:
 						editor_decal_color[0] = COLOR_SLOPE
 						editor_decal_color[0].a = clamp(brush_data["strength"], .2, .4)
+					Terrain3DEditor.ERODE:
+						editor_decal_color[0] = COLOR_ERODE
+						editor_decal_color[0].a = clamp(brush_data["strength"], .2, .5) + .25
 			Terrain3DEditor.HEIGHT:
 				editor_decal_color[0] = COLOR_HEIGHT
 				editor_decal_color[0].a = clamp(brush_data["strength"], .2, .5) + .25

--- a/src/terrain_3d_editor.cpp
+++ b/src/terrain_3d_editor.cpp
@@ -298,6 +298,10 @@ void Terrain3DEditor::_operate_map(const Vector3 &p_global_position, const real_
 						}
 						break;
 					}
+					case ERODE: {
+						destf = _erode(brush_global_position, srcf, brush_alpha * strength);
+						break;
+					}
 					default:
 						break;
 				}
@@ -822,6 +826,39 @@ Color Terrain3DEditor::_average(const Vector3 &p_global_position, const Color &p
 			.linear_to_srgb();
 }
 
+// Morphological (min-filter) erosion, adapted from Zylann's HTerrain
+// erode.gdshader (github.com/Zylann/godot_heightmap_plugin,
+// tools/brush/shaders/erode.gdshader) -- for every point within a small
+// circular neighborhood, take the minimum height plus a distance-based
+// penalty that's 0 inside the radius and grows outside it (so the square
+// sample loop below reads like a soft circular kernel, without a hard
+// per-sample cutoff), then blend toward that eroded height by p_weight.
+// This is a simple, cheap, CPU-friendly technique, not a physically-based
+// hydraulic/thermal simulation -- full procedural erosion generation
+// (issue #101) is explicitly gated on GPU compute infrastructure landing
+// first (issue #174, still open). Matches the maintainer's own scoping of
+// this feature on issue #102: "Just an erosion brush is fine."
+real_t Terrain3DEditor::_erode(const Vector3 &p_global_position, const real_t p_base, const real_t p_weight) const {
+	IS_DATA_INIT(NAN);
+	Terrain3DData *data = _terrain->get_data();
+	real_t vertex_spacing = _terrain->get_vertex_spacing();
+	const int radius = 3;
+	real_t eroded_height = p_base;
+	for (int y = -radius; y <= radius; y++) {
+		for (int x = -radius; x <= radius; x++) {
+			Vector3 sample_pos = p_global_position + Vector3(real_t(x) * vertex_spacing, 0.f, real_t(y) * vertex_spacing);
+			real_t neighbor_height = data->get_height(sample_pos);
+			if (std::isnan(neighbor_height)) {
+				continue;
+			}
+			real_t dist = Vector2(real_t(x), real_t(y)).length();
+			real_t falloff = MAX(dist - real_t(radius), 0.f);
+			eroded_height = MIN(eroded_height, neighbor_height + falloff);
+		}
+	}
+	return Math::lerp(p_base, eroded_height, CLAMP(p_weight, 0.f, 1.f));
+}
+
 ///////////////////////////
 // Public Functions
 ///////////////////////////
@@ -1005,6 +1042,7 @@ void Terrain3DEditor::_bind_methods() {
 	BIND_ENUM_CONSTANT(REPLACE);
 	BIND_ENUM_CONSTANT(AVERAGE);
 	BIND_ENUM_CONSTANT(GRADIENT);
+	BIND_ENUM_CONSTANT(ERODE);
 	BIND_ENUM_CONSTANT(OP_MAX);
 
 	BIND_ENUM_CONSTANT(SCULPT);

--- a/src/terrain_3d_editor.h
+++ b/src/terrain_3d_editor.h
@@ -52,6 +52,7 @@ public: // Constants
 		REPLACE,
 		AVERAGE,
 		GRADIENT,
+		ERODE,
 		OP_MAX,
 	};
 
@@ -61,6 +62,7 @@ public: // Constants
 		"Replace",
 		"Average",
 		"Gradient",
+		"Erode",
 		"OP_MAX",
 	};
 
@@ -100,6 +102,7 @@ private:
 	void _apply_undo(const Dictionary &p_data);
 	float _average(const AverageMode p_mode, const Vector3 &p_global_position, const float p_base, const float p_nan_val = 0.f, bool p_alt = false) const;
 	Color _average(const Vector3 &p_global_position, const Color &p_base) const;
+	real_t _erode(const Vector3 &p_global_position, const real_t p_base, const real_t p_weight) const;
 
 public:
 	Terrain3DEditor() {}


### PR DESCRIPTION
## Summary
New Sculpt tool operation, **Erode**, alongside the existing Add/Subtract/Average(Smooth)/Gradient(Slope). Implements the morphological min-filter technique from Zylann's HTerrain `erode.gdshader` ([godot_heightmap_plugin](https://github.com/Zylann/godot_heightmap_plugin/blob/master/addons/zylann.hterrain/tools/brush/shaders/erode.gdshader), linked from the issue as the reference): for every point in a small circular neighborhood (radius 3), take the minimum height plus a distance-based penalty that's 0 inside the radius and grows outside it, then blend toward that eroded result by brush strength. This wears down peaks toward their lowest nearby point without a hard per-sample cutoff at the kernel edge.

Deliberately **not** a physically-based hydraulic/thermal simulation. Full procedural erosion generation (#101) is explicitly gated by the maintainer on GPU compute infrastructure landing first (#174, still open) — building that now would mean fighting infrastructure that isn't settled yet. The scoping note on #102 itself ("Just an erosion brush is fine") describes a CPU brush op, which is what this is, fitting directly into the existing per-pixel brush pipeline alongside Average/Gradient rather than requiring any new architecture.

Editor UI: new toolbar button and cursor decal color, reusing the Smooth icon as a placeholder since no dedicated erosion icon exists yet, and no keyboard shortcut claimed since every free single letter would be arbitrary — both are easy follow-ups, not required for the feature to work.

## Test plan
- [x] Real `Terrain3DEditor` session, not just compile success: a 64x64 region with a single sharp peak (height 30) surrounded by flat terrain (height 10), five real `operate()` calls at full strength through the actual `start_operation`/`operate`/`stop_operation` sequence the editor plugin itself drives.
- [x] Peak eroded down to exactly 10 (converged to its flat neighbors, matching the min-filter math).
- [x] A flat area outside the brush radius stayed untouched.
- [x] Caught a real bug via this test, not inspection: `ERODE` was added to the `Operation` enum without a matching `BIND_ENUM_CONSTANT(ERODE)`, leaving it invisible to GDScript/the editor despite compiling fine in C++.