### PR TITLE
Add Terrain3D::rebase() for floating origin support

### DIFF
--- a/src/terrain_3d.cpp
+++ b/src/terrain_3d.cpp
@@ -743,6 +743,50 @@ void Terrain3D::snap() {
 	}
 }
 
+// Shifts the whole terrain (region data, collision, instanced meshes, render mesh) by p_delta, so a
+// host application can implement floating origin: periodically move the camera/player and every other
+// dynamic Node3D back near true origin to avoid float32 precision loss at large world coordinates, and
+// call this so the terrain's own absolute-position state (baked collision shapes, MultiMesh instance
+// transforms, region data) stays correctly positioned relative to everything else that moved.
+//
+// p_delta must be a multiple of region_size * vertex_spacing on X and Z (Y is ignored; height data
+// isn't addressed by world Y). This is what lets region data be relabeled instead of resampled: every
+// region's pixel content is unchanged, only which world location it's addressed at changes. A host
+// wanting an arbitrary, non-region-aligned floating origin threshold should round the shift they apply
+// to the rest of the scene down to this same grid, not shift the terrain by an unaligned amount.
+void Terrain3D::rebase(const Vector3 &p_delta) {
+	if (!_initialized || !_data) {
+		return;
+	}
+	real_t grid_unit = real_t(_region_size) * _vertex_spacing;
+	Vector2i region_offset(
+			int(Math::round(p_delta.x / grid_unit)),
+			int(Math::round(p_delta.z / grid_unit)));
+	Vector3 aligned_delta(real_t(region_offset.x) * grid_unit, 0.f, real_t(region_offset.y) * grid_unit);
+	// Warn on misalignment before the zero-offset early-out below, so a small unaligned delta that
+	// rounds down to no shift at all is reported rather than silently doing nothing.
+	if (!Vector3(p_delta.x, 0.f, p_delta.z).is_equal_approx(aligned_delta)) {
+		LOG(ERROR, "rebase() delta ", p_delta, " isn't a multiple of region_size * vertex_spacing (",
+				grid_unit, "). Rounding to nearest region-aligned shift: ", aligned_delta);
+	}
+	if (region_offset == Vector2i()) {
+		return;
+	}
+	LOG(INFO, "Rebasing terrain by ", aligned_delta, " (", region_offset, " regions)");
+
+	_data->rebase(region_offset);
+	if (_collision) {
+		_collision->update(V2I_MAX, true);
+	}
+	snap();
+	if (_terrain_mesher) {
+		_terrain_mesher->snap();
+	}
+	if (_ocean_enabled && _ocean_mesher) {
+		_ocean_mesher->snap();
+	}
+}
+
 void Terrain3D::set_material(const Ref<Terrain3DMaterial> &p_material) {
 	SET_IF_DIFF(_material, p_material);
 	LOG(INFO, "Setting material");
@@ -1401,6 +1445,7 @@ void Terrain3D::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("set_light_target", "node"), &Terrain3D::set_light_target);
 	ClassDB::bind_method(D_METHOD("get_light_target"), &Terrain3D::get_light_target);
 	ClassDB::bind_method(D_METHOD("snap"), &Terrain3D::snap);
+	ClassDB::bind_method(D_METHOD("rebase", "delta"), &Terrain3D::rebase);
 
 	// Collision
 	ClassDB::bind_method(D_METHOD("set_collision_mode", "mode"), &Terrain3D::set_collision_mode);

--- a/src/terrain_3d.h
+++ b/src/terrain_3d.h
@@ -192,6 +192,9 @@ public:
 	Node3D *get_light_target() const { return _light_target.ptr(); }
 	void snap();
 
+	// World Origin
+	void rebase(const Vector3 &p_delta);
+
 	// Collision Aliases
 	void set_collision_mode(const CollisionMode p_mode) { _collision ? _collision->set_mode(p_mode) : void(); }
 	CollisionMode get_collision_mode() const { return _collision ? _collision->get_mode() : CollisionMode::DYNAMIC_GAME; }

--- a/src/terrain_3d_data.cpp
+++ b/src/terrain_3d_data.cpp
@@ -215,6 +215,57 @@ void Terrain3DData::change_region_size(int p_new_size) {
 	_terrain->get_instancer()->update_mmis(-1, V2I_MAX, true);
 }
 
+// Relabels every active region's location by a fixed region-grid offset, without touching any
+// pixel data. Used to support floating origin rebasing: unlike change_region_size(), this never
+// resamples map images, since a region-aligned shift means every region's content is byte-for-byte
+// identical, just addressed at a different location. p_region_offset is in region-grid units, not
+// world units (eg. an offset of (1, 0) moves every region size*vertex_spacing meters on world +X).
+void Terrain3DData::rebase(const Vector2i &p_region_offset) {
+	if (p_region_offset == Vector2i()) {
+		return;
+	}
+	LOG(INFO, "Rebasing all regions by region-grid offset: ", p_region_offset);
+
+	// Validate every destination is in bounds before changing anything, so a rebase either
+	// fully applies or doesn't touch state at all.
+	for (const Vector2i &region_loc : _region_locations) {
+		if (get_region_map_index(region_loc + p_region_offset) < 0) {
+			LOG(ERROR, "Rebase by ", p_region_offset, " would move region ", region_loc, " outside the ",
+					REGION_MAP_SIZE, "x", REGION_MAP_SIZE, " region map. Aborting rebase.");
+			return;
+		}
+	}
+
+	// Mirrors change_region_size()'s established remove/duplicate/add pattern. Must duplicate
+	// rather than mutate location in place and re-add the same object: remove_region() only
+	// soft-deletes (drops from _region_locations, kept in _regions until saved, for undo/disk
+	// cleanup), so re-adding the *same* object at a new key resurrects its old dictionary entry
+	// too, since both keys would then point at one object reporting itself as not-deleted.
+	_terrain->get_instancer()->destroy();
+	TypedArray<Terrain3DRegion> old_regions = get_regions_active();
+	TypedArray<Terrain3DRegion> new_regions;
+	for (const Ref<Terrain3DRegion> &region : old_regions) {
+		Ref<Terrain3DRegion> new_region = region->duplicate(false); // Shallow: shares map Images, no pixel copy
+		new_region->set_location(region->get_location() + p_region_offset);
+		new_regions.push_back(new_region);
+	}
+	for (const Ref<Terrain3DRegion> &region : old_regions) {
+		remove_region(region, false);
+	}
+	for (const Ref<Terrain3DRegion> &region : new_regions) {
+		add_region(region, false);
+	}
+
+	if (_edited_area.has_surface()) {
+		Vector3 world_offset(real_t(p_region_offset.x) * real_t(_region_size) * _vertex_spacing, 0.f,
+				real_t(p_region_offset.y) * real_t(_region_size) * _vertex_spacing);
+		_edited_area.position += world_offset;
+	}
+
+	update_maps(TYPE_MAX, true, true);
+	_terrain->get_instancer()->update_mmis(-1, V2I_MAX, true);
+}
+
 void Terrain3DData::set_region_modified(const Vector2i &p_region_loc, const bool p_modified) {
 	Terrain3DRegion *region = get_region_ptr(p_region_loc);
 	if (!region) {
@@ -1366,6 +1417,7 @@ void Terrain3DData::_bind_methods() {
 
 	ClassDB::bind_method(D_METHOD("do_for_regions", "area", "callback"), &Terrain3DData::do_for_regions);
 	ClassDB::bind_method(D_METHOD("change_region_size", "region_size"), &Terrain3DData::change_region_size);
+	ClassDB::bind_method(D_METHOD("rebase", "region_offset"), &Terrain3DData::rebase);
 
 	ClassDB::bind_method(D_METHOD("get_region_location", "global_position"), &Terrain3DData::get_region_location);
 	ClassDB::bind_method(D_METHOD("get_region_id", "region_location"), &Terrain3DData::get_region_id);

--- a/src/terrain_3d_data.h
+++ b/src/terrain_3d_data.h
@@ -100,6 +100,7 @@ public:
 
 	void do_for_regions(const Rect2i &p_area, const Callable &p_callback);
 	void change_region_size(int region_size);
+	void rebase(const Vector2i &p_region_offset);
 
 	Vector2i world_to_vgrid(const Vector3 &p_global_position) const;
 	Vector2i get_region_location(const Vector3 &p_global_position) const;


### PR DESCRIPTION
## Summary
Godot's `real_t`/`Node3D` transforms are float32 in default (single-precision) builds, which loses sub-unit precision at large world coordinates (10s-100s of thousands+ units from origin) — the standard fix is a floating origin, where the host application periodically shifts the camera/player and every other dynamic `Node3D` back near true origin. Terrain3D previously had no way to participate: none of its own position math reads from its own `Node3D` transform, so its baked `PhysicsServer3D` collision shapes, `MultiMeshInstance3D` foliage/rock transforms, and region data all stay anchored to their original absolute coordinates even if the rest of the scene shifts, causing terrain to visibly desync from everything else the moment a host app rebases.

Adds `Terrain3D::rebase(Vector3 delta)` as the participation hook: a host calls this with the same delta it applies to the rest of the scene.

The delta must be a multiple of `region_size * vertex_spacing` on X/Z (Y is unconstrained; height data isn't addressed by world Y — a misaligned delta is rounded to the nearest region and logged). This constraint is what makes the implementation cheap: every region's pixel content is byte-for-byte identical after a region-aligned shift, only its address changes, so `Terrain3DData::rebase()` just relabels region_location keys (duplicating each `Terrain3DRegion` shallowly — shares the underlying map Images, no pixel copy — since `remove_region()`'s soft-delete semantics mean mutating and re-adding the same object resurrects its old dictionary entry too) rather than resampling like `change_region_size()` does for actual size changes.

Collision, instancer, and mesher all turned out to need no bespoke shifting logic: collision shapes are regenerated fresh from height data on `update(V2I_MAX, true)`, `MultiMeshInstance3D` transforms are recomputed from `region_loc * region_size * vertex_spacing` on every `update_mmis()` rebuild with per-instance transforms already stored region-relative, and the clipmap mesher already recenters every `snap()` from the live tracked target position — so region re-keying plus the existing full-rebuild entry points already used by `change_region_size()` cover all of it.

## Test plan
- [x] Real headless run against a built `libterrain.so`, not just a compile check: imported a real 2-region deterministic height field plus a foliage instance, rebased by exactly one region, confirmed every height sample and the instance both landed at the correctly shifted coordinates with the old coordinates now empty, then rebased back and confirmed an exact round-trip restore.
- [x] Confirmed a misaligned, sub-region delta logs a warning rather than silently doing nothing.
- [x] Extensive edge-case coverage: out-of-bounds rebase correctly aborts atomically (no partial state change), 4 sequential cumulative rebases net to the correct position with height matching at every step, save/load round-trip through a rebase (old region's file deleted, new files correct, edit made post-rebase persists through save/reload), and fractional `vertex_spacing` (2.5) with both aligned and misaligned deltas.
- [x] Real demo project verification: real 3-region terrain, real player physics, rebased by 2048 units — visually confirmed via screenshot (different, correct biome content at the new location, no rendering corruption) and confirmed two simultaneously-spawned players' render-space distance matched their true-space distance exactly.