### PR TITLE
Fix EditorDock leak when the asset dock is removed

### DIFF
--- a/project/addons/terrain_3d/src/asset_dock.gd
+++ b/project/addons/terrain_3d/src/asset_dock.gd
@@ -142,6 +142,17 @@ func _gui_input(p_event: InputEvent) -> void:
 
 func remove_dock(p_force: bool = false) -> void:
 	plugin.remove_dock(_dock)
+	# plugin.remove_dock() only unregisters _dock; it was created here via
+	# ClassDB.instantiate() and is owned by this script, not the scene tree.
+	# Without an explicit free it leaks at editor shutdown along with its
+	# dock_icon (terrain3d.svg) and the backing Texture + CanvasItem RIDs.
+	# `self` is a child of _dock, so detach before freeing (editor_plugin.gd
+	# still queue_free()s `self` afterward).
+	if is_instance_valid(_dock):
+		if get_parent() == _dock:
+			_dock.remove_child(self)
+		_dock.free()
+		_dock = null
 
 
 func update_dock() -> void:


### PR DESCRIPTION
Terrain3DAssetDock.initialize() creates its host dock with ClassDB.instantiate("EditorDock"), which is owned by the script rather than the scene tree. remove_dock() only calls plugin.remove_dock(_dock), which unregisters the dock but never frees it. The EditorDock, its dock_icon (terrain3d.svg), and the associated CanvasItem + Texture RIDs then leak when the editor closes:

    WARNING: 1 RID of type "CanvasItem" was leaked.
    WARNING: 2 RIDs of type "Texture" were leaked.
    ERROR: 1 RID allocations of type 'RendererRD::TextureStorage::Texture' were leaked at exit.
    Resource still in use: res://addons/terrain_3d/icons/terrain3d.svg

Free _dock after unregistering it. In the >=4.6 dock path remove_dock() is only reached from editor_plugin.gd::_exit_tree, so this is teardown-only; `self` is a child of _dock and is detached first because editor_plugin.gd still queue_free()s it afterward.

