### PR TITLE
Add real disk-based region streaming (issue #491, partial)

### DIFF
--- a/src/terrain_3d.cpp
+++ b/src/terrain_3d.cpp
@@ -146,6 +146,13 @@ void Terrain3D::__physics_process(const double p_delta) {
 	if (_collision && _collision->is_dynamic_mode()) {
 		_collision->update();
 	}
+	// Streaming doesn't need frame-perfect responsiveness the way LOD/collision
+	// snapping does, and each call can touch disk (FileAccess::file_exists per
+	// candidate region) -- throttled to a modest cadence rather than every
+	// physics tick, to keep that cost bounded regardless of physics tick rate.
+	if (_region_streaming_radius > 0.f && Engine::get_singleton()->get_physics_frames() % 30 == 0) {
+		_update_streaming();
+	}
 }
 
 /**
@@ -163,6 +170,59 @@ void Terrain3D::_grab_camera() {
 	if (!_camera.is_valid() && !_clipmap_target.is_valid()) {
 		set_physics_process(false); // No target to follow, disable snapping until one set
 		LOG(ERROR, "Cannot find clipmap target or active camera. LODs won't be updated. Set manually with set_clipmap_target() or set_camera()");
+	}
+}
+
+// Gathers the current world position of every tracked target -- the usual
+// clipmap/collision/camera targets plus anything registered via
+// add_streaming_target() (e.g. other connected players on a server) -- and
+// hands the whole list to Terrain3DData::update_streaming() in one call, so
+// it can compute the union of "needed nearby" across all of them before
+// evicting anything. See that function's own header comment for why passing
+// them individually (evicting per-target rather than against the union)
+// would risk unloading a region a different target still needs.
+void Terrain3D::_update_streaming() {
+	if (!_data) {
+		return;
+	}
+	PackedVector3Array positions;
+	if (_clipmap_target.is_valid()) {
+		positions.push_back(_clipmap_target.ptr()->get_global_position());
+	}
+	if (_collision_target.is_valid()) {
+		positions.push_back(_collision_target.ptr()->get_global_position());
+	}
+	if (_camera.is_valid()) {
+		positions.push_back(_camera.ptr()->get_global_position());
+	}
+	for (int i = 0; i < _streaming_target_ids.size(); i++) {
+		Object *obj = ObjectDB::get_instance(ObjectID(_streaming_target_ids[i]));
+		Node3D *node = obj ? cast_to<Node3D>(obj) : nullptr;
+		if (node) {
+			positions.push_back(node->get_global_position());
+		}
+	}
+	_data->update_streaming(positions, _region_streaming_radius);
+}
+
+void Terrain3D::add_streaming_target(Node3D *p_node) {
+	if (!p_node) {
+		return;
+	}
+	int64_t id = int64_t(p_node->get_instance_id());
+	if (!_streaming_target_ids.has(id)) {
+		_streaming_target_ids.push_back(id);
+	}
+}
+
+void Terrain3D::remove_streaming_target(Node3D *p_node) {
+	if (!p_node) {
+		return;
+	}
+	int64_t id = int64_t(p_node->get_instance_id());
+	int idx = _streaming_target_ids.find(id);
+	if (idx >= 0) {
+		_streaming_target_ids.remove_at(idx);
 	}
 }
 
@@ -1388,6 +1448,10 @@ void Terrain3D::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("get_label_distance"), &Terrain3D::get_label_distance);
 	ClassDB::bind_method(D_METHOD("set_label_size", "size"), &Terrain3D::set_label_size);
 	ClassDB::bind_method(D_METHOD("get_label_size"), &Terrain3D::get_label_size);
+	ClassDB::bind_method(D_METHOD("set_region_streaming_radius", "radius"), &Terrain3D::set_region_streaming_radius);
+	ClassDB::bind_method(D_METHOD("get_region_streaming_radius"), &Terrain3D::get_region_streaming_radius);
+	ClassDB::bind_method(D_METHOD("add_streaming_target", "node"), &Terrain3D::add_streaming_target);
+	ClassDB::bind_method(D_METHOD("remove_streaming_target", "node"), &Terrain3D::remove_streaming_target);
 
 	// Target Tracking
 	ClassDB::bind_method(D_METHOD("set_camera", "camera"), &Terrain3D::set_camera);
@@ -1551,6 +1615,9 @@ void Terrain3D::_bind_methods() {
 	ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "label_distance", PROPERTY_HINT_RANGE, "0.0,10000.0,0.5,or_greater"), "set_label_distance", "get_label_distance");
 	ADD_PROPERTY(PropertyInfo(Variant::INT, "label_size", PROPERTY_HINT_RANGE, "24,128,1"), "set_label_size", "get_label_size");
 	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "show_grid"), "set_show_region_grid", "get_show_region_grid");
+	// 0 (default) disables streaming -- existing eager load_directory() behavior
+	// is unaffected unless this is explicitly set above 0.
+	ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "region_streaming_radius", PROPERTY_HINT_RANGE, "0.0,100000.0,1.0,or_greater"), "set_region_streaming_radius", "get_region_streaming_radius");
 
 	ADD_GROUP("Collision", "");
 	ADD_PROPERTY(PropertyInfo(Variant::INT, "collision_mode", PROPERTY_HINT_ENUM, "Disabled,Dynamic / Game,Dynamic / Editor,Full / Game,Full / Editor"), "set_collision_mode", "get_collision_mode");

--- a/src/terrain_3d.h
+++ b/src/terrain_3d.h
@@ -66,6 +66,22 @@ private:
 	real_t _label_distance = 0.f;
 	int _label_size = 48;
 
+	// Region streaming. 0 (default) disables streaming entirely -- existing
+	// eager load_directory()/manual load_region() behavior is unaffected
+	// unless this is explicitly set. See Terrain3DData::update_streaming()
+	// for the real load/unload logic; this class only tracks targets and
+	// triggers it periodically.
+	real_t _region_streaming_radius = 0.f;
+	// Extra streaming interest points beyond the usual clipmap/collision/
+	// camera targets below -- e.g. other connected players on a server, which
+	// have no reason to be the clipmap/collision/camera target but whose
+	// nearby regions must still stay loaded. Stored as instance IDs, not raw
+	// pointers, since a registered Node3D can be freed without unregistering
+	// (a disconnecting player, say) -- resolved through ObjectDB and silently
+	// skipped if invalid each time streaming runs, same safety pattern as
+	// TargetNode3D uses for the single-target fields below.
+	PackedInt64Array _streaming_target_ids;
+
 	// Tracked Targets
 	TargetNode3D _clipmap_target;
 	TargetNode3D _collision_target;
@@ -115,6 +131,7 @@ private:
 	void _initialize();
 	void __physics_process(const double p_delta);
 	void _grab_camera();
+	void _update_streaming();
 
 	void _destroy_collision(const bool p_final = false);
 
@@ -178,6 +195,12 @@ public:
 	void set_label_size(const int p_size);
 	int get_label_size() const { return _label_size; }
 	void update_region_labels();
+
+	// Region Streaming
+	void set_region_streaming_radius(const real_t p_radius) { _region_streaming_radius = MAX(p_radius, 0.f); }
+	real_t get_region_streaming_radius() const { return _region_streaming_radius; }
+	void add_streaming_target(Node3D *p_node);
+	void remove_streaming_target(Node3D *p_node);
 
 	// Target Tracking
 	void set_camera(Camera3D *p_camera);

--- a/src/terrain_3d_data.cpp
+++ b/src/terrain_3d_data.cpp
@@ -459,6 +459,156 @@ void Terrain3DData::load_region(const Vector2i &p_region_loc, const String &p_di
 	add_region(region, p_update);
 }
 
+// Removes a region from memory without marking it for disk deletion. Unlike
+// remove_region() -- which soft-deletes for the editor's undo/redo-aware Add/
+// Remove Region workflow, keeping the object in _regions until the NEXT
+// save_region() call notices is_deleted() and actually erases it -- this is a
+// clean, immediate unload: the file on disk (if any) is left untouched, only
+// the in-memory copy goes away right now. Used by update_streaming(), where
+// "no longer needed nearby" must free memory immediately, not wait for a
+// future save. Caller is responsible for having already saved any modified
+// data; this does not check is_modified() or save anything itself.
+void Terrain3DData::unload_region(const Vector2i &p_region_loc, const bool p_update) {
+	int idx = _region_locations.find(p_region_loc);
+	if (idx < 0) {
+		LOG(DEBUG, "Region ", p_region_loc, " not active, nothing to unload");
+		return;
+	}
+	LOG(DEBUG, "Unloading region ", p_region_loc, " from memory (file on disk untouched)");
+	_region_locations.remove_at(idx);
+	_regions.erase(p_region_loc);
+	_region_map_dirty = true;
+	if (p_update) {
+		update_maps(TYPE_MAX, true, false);
+	}
+}
+
+// Real disk-based region streaming: loads regions from _terrain's data_directory
+// as they come within p_radius of any position in p_target_positions, and
+// unloads (freeing memory, saving first if modified) regions that fall
+// outside p_radius of ALL of them. p_target_positions is deliberately a list,
+// not a single position -- computing the union of "needed nearby" across every
+// tracked position BEFORE any unload happens is what keeps this safe for
+// multiple simultaneous players/cameras: a region only unloads if it's out of
+// range of every target, never based on evaluating targets independently
+// (which could evict a region a different target is still standing on).
+//
+// No-ops completely -- no disk access, no eviction -- if p_radius <= 0 (the
+// default; existing eager load_directory()/manual load_region() behavior is
+// unaffected unless this is explicitly enabled) or if _terrain has no
+// data_directory set (pure in-memory/procedural use, e.g. building a terrain
+// entirely via import_images() with nothing ever saved to disk, must behave
+// exactly as before).
+//
+// Deliberately does NOT touch the existing region addressing/REGION_MAP_SIZE
+// bound -- a region can only stream in if it's within the same ±16 region
+// range that's always been valid. This keeps the change isolated to "which
+// in-bounds regions are currently resident in memory," not "how big can the
+// world be," which is a separate, much larger question (see the design note
+// on GitHub issue #491).
+void Terrain3DData::update_streaming(const PackedVector3Array &p_target_positions, const real_t p_radius) {
+	if (p_radius <= 0.f || p_target_positions.is_empty()) {
+		return;
+	}
+	String dir = _terrain->get_data_directory();
+	if (dir.is_empty()) {
+		return;
+	}
+
+	// Union, across every target, of region locations that should be loaded.
+	// Dictionary-as-set, matching the existing idiom used elsewhere in this
+	// file (see change_region_size()) rather than introducing a new container
+	// type for one function.
+	Dictionary desired;
+	// Clamped to the existing addressing bound up front -- the per-cell
+	// get_region_map_index() check below already excludes anything outside
+	// it, but without this clamp a large radius (the property allows up to
+	// 100000) still pays for the full O(radius^2) iteration first, wastefully,
+	// every 30 physics ticks per target, even though the result can never
+	// exceed REGION_MAP_SIZE/2 regions out either way.
+	//
+	// A region's actual world-space footprint is region_size * vertex_spacing,
+	// not region_size alone -- p_radius is a world-space distance (compared
+	// directly against region_center_world below, which IS vertex_spacing-
+	// scaled), so the search window has to be scaled the same way or this
+	// under-scans whenever vertex_spacing < 1.0 (a normal, commonly-used
+	// setting): regions genuinely inside the configured radius would silently
+	// never enter `desired`, shrinking the effective streaming radius below
+	// what was actually configured. vertex_spacing has a real minimum of 0.25
+	// (see Terrain3DRegion::set_vertex_spacing), but MAX(..., 0.001f) guards
+	// the division regardless of where that minimum is enforced.
+	int radius_regions = MIN(int(Math::ceil(p_radius / real_t(MAX(_region_size, 1)) / MAX(_vertex_spacing, real_t(0.001)))), Terrain3DData::REGION_MAP_SIZE / 2);
+	for (int i = 0; i < p_target_positions.size(); i++) {
+		Vector3 pos = p_target_positions[i];
+		Vector2i center_loc = get_region_location(pos);
+		for (int y = -radius_regions; y <= radius_regions; y++) {
+			for (int x = -radius_regions; x <= radius_regions; x++) {
+				Vector2i loc = center_loc + Vector2i(x, y);
+				if (get_region_map_index(loc) < 0) {
+					continue; // Stays within the existing addressing bound, see header comment above
+				}
+				Vector2 region_center_world = Vector2((real_t(loc.x) + .5f) * _region_size, (real_t(loc.y) + .5f) * _region_size) * _vertex_spacing;
+				if (region_center_world.distance_to(Vector2(pos.x, pos.z)) <= p_radius) {
+					desired[loc] = true;
+				}
+			}
+		}
+	}
+
+	// Load: anything desired, not already active, with a file on disk.
+	// (Streaming only ever loads pre-existing files -- it never creates
+	// regions; that stays an explicit editor/API action, same as today.)
+	Array desired_locations = desired.keys();
+	bool any_loaded = false;
+	for (int i = 0; i < desired_locations.size(); i++) {
+		Vector2i loc = desired_locations[i];
+		if (has_region(loc)) {
+			continue;
+		}
+		String path = dir + String("/") + Util::location_to_filename(loc);
+		if (FileAccess::file_exists(path)) {
+			load_region(loc, dir, false);
+			any_loaded = true;
+		}
+	}
+
+	// Evict: anything currently active, not in the desired set. Snapshot
+	// _region_locations first since unload_region() mutates it in place.
+	Array current_locations = _region_locations.duplicate();
+	bool any_unloaded = false;
+	for (int i = 0; i < current_locations.size(); i++) {
+		Vector2i loc = current_locations[i];
+		if (desired.has(loc)) {
+			continue;
+		}
+		Ref<Terrain3DRegion> region = get_region(loc);
+		if (region.is_null()) {
+			continue;
+		}
+		if (region->is_modified()) {
+			save_region(loc, dir, _terrain->get_save_16_bit());
+			if (region->is_modified()) {
+				// save_region() logs its own error; the save genuinely
+				// failed (save() only clears the modified flag on success).
+				// Do NOT unload -- that would silently lose this region's
+				// changes, since nothing else is holding a copy. Leave it
+				// loaded; it'll be retried on the next update_streaming()
+				// call once whatever caused the failure (e.g. a full disk,
+				// a permissions problem) is resolved.
+				LOG(ERROR, "Region ", loc, " failed to save, keeping it loaded rather than risk losing changes");
+				continue;
+			}
+		}
+		unload_region(loc, false);
+		any_unloaded = true;
+	}
+
+	if (any_loaded || any_unloaded) {
+		update_maps(TYPE_MAX, true, false);
+		_terrain->get_instancer()->update_mmis(-1, V2I_MAX, true);
+	}
+}
+
 TypedArray<Image> Terrain3DData::get_maps(const MapType p_map_type) const {
 	if (p_map_type < 0 || p_map_type >= TYPE_MAX) {
 		LOG(ERROR, "Specified map type out of range");
@@ -1392,6 +1542,8 @@ void Terrain3DData::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("save_region", "region_location", "directory", "save_16_bit"), &Terrain3DData::save_region, DEFVAL(false));
 	ClassDB::bind_method(D_METHOD("load_directory", "directory"), &Terrain3DData::load_directory);
 	ClassDB::bind_method(D_METHOD("load_region", "region_location", "directory", "update"), &Terrain3DData::load_region, DEFVAL(true));
+	ClassDB::bind_method(D_METHOD("unload_region", "region_location", "update"), &Terrain3DData::unload_region, DEFVAL(true));
+	ClassDB::bind_method(D_METHOD("update_streaming", "target_positions", "radius"), &Terrain3DData::update_streaming);
 
 	ClassDB::bind_method(D_METHOD("get_height_maps"), &Terrain3DData::get_height_maps);
 	ClassDB::bind_method(D_METHOD("get_control_maps"), &Terrain3DData::get_control_maps);

--- a/src/terrain_3d_data.h
+++ b/src/terrain_3d_data.h
@@ -131,6 +131,8 @@ public:
 	void save_region(const Vector2i &p_region_loc, const String &p_dir, const bool p_16_bit = false);
 	void load_directory(const String &p_dir);
 	void load_region(const Vector2i &p_region_loc, const String &p_dir, const bool p_update = true);
+	void unload_region(const Vector2i &p_region_loc, const bool p_update = true);
+	void update_streaming(const PackedVector3Array &p_target_positions, const real_t p_radius);
 
 	// Maps
 	TypedArray<Image> get_height_maps() const { return _height_maps; }


### PR DESCRIPTION
## Summary
`Terrain3DData::load_directory()` currently loads every region file in a directory unconditionally, forever — there was no way to load/unload by distance at all. `update_streaming(target_positions, radius)` fixes that: regions load in and (after saving, if modified) unload as they cross `radius` of any tracked target.

`target_positions` is a list, not a single position, and the union across all of them is computed fully before any eviction happens — this is what keeps it safe for multiple simultaneous players/cameras: a region only unloads if it's out of range of *every* target, never based on evaluating targets independently, which could evict a region a different target still needs. `Terrain3D::_update_streaming()` gathers the usual clipmap/collision/camera targets plus anything registered via the new `add_streaming_target()`/`remove_streaming_target()` (e.g. other connected players on a server) into one call for exactly this reason.

New `unload_region()` is deliberately **not** `remove_region()`: `remove_region()` soft-deletes for the editor's undo/redo-aware Add/Remove Region workflow (keeps the object in `_regions` until the *next* save notices `is_deleted()` and actually erases it), which is wrong for streaming eviction on two counts — it wouldn't actually free memory until some later unrelated save, and it would mark the file for disk deletion, when the file should be left alone. `unload_region()` does a clean, immediate removal from both `_regions` and `_region_locations`, disk file untouched.

Save-before-evict re-checks `is_modified()` *after* calling `save_region()`, not just before: `Terrain3DRegion::save()` only clears that flag on success, so if it's still set the save genuinely failed, and eviction is skipped rather than risking silent data loss — the region stays loaded and gets retried next cycle.

## What this deliberately does not attempt
Region addressing / `REGION_MAP_SIZE` are untouched — a region can only stream in within the same existing ±16 range. I found that removing that bound and making the region map relative to camera position both run into the same deeper problem: `get_region_id()` (used by every collision/instancer/editor/gameplay query) reads directly from the same `_region_map` array that's uploaded as the literal GLSL shader uniform (`main.glsl`/`displacement_buffer.glsl`: `uniform int _region_map[1024]`) — not similar to it, the *same* array serving two different jobs. Decoupling those is real, careful work on the single hottest path in the codebase, and affects every consumer of `Terrain3DData`. I've posted a design writeup on #491 with what I found rather than attempting that unilaterally in this PR.

## Test plan
- [x] Real headless test, four scenarios: (1) no-op with no `data_directory` set, confirming pure in-memory/procedural use (e.g. `CodeGeneratedDemo`) is unaffected.
- [x] (2) Full round trip — edited a region, streamed it out of range, confirmed via an independent fresh disk load (not the same terrain instance) that the edit actually made it to disk before eviction, then streamed back in and confirmed the edit survived.
- [x] (3) Two targets near two different regions, confirming both stay loaded simultaneously (real union, not last-target-wins).
- [x] (4) Regression test for a real bug caught in review — the region-search radius wasn't scaled by `vertex_spacing`, only `region_size`, so at `vertex_spacing < 1.0` (a normal setting) regions genuinely inside the configured radius would be silently missed/evicted. Confirmed the fix by reverting it and rerunning: exactly the new test's check failed, nothing else did; restored the fix and confirmed all 20 checks across all four scenarios pass.