### PR TITLE
Optimize collision shape generation by 16x or more

### DIFF
--- a/src/terrain_3d_collision.cpp
+++ b/src/terrain_3d_collision.cpp
@@ -2,6 +2,7 @@
 
 #include <godot_cpp/classes/engine.hpp>
 #include <godot_cpp/classes/height_map_shape3d.hpp>
+#include <godot_cpp/classes/image.hpp>
 #include <godot_cpp/classes/time.hpp>
 #include <godot_cpp/classes/world3d.hpp>
 
@@ -12,11 +13,31 @@
 #include "terrain_3d.h"
 #include "terrain_3d_collision.h"
 #include "terrain_3d_data.h"
+#include "terrain_3d_material.h"
 #include "terrain_3d_util.h"
 
 ///////////////////////////
 // Private Functions
 ///////////////////////////
+
+_FORCE_INLINE_ real_t Terrain3DCollision::_get_modified_collision_height(const Vector2i &p_vgrid, const Vector2i &p_region_loc, const int p_region_size, const real_t p_region_texel_size,
+		const float *const *p_height_maps, const float *const *p_control_maps, const bool p_blend, const real_t p_ground_level, const real_t p_region_blend) const {
+	const Vector2i offset = V2I_DIVIDE_FLOOR(p_vgrid, p_region_size) - p_region_loc;
+	const int slot = offset.y * 2 + offset.x;
+	if (!p_height_maps[slot] || !p_control_maps[slot]) {
+		return NAN;
+	}
+	const Vector2i img_pos(Math::posmod(p_vgrid.x, p_region_size), Math::posmod(p_vgrid.y, p_region_size));
+	const int pixel_index = img_pos.y * p_region_size + img_pos.x;
+	if (is_hole(p_control_maps[slot][pixel_index])) {
+		return NAN;
+	}
+	real_t height = p_height_maps[slot][pixel_index];
+	if (p_blend) {
+		height = Math::lerp(height, p_ground_level, smoothstep(0.f, 1.f, _terrain->get_data()->get_region_blend(Vector2(p_vgrid) * p_region_texel_size, p_region_blend)));
+	}
+	return height;
+}
 
 // Calculates shape data from top left position. Assumes descaled and snapped.
 Dictionary Terrain3DCollision::_get_shape_data(const Vector2i &p_position, const int p_size) {
@@ -31,9 +52,44 @@ Dictionary Terrain3DCollision::_get_shape_data(const Vector2i &p_position, const
 		return Dictionary();
 	}
 
+	const int region_size = _terrain->get_region_size();
+	bool blend = false;
+	real_t ground_level = 0.f;
+	real_t region_blend = 0.f;
+	const Ref<Terrain3DMaterial> material = _terrain->get_material();
+	if (material.is_valid()) {
+		const Terrain3DMaterial::WorldBackground bg_mode = material->get_world_background();
+		if (bg_mode == Terrain3DMaterial::WorldBackground::FLAT || bg_mode == Terrain3DMaterial::WorldBackground::NOISE) {
+			Variant var_gl = material->get("ground_level");
+			Variant var_rb = material->get("region_blend");
+			if (var_gl.get_type() != Variant::NIL && var_rb.get_type() != Variant::NIL) {
+				blend = true;
+				ground_level = var_gl;
+				region_blend = var_rb;
+			}
+		}
+	}
+	const float *height_maps[4] = {};
+	const float *control_maps[4] = {};
+	const Vector2i region_offsets[4] = { Vector2i(0, 0), Vector2i(1, 0), Vector2i(0, 1), Vector2i(1, 1) };
+	for (int i = 0; i < 4; i++) {
+		const Terrain3DRegion *extract_region = data->get_region_ptr(region_loc + region_offsets[i]);
+		if (!extract_region || extract_region->is_deleted() || extract_region->get_region_size() != region_size) {
+			continue;
+		}
+		Image *height_map = extract_region->get_map_ptr(TYPE_HEIGHT);
+		Image *control_map = extract_region->get_map_ptr(TYPE_CONTROL);
+		if (height_map && control_map) {
+			height_maps[i] = reinterpret_cast<const float *>(height_map->ptr());
+			control_maps[i] = reinterpret_cast<const float *>(control_map->ptr());
+		}
+	}
+	const real_t region_texel_size = 1.f / real_t(region_size);
+
 	int hshape_size = p_size + 1; // Calculate last vertex at end
 	PackedRealArray map_data = PackedRealArray();
 	map_data.resize(hshape_size * hshape_size);
+	real_t *map_ptr = map_data.ptrw();
 	real_t min_height = FLT_MAX;
 	real_t max_height = -FLT_MAX;
 
@@ -45,8 +101,9 @@ Dictionary Terrain3DCollision::_get_shape_data(const Vector2i &p_position, const
 			// int index = z * hshape_size + x;
 			// Array Index Rotated Y=-90 - must rotate shape Y=+90 (xform below)
 			int index = hshape_size - 1 - z + x * hshape_size;
-			real_t height = data->get_modified_height(p_position + Vector2i(x, z));
-			map_data[index] = height;
+			real_t height = _get_modified_collision_height(p_position + Vector2i(x, z), region_loc, region_size, region_texel_size,
+					height_maps, control_maps, blend, ground_level, region_blend);
+			map_ptr[index] = height;
 			if (!std::isnan(height)) {
 				min_height = MIN(min_height, height);
 				max_height = MAX(max_height, height);

--- a/src/terrain_3d_collision.h
+++ b/src/terrain_3d_collision.h
@@ -48,6 +48,8 @@ private:
 
 	Vector2i _snap_to_grid(const Vector2i &p_pos) const;
 	Vector2i _snap_to_grid(const Vector3 &p_pos) const;
+	real_t _get_modified_collision_height(const Vector2i &p_vgrid, const Vector2i &p_region_loc, const int p_region_size, const real_t p_region_texel_size,
+			const float *const *p_height_maps, const float *const *p_control_maps, const bool p_blend, const real_t p_ground_level, const real_t p_region_blend) const;
 	Dictionary _get_shape_data(const Vector2i &p_position, const int p_size);
 
 	void _shape_set_disabled(const int p_shape_id, const bool p_disabled);

--- a/src/terrain_3d_data.cpp
+++ b/src/terrain_3d_data.cpp
@@ -741,7 +741,10 @@ real_t Terrain3DData::get_region_blend(const Vector2 &p_uv2) const {
 		return 0.f;
 	}
 	const real_t region_blend = var_rb;
+	return get_region_blend(p_uv2, region_blend);
+}
 
+real_t Terrain3DData::get_region_blend(const Vector2 &p_uv2, const real_t p_region_blend) const {
 	auto check_region = [&](const Vector2 &uv2) -> real_t {
 		int idx = get_region_map_index(Vector2i(Math::floor(uv2.x), Math::floor(uv2.y)));
 		return (idx >= 0 && _region_map[idx] > 0) ? 1.f : 0.f;
@@ -755,7 +758,7 @@ real_t Terrain3DData::get_region_blend(const Vector2 &p_uv2) const {
 	real_t c = check_region(uv2 + Vector2(1.0f, 0.0f));
 	real_t d = check_region(uv2 + Vector2(0.0f, 0.0f));
 
-	real_t blend_factor = 2.0f + 126.0f * (1.0f - region_blend);
+	real_t blend_factor = 2.0f + 126.0f * (1.0f - p_region_blend);
 	Vector2 f = Vector2(uv2.x - Math::floor(uv2.x), uv2.y - Math::floor(uv2.y));
 	f.x = Math::clamp(f.x, real_t(1e-8f), real_t(1.0f - 1e-8f));
 	f.y = Math::clamp(f.y, real_t(1e-8f), real_t(1.0f - 1e-8f));

--- a/src/terrain_3d_data.h
+++ b/src/terrain_3d_data.h
@@ -152,6 +152,7 @@ public:
 	real_t get_surface_height(const Vector3 &p_global_position) const;
 	real_t get_modified_height(const Vector2i &p_vgrid) const;
 	real_t get_region_blend(const Vector2 &p_uv2) const;
+	real_t get_region_blend(const Vector2 &p_uv2, const real_t p_region_blend) const;
 	Vector3 get_normal(const Vector3 &p_global_position) const;
 	bool is_in_slope(const Vector3 &p_global_position, const Vector2 &p_slope_range, const Vector3 &p_normal = V3_ZERO) const;
 


### PR DESCRIPTION
With my game, I have long views and distant vehicles that need to drive and interact with the player from many kilometers away (often up to 15 km), so full (game) collision generation is best.

However, it currently takes upwards of 10-25 seconds to generate on map load (at 1024 regions), which isn't great.

Collision generation calls `get_modified_height()` for every generated vertex. For a 1024 region map with 256x256 regions, that amounts to about 67.6 million calls, which repeat the same internal calls to get the same info: resolve the region, height, control maps, material, background mode, ground_level, region_blend.

This PR changes it so fetching that data happens outside the loop (preloads it) for its region and nearby regions, and then generates the vertices. I didn't do anything with background blending (still uses the existing blending calculation).

I benchmarked it and went from 22 seconds to 1 second on my Windows computer, similar ratio on macOS:

```
Machine  Regions  Current ms  Patched ms  Speedup
M1 Max      1,024  11,448.494     401.981   28.48x
Windows     1,024  22,613.607   1,025.145   22.06x
M1 Max          1      10.630       0.359   29.61x
Windows         1       8.310       0.512   16.23x
```

M1 Max = macOS with 64 GB RAM
Windows = Windows 11 liquid-cooled gaming laptop, i9-12900H

One downside is that some of the logic is duplicated, since it's pretty hard to untangle it without complicating the original code.
